### PR TITLE
Add custom item to pickup events

### DIFF
--- a/Exiled.Events/EventArgs/ItemDroppedEventArgs.cs
+++ b/Exiled.Events/EventArgs/ItemDroppedEventArgs.cs
@@ -11,6 +11,8 @@ namespace Exiled.Events.EventArgs
 
     using Exiled.API.Features;
 
+    using Exiled.CustomItems.API;
+
     /// <summary>
     /// Contains all informations after a player drops an item.
     /// </summary>
@@ -21,7 +23,8 @@ namespace Exiled.Events.EventArgs
         /// </summary>
         /// <param name="player"><inheritdoc cref="Player"/></param>
         /// <param name="pickup"><inheritdoc cref="Pickup"/></param>
-        public ItemDroppedEventArgs(Player player, Pickup pickup)
+        /// <param name="customItem"><inheritdoc cref="CustomItem"/></param>
+        public ItemDroppedEventArgs(Player player, Pickup pickup, CustomItem customItem)
         {
             Player = player;
             Pickup = pickup;
@@ -36,5 +39,10 @@ namespace Exiled.Events.EventArgs
         /// Gets the dropped pickup.
         /// </summary>
         public Pickup Pickup { get; }
+
+        /// <summary>
+        /// Gets the custom item if the dropped pickup was a custom item, otherwise null.
+        /// </summary>
+        public CustomItem CustomItem { get; }
     }
 }

--- a/Exiled.Events/EventArgs/PickingUpItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/PickingUpItemEventArgs.cs
@@ -9,6 +9,8 @@ namespace Exiled.Events.EventArgs
 {
     using Exiled.API.Features;
 
+    using Exiled.CustomItems.API;
+
     /// <summary>
     /// Contains all informations before a player picks up an item.
     /// </summary>
@@ -19,9 +21,10 @@ namespace Exiled.Events.EventArgs
         /// </summary>
         /// <param name="player">The player who's picking up the item.</param>
         /// <param name="pickup">The pickup to be picked up.</param>
+        /// <param name="customItem">The custom item of the pickup.</param>
         /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
-        public PickingUpItemEventArgs(Player player, Pickup pickup, bool isAllowed = true)
-            : base(player, pickup)
+        public PickingUpItemEventArgs(Player player, Pickup pickup, CustomItem customItem, bool isAllowed = true)
+            : base(player, pickup, customItem)
         {
             IsAllowed = isAllowed;
         }

--- a/Exiled.Events/Patches/Events/Player/ItemDrop.cs
+++ b/Exiled.Events/Patches/Events/Player/ItemDrop.cs
@@ -13,6 +13,8 @@ namespace Exiled.Events.Patches.Events.Player
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
 
+    using Exiled.CustomItems.API;
+
     using HarmonyLib;
 
     /// <summary>
@@ -35,8 +37,10 @@ namespace Exiled.Events.Patches.Events.Player
                 if (__instance.items[itemInventoryIndex].id != syncItemInfo.id)
                     return false;
 
+                API.IsCustomItem(syncItemInfo, out var customItem);
+
                 var droppingItemEventArgs =
-                    new DroppingItemEventArgs(API.Features.Player.Get(__instance.gameObject), syncItemInfo);
+                    new DroppingItemEventArgs(API.Features.Player.Get(__instance.gameObject), syncItemInfo, customItem);
 
                 Player.OnDroppingItem(droppingItemEventArgs);
 

--- a/Exiled.Events/Patches/Events/Player/PickingUpItem.cs
+++ b/Exiled.Events/Patches/Events/Player/PickingUpItem.cs
@@ -13,6 +13,8 @@ namespace Exiled.Events.Patches.Events.Player
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
 
+    using Exiled.CustomItems.API;
+
     using HarmonyLib;
 
     using Searching;
@@ -28,7 +30,9 @@ namespace Exiled.Events.Patches.Events.Player
         {
             try
             {
-                var ev = new PickingUpItemEventArgs(API.Features.Player.Get(__instance.Hub.gameObject), __instance.TargetPickup);
+                API.IsCustomItem(__instance.TargetPickup, out var customItem);
+
+                var ev = new PickingUpItemEventArgs(API.Features.Player.Get(__instance.Hub.gameObject), __instance.TargetPickup, customItem);
 
                 Player.OnPickingUpItem(ev);
 


### PR DESCRIPTION
This will allow you to more easily interact with custom items in drop and pickup event, from outside of the custom item itself.