### PR TITLE
Make Group setter actually work

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -754,7 +754,7 @@ namespace Exiled.API.Features
         public UserGroup Group
         {
             get => ReferenceHub.serverRoles.Group;
-            set => ReferenceHub.serverRoles.SetGroup(value, false, false, value.Cover);
+            set => ReferenceHub.serverRoles.SetGroup(value, false);
         }
 
         /// <summary>


### PR DESCRIPTION
disp is a toggle for if the hidden attribute on groups should apply. That means that if group's cover attribute is true, then hidden won't apply. This fixes that.