### PR TITLE
Remove Lazy instance from example plugin

### DIFF
--- a/Exiled.Example/Example.cs
+++ b/Exiled.Example/Example.cs
@@ -17,7 +17,7 @@ namespace Exiled.Example
     /// </summary>
     public class Example : Plugin<Config>
     {
-        private static readonly Lazy<Example> LazyInstance = new Lazy<Example>(() => new Example());
+        private static Example singleton = new Example();
 
         private Handlers.Server server;
         private Handlers.Player player;
@@ -30,9 +30,9 @@ namespace Exiled.Example
         }
 
         /// <summary>
-        /// Gets the lazy instance.
+        /// Gets the only existing instance of this plugin.
         /// </summary>
-        public static Example Instance => LazyInstance.Value;
+        public static Example Instance => singleton;
 
         /// <inheritdoc/>
         public override PluginPriority Priority { get; } = PluginPriority.Last;


### PR DESCRIPTION
In the Discord people regularly ridicule plugins that use a Lazy
instance. Let's save Amathor from making some review comments and remove
Lazy instances from the Example that people use as a template for their plugins.