### PR TITLE
Add a null check for RA config

### DIFF
--- a/Exiled.Permissions/Extensions/Permissions.cs
+++ b/Exiled.Permissions/Extensions/Permissions.cs
@@ -88,6 +88,14 @@ namespace Exiled.Permissions.Extensions
         /// </summary>
         public static void Reload()
         {
+            if (ServerStatic.PermissionsHandler == null)
+            {
+                Log.Error("Your Remote Admin config is broken. You have to fix it because the game won't even start with a broken config.");
+
+                // Then do nothing.
+                return;
+            }
+
             try
             {
                 Dictionary<string, object> rawDeserializedPerms = Deserializer.Deserialize<Dictionary<string, object>>(File.ReadAllText(Instance.Config.FullPath)) ?? new Dictionary<string, object>();

--- a/Exiled.Permissions/Extensions/Permissions.cs
+++ b/Exiled.Permissions/Extensions/Permissions.cs
@@ -92,7 +92,7 @@ namespace Exiled.Permissions.Extensions
             {
                 Log.Error("Your Remote Admin config is broken. You have to fix it because the game won't even start with a broken config.");
 
-                // Then do nothing.
+                // If we don't return the context, it'll throw another exception.
                 return;
             }
 


### PR DESCRIPTION
This will let users know the exact reason of a NullReferenceException with the message `Unable to parse permission config: ...`.