### PR TITLE
Remove Redundant .Where()'s

### DIFF
--- a/Exiled.API/Extensions/Item.cs
+++ b/Exiled.API/Extensions/Item.cs
@@ -154,7 +154,7 @@ namespace Exiled.API.Extensions
             WeaponManager wmanager = player.ReferenceHub.weaponManager;
             if (weapon.id.IsWeapon())
             {
-                WeaponManager.Weapon wep = wmanager.weapons.Where(wp => wp.inventoryID == weapon.id).FirstOrDefault();
+                WeaponManager.Weapon wep = wmanager.weapons.FirstOrDefault(wp => wp.inventoryID == weapon.id);
                 if (wep != null)
                 {
                     try
@@ -183,7 +183,7 @@ namespace Exiled.API.Extensions
 
             if (weapon.id.IsWeapon())
             {
-                WeaponManager.Weapon wep = weaponManager.weapons.Where(wp => wp.inventoryID == weapon.id).FirstOrDefault();
+                WeaponManager.Weapon wep = weaponManager.weapons.FirstOrDefault(wp => wp.inventoryID == weapon.id);
                 if (wep != null)
                 {
                     string name = type.ToString("g").SplitCamelCase();
@@ -210,7 +210,7 @@ namespace Exiled.API.Extensions
             WeaponManager wmanager = player.ReferenceHub.weaponManager;
             if (weapon.id.IsWeapon())
             {
-                WeaponManager.Weapon wep = wmanager.weapons.Where(wp => wp.inventoryID == weapon.id).FirstOrDefault();
+                WeaponManager.Weapon wep = wmanager.weapons.FirstOrDefault(wp => wp.inventoryID == weapon.id);
                 if (wep != null)
                 {
                     try
@@ -238,7 +238,7 @@ namespace Exiled.API.Extensions
             WeaponManager wmanager = player.ReferenceHub.weaponManager;
             if (weapon.id.IsWeapon())
             {
-                WeaponManager.Weapon wep = wmanager.weapons.Where(wp => wp.inventoryID == weapon.id).FirstOrDefault();
+                WeaponManager.Weapon wep = wmanager.weapons.FirstOrDefault(wp => wp.inventoryID == weapon.id);
                 if (wep != null)
                 {
                     string name = type.ToString("g").SplitCamelCase();
@@ -265,7 +265,7 @@ namespace Exiled.API.Extensions
             WeaponManager wmanager = player.ReferenceHub.weaponManager;
             if (weapon.id.IsWeapon())
             {
-                WeaponManager.Weapon wep = wmanager.weapons.Where(wp => wp.inventoryID == weapon.id).FirstOrDefault();
+                WeaponManager.Weapon wep = wmanager.weapons.FirstOrDefault(wp => wp.inventoryID == weapon.id);
                 if (wep != null)
                 {
                     try
@@ -293,7 +293,7 @@ namespace Exiled.API.Extensions
             WeaponManager wmanager = player.ReferenceHub.weaponManager;
             if (weapon.id.IsWeapon())
             {
-                WeaponManager.Weapon wep = wmanager.weapons.Where(wp => wp.inventoryID == weapon.id).FirstOrDefault();
+                WeaponManager.Weapon wep = wmanager.weapons.FirstOrDefault(wp => wp.inventoryID == weapon.id);
                 if (wep != null)
                 {
                     string name = type.ToString("g").SplitCamelCase();

--- a/Exiled.API/Extensions/Role.cs
+++ b/Exiled.API/Extensions/Role.cs
@@ -49,7 +49,6 @@ namespace Exiled.API.Extensions
                     return Side.ChaosInsurgency;
                 case Team.TUT:
                     return Side.Tutorial;
-                case Team.RIP:
                 default:
                     return Side.None;
             }

--- a/Exiled.API/Features/Respawn.cs
+++ b/Exiled.API/Features/Respawn.cs
@@ -48,7 +48,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets the actual <see cref="RespawnEffectsController"/>.
         /// </summary>
-        public static RespawnEffectsController Controller => RespawnEffectsController.AllControllers.Where(controller => controller != null).FirstOrDefault();
+        public static RespawnEffectsController Controller => RespawnEffectsController.AllControllers.FirstOrDefault(controller => controller != null);
 
         /// <summary>
         /// Play an effect when a certain class spawns.


### PR DESCRIPTION
Removes a few .Where().FirstOrDefault() in exchange for .FirstOrDefault() and removes an unnecessary case.