### PR TITLE
Fix for #428

### DIFF
--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -28,11 +28,30 @@ namespace Exiled.API.Features
     /// </summary>
     public static class Map
     {
-        private static readonly List<Room> RoomsValue = new List<Room>(250);
-        private static readonly List<DoorVariant> DoorsValue = new List<DoorVariant>(250);
-        private static readonly List<Camera079> CamerasValue = new List<Camera079>(250);
-        private static readonly List<Lift> LiftsValue = new List<Lift>(10);
-        private static readonly List<TeslaGate> TeslasValue = new List<TeslaGate>(10);
+        /// <summary>
+        /// A list of <see cref="Room"/>s on the map.
+        /// </summary>
+        internal static readonly List<Room> RoomsValue = new List<Room>(250);
+
+        /// <summary>
+        /// A list of <see cref="DoorVariant"/>s on the map.
+        /// </summary>
+        internal static readonly List<DoorVariant> DoorsValue = new List<DoorVariant>(250);
+
+        /// <summary>
+        /// A list of <see cref="Camera079"/>s on the map.
+        /// </summary>
+        internal static readonly List<Camera079> CamerasValue = new List<Camera079>(250);
+
+        /// <summary>
+        /// A list of <see cref="Lift"/>s on the map.
+        /// </summary>
+        internal static readonly List<Lift> LiftsValue = new List<Lift>(10);
+
+        /// <summary>
+        /// A list of <see cref="TeslaGate"/>s on the map.
+        /// </summary>
+        internal static readonly List<TeslaGate> TeslasValue = new List<TeslaGate>(10);
 
         private static readonly ReadOnlyCollection<Room> ReadOnlyRoomsValue = RoomsValue.AsReadOnly();
         private static readonly ReadOnlyCollection<DoorVariant> ReadOnlyDoorsValue = DoorsValue.AsReadOnly();
@@ -55,109 +74,27 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets all <see cref="Room"/> objects.
         /// </summary>
-        public static ReadOnlyCollection<Room> Rooms
-        {
-            get
-            {
-                if (RoomsValue.Count == 0)
-                {
-                    List<GameObject> roomObjects = ListPool<GameObject>.Shared.Rent();
-
-                    // Get bulk of rooms.
-                    roomObjects.AddRange(GameObject.FindGameObjectsWithTag("Room"));
-
-                    // If no rooms were found, it means a plugin is trying to access this before the map is created.
-                    if (roomObjects.Count == 0)
-                    {
-                        ListPool<GameObject>.Shared.Return(roomObjects);
-                        throw new InvalidOperationException("Plugin is trying to access Rooms before they are created.");
-                    }
-
-                    // Add the pocket dimension since it is not tagged Room.
-                    const string PocketPath = "HeavyRooms/PocketWorld";
-
-                    var pocket = GameObject.Find(PocketPath);
-
-                    if (pocket == null)
-                        Log.Send($"[{typeof(Map).FullName}]: Pocket Dimension not found. The name or location in the game's hierarchy might have changed.", Discord.LogLevel.Error, ConsoleColor.DarkRed);
-                    else
-                        roomObjects.Add(pocket);
-
-                    // Add the surface since it is not tagged Room. Add it last so we can use it as a default room since it never changes.
-                    const string surfaceRoomName = "Outside";
-
-                    var surface = GameObject.Find(surfaceRoomName);
-
-                    if (surface == null)
-                        Log.Send($"[{typeof(Map).FullName}]: Surface not found. The name in the game's hierarchy might have changed.", Discord.LogLevel.Error, ConsoleColor.DarkRed);
-                    else
-                        roomObjects.Add(surface);
-
-                    foreach (var roomObject in roomObjects)
-                        RoomsValue.Add(Room.CreateComponent(roomObject));
-
-                    ListPool<GameObject>.Shared.Return(roomObjects);
-                }
-
-                return ReadOnlyRoomsValue;
-            }
-        }
+        public static ReadOnlyCollection<Room> Rooms => ReadOnlyRoomsValue;
 
         /// <summary>
         /// Gets all <see cref="DoorVariant"/> objects.
         /// </summary>
-        public static ReadOnlyCollection<DoorVariant> Doors
-        {
-            get
-            {
-                if (DoorsValue.Count == 0)
-                    DoorsValue.AddRange(Object.FindObjectsOfType<DoorVariant>());
-
-                return ReadOnlyDoorsValue;
-            }
-        }
+        public static ReadOnlyCollection<DoorVariant> Doors => ReadOnlyDoorsValue;
 
         /// <summary>
         /// Gets all <see cref="Camera079"/> objects.
         /// </summary>
-        public static ReadOnlyCollection<Camera079> Cameras
-        {
-            get
-            {
-                if (CamerasValue.Count == 0)
-                    CamerasValue.AddRange(Object.FindObjectsOfType<Camera079>());
-
-                return ReadOnlyCamerasValue;
-            }
-        }
+        public static ReadOnlyCollection<Camera079> Cameras => ReadOnlyCamerasValue;
 
         /// <summary>
         /// Gets all <see cref="Lift"/> objects.
         /// </summary>
-        public static ReadOnlyCollection<Lift> Lifts
-        {
-            get
-            {
-                if (LiftsValue.Count == 0)
-                    LiftsValue.AddRange(Object.FindObjectsOfType<Lift>());
-
-                return ReadOnlyLiftsValue;
-            }
-        }
+        public static ReadOnlyCollection<Lift> Lifts => ReadOnlyLiftsValue;
 
         /// <summary>
         /// Gets all <see cref="TeslaGate"/> objects.
         /// </summary>
-        public static ReadOnlyCollection<TeslaGate> TeslaGates
-        {
-            get
-            {
-                if (TeslasValue.Count == 0)
-                    TeslasValue.AddRange(Object.FindObjectsOfType<TeslaGate>());
-
-                return ReadOnlyTeslasValue;
-            }
-        }
+        public static ReadOnlyCollection<TeslaGate> TeslaGates => ReadOnlyTeslasValue;
 
         /// <summary>
         /// Gets the Default <see cref="Ragdoll.Info"/>,

--- a/Exiled.Events/Handlers/Internal/MapGenerated.cs
+++ b/Exiled.Events/Handlers/Internal/MapGenerated.cs
@@ -28,6 +28,7 @@ namespace Exiled.Events.Handlers.Internal
         /// </remarks>
         public static void OnMapGenerated()
         {
+            API.Features.Map.ClearCache();
             LiftTypeExtension.RegisterElevatorTypesOnLevelLoad();
             CameraExtensions.RegisterCameraInfoOnLevelLoad();
             DoorExtensions.RegisterDoorTypesOnLevelLoad();

--- a/Exiled.Events/Handlers/Internal/MapGenerated.cs
+++ b/Exiled.Events/Handlers/Internal/MapGenerated.cs
@@ -7,10 +7,20 @@
 
 namespace Exiled.Events.Handlers.Internal
 {
+    using System;
+    using System.Collections.Generic;
+
     using Exiled.API.Extensions;
+    using Exiled.API.Features;
+
+    using Interactables.Interobjects.DoorUtils;
+
+    using NorthwoodLib.Pools;
+
+    using UnityEngine;
 
     /// <summary>
-    /// Handles <see cref="Map.Generated"/> event.
+    /// Handles <see cref="Exiled.Events.Handlers.Map.Generated"/> event.
     /// </summary>
     internal static class MapGenerated
     {
@@ -33,5 +43,62 @@ namespace Exiled.Events.Handlers.Internal
             CameraExtensions.RegisterCameraInfoOnLevelLoad();
             DoorExtensions.RegisterDoorTypesOnLevelLoad();
         }
+
+        private static void GenerateCache()
+        {
+            GenerateRooms();
+            GenerateDoors();
+            GenerateCameras();
+            GenerateTeslaGates();
+            GenerateLifts();
+        }
+
+        private static void GenerateRooms()
+        {
+            List<GameObject> roomObjects = ListPool<GameObject>.Shared.Rent();
+
+            // Get bulk of rooms.
+            roomObjects.AddRange(GameObject.FindGameObjectsWithTag("Room"));
+
+            // If no rooms were found, it means a plugin is trying to access this before the map is created.
+            if (roomObjects.Count == 0)
+            {
+                ListPool<GameObject>.Shared.Return(roomObjects);
+                throw new InvalidOperationException("Plugin is trying to access Rooms before they are created.");
+            }
+
+            // Add the pocket dimension since it is not tagged Room.
+            const string PocketPath = "HeavyRooms/PocketWorld";
+
+            var pocket = GameObject.Find(PocketPath);
+
+            if (pocket == null)
+                Log.Send($"[{typeof(Map).FullName}]: Pocket Dimension not found. The name or location in the game's hierarchy might have changed.", Discord.LogLevel.Error, ConsoleColor.DarkRed);
+            else
+                roomObjects.Add(pocket);
+
+            // Add the surface since it is not tagged Room. Add it last so we can use it as a default room since it never changes.
+            const string surfaceRoomName = "Outside";
+
+            var surface = GameObject.Find(surfaceRoomName);
+
+            if (surface == null)
+                Log.Send($"[{typeof(Map).FullName}]: Surface not found. The name in the game's hierarchy might have changed.", Discord.LogLevel.Error, ConsoleColor.DarkRed);
+            else
+                roomObjects.Add(surface);
+
+            foreach (var roomObject in roomObjects)
+                Exiled.API.Features.Map.RoomsValue.Add(Room.CreateComponent(roomObject));
+
+            ListPool<GameObject>.Shared.Return(roomObjects);
+        }
+
+        private static void GenerateDoors() => Map.DoorsValue.AddRange(UnityEngine.Object.FindObjectsOfType<DoorVariant>());
+
+        private static void GenerateCameras() => Map.CamerasValue.AddRange(UnityEngine.Object.FindObjectsOfType<Camera079>());
+
+        private static void GenerateLifts() => Map.LiftsValue.AddRange(UnityEngine.Object.FindObjectsOfType<Lift>());
+
+        private static void GenerateTeslaGates() => Map.TeslasValue.AddRange(UnityEngine.Object.FindObjectsOfType<TeslaGate>());
     }
 }

--- a/Exiled.Events/Handlers/Internal/MapGenerated.cs
+++ b/Exiled.Events/Handlers/Internal/MapGenerated.cs
@@ -39,6 +39,7 @@ namespace Exiled.Events.Handlers.Internal
         public static void OnMapGenerated()
         {
             API.Features.Map.ClearCache();
+            GenerateCache();
             LiftTypeExtension.RegisterElevatorTypesOnLevelLoad();
             CameraExtensions.RegisterCameraInfoOnLevelLoad();
             DoorExtensions.RegisterDoorTypesOnLevelLoad();

--- a/Exiled.Events/Handlers/Internal/Round.cs
+++ b/Exiled.Events/Handlers/Internal/Round.cs
@@ -35,7 +35,6 @@ namespace Exiled.Events.Handlers.Internal
         {
             MultiAdminFeatures.CallEvent(MultiAdminFeatures.EventType.ROUND_END);
 
-            API.Features.Map.ClearCache();
             API.Features.Scp173.TurnedPlayers.Clear();
             API.Features.Scp096.TurnedPlayers.Clear();
         }


### PR DESCRIPTION
By moving the ClearCache() call to when the map is generated, we guaruntee that the cache will always be cleared as close as possible to when the new map is generated, and should prevent issues pointed out in #428 