### PR TITLE
Fixed PreAuthenticatingEventArgs.Reject()

### DIFF
--- a/Exiled.Events/EventArgs/PreAuthenticatingEventArgs.cs
+++ b/Exiled.Events/EventArgs/PreAuthenticatingEventArgs.cs
@@ -153,6 +153,8 @@ namespace Exiled.Events.EventArgs
 
             NetDataWriter rejectData = new NetDataWriter();
 
+            rejectData.Put((byte)rejectionReason);
+
             switch (rejectionReason)
             {
                 case RejectionReason.Banned:

--- a/Exiled.Events/Events.cs
+++ b/Exiled.Events/Events.cs
@@ -91,7 +91,6 @@ namespace Exiled.Events
             Handlers.Map.Generated += Handlers.Internal.MapGenerated.OnMapGenerated;
 
             MapGeneration.SeedSynchronizer.OnMapGenerated += Handlers.Map.OnGenerated;
-
             ServerConsole.ReloadServerName();
             Scp096.MaxShield = Config.Scp096MaxShieldAmount;
         }

--- a/Exiled.Events/Events.cs
+++ b/Exiled.Events/Events.cs
@@ -91,6 +91,7 @@ namespace Exiled.Events
             Handlers.Map.Generated += Handlers.Internal.MapGenerated.OnMapGenerated;
 
             MapGeneration.SeedSynchronizer.OnMapGenerated += Handlers.Map.OnGenerated;
+
             ServerConsole.ReloadServerName();
             Scp096.MaxShield = Config.Scp096MaxShieldAmount;
         }


### PR DESCRIPTION
Currently ev.Reject() causes rejection with `Unspecified error occured on the server` message