### PR TITLE
Changes

### DIFF
--- a/Exiled.Events/EventArgs/AddingTargetEventArgs.cs
+++ b/Exiled.Events/EventArgs/AddingTargetEventArgs.cs
@@ -19,16 +19,18 @@ namespace Exiled.Events.EventArgs
         /// <summary>
         /// Initializes a new instance of the <see cref="AddingTargetEventArgs"/> class.
         /// </summary>
-        /// <param name="scp096"><see cref="Player"/> who is SCP-096.</param>
-        /// <param name="target"><see cref="Player"/> who is the target to be added.</param>
-        /// <param name="ahpToAdd"><see cref="int"/> amount of temporary health to add to <see cref="Scp096"/>.</param>
-        /// <param name="enrageTimeToAdd"><see cref="float"/> amount of time to add to <see cref="Scp096"/>'s enrage timer. Note: This does not affect anything if he doesn't already have any targets before this event is called.</param>
-        public AddingTargetEventArgs(Player scp096, Player target, int ahpToAdd, float enrageTimeToAdd)
+        /// <param name="scp096"><inheritdoc cref="Scp096"/></param>
+        /// <param name="target"><inheritdoc cref="Target"/></param>
+        /// <param name="ahpToAdd"><inheritdoc cref="AhpToAdd"/></param>
+        /// <param name="enrageTimeToAdd"><inheritdoc cref="EnrageTimeToAdd"/></param>
+        /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
+        public AddingTargetEventArgs(Player scp096, Player target, int ahpToAdd, float enrageTimeToAdd, bool isAllowed = true)
         {
             Scp096 = scp096;
             Target = target;
             AhpToAdd = ahpToAdd;
             EnrageTimeToAdd = enrageTimeToAdd;
+            IsAllowed = isAllowed;
         }
 
         /// <summary>
@@ -42,18 +44,19 @@ namespace Exiled.Events.EventArgs
         public Player Target { get; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not the target is allowed to be added.
-        /// </summary>
-        public bool IsAllowed { get; set; } = true;
-
-        /// <summary>
         /// Gets or sets the amount of AHP to add to SCP-096 if <see cref="IsAllowed"/> is true.
         /// </summary>
         public int AhpToAdd { get; set; }
 
         /// <summary>
         /// Gets or sets how much time is added to SCP-096's enrage timer if <see cref="IsAllowed"/> is true.
+        /// Note: This does not affect anything if he doesn't already have any targets before this event is called.
         /// </summary>
         public float EnrageTimeToAdd { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not the target is allowed to be added.
+        /// </summary>
+        public bool IsAllowed { get; set; }
     }
 }

--- a/Exiled.Events/EventArgs/AddingTargetEventArgs.cs
+++ b/Exiled.Events/EventArgs/AddingTargetEventArgs.cs
@@ -50,8 +50,8 @@ namespace Exiled.Events.EventArgs
 
         /// <summary>
         /// Gets or sets how much time is added to SCP-096's enrage timer if <see cref="IsAllowed"/> is true.
-        /// Note: This does not affect anything if he doesn't already have any targets before this event is called.
         /// </summary>
+        /// <remarks>This does not affect anything if he doesn't already have any targets before this event is called.</remarks>
         public float EnrageTimeToAdd { get; set; }
 
         /// <summary>

--- a/Exiled.Events/EventArgs/ChangingIntoGrenadeEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingIntoGrenadeEventArgs.cs
@@ -1,0 +1,52 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChangingIntoGrenadeEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+    using Exiled.API.Enums;
+
+    /// <summary>
+    /// Contains all information for when the server is turning a pickup into a live grenade.
+    /// </summary>
+    public class ChangingIntoGrenadeEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangingIntoGrenadeEventArgs"/> class.
+        /// </summary>
+        /// <param name="pickup">The <see cref="Pickup"/> being changed.</param>
+        /// <param name="fuseTime">The duration, in seconds, of the fuse time to be used when the grenade goes live.</param>
+        /// <param name="isAllowed">Whether or not the event is allowed to continue.</param>
+        public ChangingIntoGrenadeEventArgs(Pickup pickup, float fuseTime = 3f, bool isAllowed = true)
+        {
+            Pickup = pickup;
+            Type = pickup.itemId;
+            FuseTime = fuseTime;
+            IsAllowed = isAllowed;
+        }
+
+        /// <summary>
+        /// Gets a value indicating the pickup being changed.
+        /// </summary>
+        public Pickup Pickup { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating what type of grenade will be spawned.
+        /// </summary>
+        public ItemType Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the pickup will be changed.
+        /// </summary>
+        public bool IsAllowed { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating how long the fuse of the changed grenade will be.
+        /// </summary>
+        public float FuseTime { get; set; }
+    }
+}

--- a/Exiled.Events/EventArgs/GeneratorActivatedEventArgs.cs
+++ b/Exiled.Events/EventArgs/GeneratorActivatedEventArgs.cs
@@ -18,11 +18,21 @@ namespace Exiled.Events.EventArgs
         /// Initializes a new instance of the <see cref="GeneratorActivatedEventArgs"/> class.
         /// </summary>
         /// <param name="generator"><inheritdoc cref="Generator"/></param>
-        public GeneratorActivatedEventArgs(Generator079 generator) => Generator = generator;
+        /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
+        public GeneratorActivatedEventArgs(Generator079 generator, bool isAllowed = true)
+        {
+            Generator = generator;
+            IsAllowed = isAllowed;
+        }
 
         /// <summary>
         /// Gets the activated generator.
         /// </summary>
         public Generator079 Generator { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the generator can be activated or not.
+        /// </summary>
+        public bool IsAllowed { get; set; }
     }
 }

--- a/Exiled.Events/EventArgs/SendingConsoleCommandEventArgs.cs
+++ b/Exiled.Events/EventArgs/SendingConsoleCommandEventArgs.cs
@@ -78,6 +78,7 @@ namespace Exiled.Events.EventArgs
         /// <summary>
         /// Gets or sets a value indicating whether the event can be executed or not.
         /// </summary>
+        [Obsolete("Use IsAllowed instead", true)]
         public bool Allow
         {
             get => IsAllowed;

--- a/Exiled.Events/Handlers/Map.cs
+++ b/Exiled.Events/Handlers/Map.cs
@@ -10,6 +10,8 @@ namespace Exiled.Events.Handlers
     using Exiled.Events.EventArgs;
     using Exiled.Events.Extensions;
 
+    using Grenades;
+
     using static Exiled.Events.Events;
 
     /// <summary>
@@ -76,6 +78,11 @@ namespace Exiled.Events.Handlers
         /// Invoked after the map is generated.
         /// </summary>
         public static event CustomEventHandler Generated;
+
+        /// <summary>
+        /// Invoked before the server changes a pickup into a grenade, when triggered by an explosion.
+        /// </summary>
+        public static event CustomEventHandler<ChangingIntoGrenadeEventArgs> ChangingIntoGrenade;
 
         /// <summary>
         /// Called before placing a decal.
@@ -147,5 +154,11 @@ namespace Exiled.Events.Handlers
         /// Called after the map is generated.
         /// </summary>
         public static void OnGenerated() => Generated.InvokeSafely();
+
+        /// <summary>
+        /// Called before the server changes a <see cref="Pickup"/> into a <see cref="Grenade"/> when hit by an explosion.
+        /// </summary>
+        /// <param name="ev">The <see cref="ChangingIntoGrenadeEventArgs"/> instance.</param>
+        public static void OnChangingIntoGrenade(ChangingIntoGrenadeEventArgs ev) => ChangingIntoGrenade.InvokeSafely(ev);
     }
 }

--- a/Exiled.Events/Patches/Events/Map/AnnouncingNtfEntrance.cs
+++ b/Exiled.Events/Patches/Events/Map/AnnouncingNtfEntrance.cs
@@ -9,7 +9,6 @@ namespace Exiled.Events.Patches.Events.Map
 {
     using System.Linq;
 
-#pragma warning disable SA1313
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
 

--- a/Exiled.Events/Patches/Events/Map/AnnouncingScpTermination.cs
+++ b/Exiled.Events/Patches/Events/Map/AnnouncingScpTermination.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.Events.Patches.Events.Map
 {
-#pragma warning disable SA1313
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
 

--- a/Exiled.Events/Patches/Events/Map/ChangingIntoGrenade.cs
+++ b/Exiled.Events/Patches/Events/Map/ChangingIntoGrenade.cs
@@ -1,0 +1,101 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChangingIntoGrenade.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Map
+{
+#pragma warning disable SA1118
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Reflection.Emit;
+
+    using Exiled.API.Features;
+    using Exiled.Events.EventArgs;
+
+    using Grenades;
+
+    using HarmonyLib;
+
+    using Mirror;
+
+    using NorthwoodLib.Pools;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    /// Patches <see cref="FragGrenade.ChangeIntoGrenade"/>.
+    /// Adds the <see cref="Handlers.Map.ChangingIntoGrenade"/> event.
+    /// </summary>
+    [HarmonyPatch(typeof(FragGrenade), nameof(FragGrenade.ChangeIntoGrenade))]
+    internal static class ChangingIntoGrenade
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            // The index offset
+            int offset = 2;
+
+            // Find the last return false call.
+            int index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Ldc_I4_0) + offset;
+
+            // Generate a continue lable.
+            Label continueLabel = generator.DefineLabel();
+
+            // Declare ChangingIntoGrenadeEventArgs, to be able to store it's instance with "stloc.s".
+            LocalBuilder ev = generator.DeclareLocal(typeof(ChangingIntoGrenadeEventArgs));
+
+            newInstructions.InsertRange(index, new[]
+            {
+                // (Pickup item, float fuseTime, bool isAllowed)
+                new CodeInstruction(OpCodes.Ldarg_1).MoveLabelsFrom(newInstructions[index]),
+                new CodeInstruction(OpCodes.Ldc_R4, 3f),
+                new CodeInstruction(OpCodes.Ldc_I4_1),
+
+                // var ev = new ServerChangingGrenadeEventArgs(pickup)
+                new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(ChangingIntoGrenadeEventArgs))[0]),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Stloc_S, ev.LocalIndex),
+
+                // Handlers.Map.OnServerChangingGrenade(ev)
+                new CodeInstruction(OpCodes.Call, Method(typeof(Handlers.Map), nameof(Handlers.Map.OnChangingIntoGrenade))),
+
+                // if (!ev.IsAllowed)
+                //     return;
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingIntoGrenadeEventArgs), nameof(ChangingIntoGrenadeEventArgs.IsAllowed))),
+                new CodeInstruction(OpCodes.Brtrue_S, continueLabel),
+                new CodeInstruction(OpCodes.Ldc_I4_0),
+                new CodeInstruction(OpCodes.Ret),
+
+                // item.ItemId = ev.Type
+                new CodeInstruction(OpCodes.Ldarg_1).WithLabels(continueLabel),
+                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
+                new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(ChangingIntoGrenadeEventArgs), nameof(ChangingIntoGrenadeEventArgs.Type))),
+                new CodeInstruction(OpCodes.Call, PropertySetter(typeof(Pickup), nameof(Pickup.ItemId))),
+            });
+
+            // Find the last method call
+            index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Callvirt && (MethodInfo)instruction.operand == Method(typeof(Grenade), nameof(Grenade.InitData), new[] { typeof(FragGrenade), typeof(Pickup) }));
+
+            newInstructions.InsertRange(index, new[]
+            {
+                // grenade.NetworkFuseTime = NetworkTime.Time + ev.FuseTime
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingIntoGrenadeEventArgs), nameof(ChangingIntoGrenadeEventArgs.FuseTime))),
+                new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(NetworkTime), nameof(NetworkTime.time))),
+                new CodeInstruction(OpCodes.Add),
+                new CodeInstruction(OpCodes.Callvirt, PropertySetter(typeof(Grenades.Grenade), nameof(Grenades.Grenade.NetworkfuseTime))),
+            });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Map/DamagingWindow.cs
+++ b/Exiled.Events/Patches/Events/Map/DamagingWindow.cs
@@ -7,20 +7,24 @@
 
 namespace Exiled.Events.Patches.Events.Map
 {
+    using Exiled.Events.EventArgs;
+    using Exiled.Events.Handlers;
 #pragma warning disable SA1313
     using HarmonyLib;
 
     /// <summary>
     /// Patches <see cref="BreakableWindow.ServerDamageWindow(float)"/>.
-    /// Adds the <see cref="Handlers.Map.DamagingWindow"/> event.
+    /// Adds the <see cref="Map.DamagingWindow"/> event.
     /// </summary>
     [HarmonyPatch(typeof(BreakableWindow), nameof(BreakableWindow.ServerDamageWindow))]
     internal static class DamagingWindow
     {
         private static void Prefix(BreakableWindow __instance, ref float damage)
         {
-            var ev = new EventArgs.DamagingWindowEventArgs(__instance, damage);
-            Handlers.Map.OnDamagingWindow(ev);
+            var ev = new DamagingWindowEventArgs(__instance, damage);
+
+            Map.OnDamagingWindow(ev);
+
             damage = ev.Damage;
         }
     }

--- a/Exiled.Events/Patches/Events/Map/Decontaminating.cs
+++ b/Exiled.Events/Patches/Events/Map/Decontaminating.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.Events.Patches.Events.Map
 {
-#pragma warning disable SA1313
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
 

--- a/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
+++ b/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
@@ -66,7 +66,7 @@ namespace Exiled.Events.Patches.Events.Map
             }
             catch (Exception exception)
             {
-                Log.Error($"{typeof(ExplodingFlashGrenade).FullName}: {exception}");
+                Log.Error($"{typeof(ExplodingFlashGrenade).FullName}:\n{exception}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
+++ b/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
@@ -66,7 +66,7 @@ namespace Exiled.Events.Patches.Events.Map
             }
             catch (Exception exception)
             {
-                Log.Error($"{nameof(Handlers.Map.OnExplodingGrenade)} error: {exception}");
+                Log.Error($"{typeof(ExplodingFlashGrenade).FullName}: {exception}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
+++ b/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
@@ -66,7 +66,7 @@ namespace Exiled.Events.Patches.Events.Map
             }
             catch (Exception exception)
             {
-                Log.Error($"Exiled.Events.Patches.Events.Map.ExplodingFlashGrenade: {exception}\n{exception.StackTrace}");
+                Log.Error($"{nameof(Handlers.Map.OnExplodingGrenade)} error: {exception}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Map/SpawningItem.cs
+++ b/Exiled.Events/Patches/Events/Map/SpawningItem.cs
@@ -32,13 +32,18 @@ namespace Exiled.Events.Patches.Events.Map
             if (ev.IsAllowed)
             {
                 Pickup pickup = ReferenceHub.GetHub(PlayerManager.localPlayer).inventory.SetPickup(ev.Id, 0.0f, Vector3.zero, Quaternion.identity, 0, 0, 0);
+
                 yield return float.NegativeInfinity;
+
                 HostItemSpawner.SetPos(pickup, ev.Position, ev.Id, ev.Rotation.eulerAngles);
+
                 pickup.RefreshDurability(true, true);
+
                 if (ev.Locked)
                     pickup.Locked = true;
 
                 SpawnedItemEventArgs spawned_ev = new SpawnedItemEventArgs(pickup);
+
                 Handlers.Map.OnSpawnedItem(spawned_ev);
             }
         }

--- a/Exiled.Events/Patches/Events/Scp096/AddingTarget.cs
+++ b/Exiled.Events/Patches/Events/Scp096/AddingTarget.cs
@@ -7,17 +7,22 @@
 
 namespace Exiled.Events.Patches.Events.Scp096
 {
-#pragma warning disable SA1313
+#pragma warning disable SA1118
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Reflection.Emit;
+
+    using Exiled.API.Extensions;
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
 
     using HarmonyLib;
 
-    using Mirror;
-
-    using PlayableScps.Messages;
+    using NorthwoodLib.Pools;
 
     using UnityEngine;
+
+    using static HarmonyLib.AccessTools;
 
     using Scp096 = PlayableScps.Scp096;
 
@@ -28,45 +33,115 @@ namespace Exiled.Events.Patches.Events.Scp096
     [HarmonyPatch(typeof(Scp096), nameof(Scp096.AddTarget))]
     internal static class AddingTarget
     {
-        private static bool Prefix(Scp096 __instance, GameObject target)
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
-            ReferenceHub hub = ReferenceHub.GetHub(target);
-            if (!__instance.CanReceiveTargets || hub == null || __instance._targets.Contains(hub))
-                return false;
-            API.Features.Player scp096 = API.Features.Player.Get(__instance.Hub.gameObject);
-            API.Features.Player targetPlayer = API.Features.Player.Get(target);
-            if (scp096 == null)
+            var newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            // The index offset.
+            var offset = 1;
+
+            // Search for the third "ldarg.0".
+            var index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Ret) + offset;
+
+            // Get the return label from the "ret" instruction.
+            var returnLabel = newInstructions[index - offset].labels[0];
+
+            // Declare AddingTargetEventArgs, to be able to store its instance with "stloc.s".
+            var ev = generator.DeclareLocal(typeof(AddingTargetEventArgs));
+
+            // var ev = new AddingTargetEventArgs(Player.Get(this.Hub), Player.Get(target), 70, this.EnrageTimePerReset);
+            //
+            // Handlers.Scp096.OnAddingTarget(ev);
+            //
+            // if (!ev.IsAllowed)
+            //   return;
+            newInstructions.InsertRange(index, new[]
             {
-                Log.Error("SCP-096.AddTarget: Could not get SCP-096 player object.");
-                return true;
-            }
+                // Player.Get(this.Hub)
+                new CodeInstruction(OpCodes.Ldarg_0).MoveLabelsFrom(newInstructions[index]),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Scp096), nameof(Scp096.Hub))),
+                new CodeInstruction(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
 
-            if (targetPlayer == null)
+                // Player.Get(target)
+                new CodeInstruction(OpCodes.Ldarg_1),
+                new CodeInstruction(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(GameObject) })),
+
+                // 70
+                new CodeInstruction(OpCodes.Ldc_I4_S, 70),
+
+                // this.EnrageTimePerReset;
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(Scp096), nameof(Scp096.EnrageTimePerReset))),
+
+                // true
+                new CodeInstruction(OpCodes.Ldc_I4_1),
+
+                // var ev = new AddingTargetEventArgs(...)
+                new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(AddingTargetEventArgs))[0]),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Stloc_S, ev.LocalIndex),
+
+                // Handlers.Scp096.OnAddingTarget(ev)
+                new CodeInstruction(OpCodes.Call, Method(typeof(Handlers.Scp096), nameof(Handlers.Scp096.OnAddingTarget))),
+
+                // if (!ev.IsAllowed)
+                //   return;
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(AddingTargetEventArgs), nameof(AddingTargetEventArgs.IsAllowed))),
+                new CodeInstruction(OpCodes.Brfalse_S, returnLabel),
+            });
+
+            offset = -1;
+            var instructionsToRemove = 2;
+
+            // Search for the sixth "ldarg.0".
+            index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Call &&
+            (MethodInfo)instruction.operand == Method(typeof(Scp096), nameof(Scp096.AddReset))) + offset;
+
+            // Extract all labels from it.
+            var addResetLabels = newInstructions[index].ExtractLabels();
+
+            // Remove "this.AddReset()"
+            newInstructions.RemoveRange(index, instructionsToRemove);
+
+            newInstructions.InsertRange(index, new[]
             {
-                Log.Error("SCP-096.AddTarget: Could not get Target player object.");
-                return true;
-            }
+                // this.EnrageTimeLeft += ev.EnrageTimeToAdd
+                new CodeInstruction(OpCodes.Ldarg_0).WithLabels(addResetLabels),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(Scp096), nameof(Scp096.EnrageTimeLeft))),
+                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(AddingTargetEventArgs), nameof(AddingTargetEventArgs.EnrageTimeToAdd))),
+                new CodeInstruction(OpCodes.Add),
+                new CodeInstruction(OpCodes.Call, PropertySetter(typeof(Scp096), nameof(Scp096.EnrageTimeLeft))),
 
-            AddingTargetEventArgs ev = new AddingTargetEventArgs(scp096, targetPlayer, 70, __instance.EnrageTimePerReset);
-            Exiled.Events.Handlers.Scp096.OnAddingTarget(ev);
-            if (ev.IsAllowed)
+                // this.AddedTimeThisRage += ev.EnrageTimeToAdd
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(Scp096), nameof(Scp096.AddedTimeThisRage))),
+                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(AddingTargetEventArgs), nameof(AddingTargetEventArgs.EnrageTimeToAdd))),
+                new CodeInstruction(OpCodes.Add),
+                new CodeInstruction(OpCodes.Call, PropertySetter(typeof(Scp096), nameof(Scp096.AddedTimeThisRage))),
+            });
+
+            // Get the index of the last "ldc.i4.s".
+            index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Ldc_I4_S);
+
+            // Remove "ldc.i4.s" instruction.
+            newInstructions.RemoveAt(index);
+
+            // Load "ev.AhpToAdd" instead of 70.
+            newInstructions.InsertRange(index, new[]
             {
-                if (!__instance._targets.IsEmpty() || __instance.Enraged)
-                {
-                    if (__instance.AddedTimeThisRage + ev.EnrageTimeToAdd >= __instance.MaximumAddedEnrageTime)
-                        ev.EnrageTimeToAdd = 0f;
-                    else if (__instance.AddedTimeThisRage + ev.EnrageTimeToAdd > __instance.MaximumAddedEnrageTime)
-                        ev.EnrageTimeToAdd = __instance.AddedTimeThisRage + ev.EnrageTimeToAdd - __instance.MaximumAddedEnrageTime;
-                    __instance.EnrageTimeLeft += ev.EnrageTimeToAdd;
-                    __instance.AddedTimeThisRage += ev.EnrageTimeToAdd;
-                }
+                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(AddingTargetEventArgs), nameof(AddingTargetEventArgs.AhpToAdd))),
+            });
 
-                __instance._targets.Add(hub);
-                __instance.AdjustShield(ev.AhpToAdd);
-                NetworkServer.SendToClientOfPlayer<Scp096ToTargetMessage>(hub.characterClassManager.netIdentity, new Scp096ToTargetMessage(hub));
-            }
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
 
-            return false;
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Scp096/CalmingDown.cs
+++ b/Exiled.Events/Patches/Events/Scp096/CalmingDown.cs
@@ -23,7 +23,7 @@ namespace Exiled.Events.Patches.Events.Scp096
     {
         private static bool Prefix(Scp096 __instance)
         {
-            var ev = new CalmingDownEventArgs(__instance, API.Features.Player.Get(__instance.Hub.gameObject));
+            var ev = new CalmingDownEventArgs(__instance, API.Features.Player.Get(__instance.Hub));
 
             Handlers.Scp096.OnCalmingDown(ev);
 

--- a/Exiled.Events/Patches/Events/Scp096/StartPryingGate.cs
+++ b/Exiled.Events/Patches/Events/Scp096/StartPryingGate.cs
@@ -23,12 +23,14 @@ namespace Exiled.Events.Patches.Events.Scp096
     [HarmonyPatch(typeof(Scp096), nameof(Scp096.PryGate))]
     internal static class StartPryingGate
     {
-        private static bool Prefix(PlayableScps.Scp096 __instance, PryableDoor gate)
+        private static bool Prefix(Scp096 __instance, PryableDoor gate)
         {
             if (__instance.Charging && __instance.Enraged && (!gate.TargetState /* && gate.doorType == Door.DoorTypes.HeavyGate */))
             {
                 var ev = new StartPryingGateEventArgs(API.Features.Player.Get(__instance.Hub.gameObject), gate);
-                Exiled.Events.Handlers.Scp096.OnStartPryingGate(ev);
+
+                Handlers.Scp096.OnStartPryingGate(ev);
+
                 return ev.IsAllowed;
             }
 

--- a/Exiled.Events/Patches/Events/Scp173/Blinking.cs
+++ b/Exiled.Events/Patches/Events/Scp173/Blinking.cs
@@ -35,6 +35,7 @@ namespace Exiled.Events.Patches.Events.Scp173
                     if (player.Team != Team.SCP && player.Team != Team.RIP)
                     {
                         Scp173PlayerScript playerScript = player.ReferenceHub.characterClassManager.Scp173;
+
                         if (playerScript.LookFor173(__instance.gameObject, true))
                             triggers.Add(player);
                     }

--- a/Exiled.Events/Patches/Events/Scp914/UpgradingItems.cs
+++ b/Exiled.Events/Patches/Events/Scp914/UpgradingItems.cs
@@ -7,8 +7,11 @@
 
 namespace Exiled.Events.Patches.Events.Scp914
 {
-#pragma warning disable SA1313
+#pragma warning disable SA1118
+    using System.Collections.Generic;
+
     using System.Linq;
+    using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -17,9 +20,9 @@ namespace Exiled.Events.Patches.Events.Scp914
 
     using HarmonyLib;
 
-    using Mirror;
+    using NorthwoodLib.Pools;
 
-    using UnityEngine;
+    using static HarmonyLib.AccessTools;
 
     /// <summary>
     /// Patches <see cref="Scp914Machine.ProcessItems"/>.
@@ -28,40 +31,85 @@ namespace Exiled.Events.Patches.Events.Scp914
     [HarmonyPatch(typeof(Scp914Machine), nameof(Scp914Machine.ProcessItems))]
     internal static class UpgradingItems
     {
-        private static bool Prefix(Scp914Machine __instance)
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
-            if (!NetworkServer.active)
-                return true;
-            Collider[] colliderArray = Physics.OverlapBox(__instance.intake.position, __instance.inputSize / 2f);
-            __instance.players.Clear();
-            __instance.items.Clear();
-            foreach (Collider collider in colliderArray)
+            var newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            // The first index offset.
+            var offset = 0;
+
+            // Search for the first "nop".
+            var index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Nop) + offset;
+
+            // Declare UpgradingItemsEventArgs, to be able to store its instance with "stloc.s".
+            var ev = generator.DeclareLocal(typeof(UpgradingItemsEventArgs));
+
+            newInstructions.InsertRange(index, new[]
             {
-                CharacterClassManager component1 = collider.GetComponent<CharacterClassManager>();
-                if (component1 != null)
-                {
-                    __instance.players.Add(component1);
-                }
-                else
-                {
-                    Pickup component2 = collider.GetComponent<Pickup>();
-                    if (component2 != null)
-                        __instance.items.Add(component2);
-                }
-            }
+                // var ev = new UpgradingItemsEventArgs(this, this.players.Select(player => API.Features.Player.Get(player.gameObject)).ToList(), this.items, this.knobState);
+                //
+                // Scp914.OnUpgradingItems(ev);
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Scp914Machine), nameof(Scp914Machine.players))),
+                new CodeInstruction(OpCodes.Call, Method(typeof(UpgradingItems), nameof(UpgradingItems.FromCharacterClassManagersToPlayers))),
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Scp914Machine), nameof(Scp914Machine.items))),
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Scp914Machine), nameof(Scp914Machine.knobState))),
+                new CodeInstruction(OpCodes.Ldc_I4_1),
+                new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(UpgradingItemsEventArgs))[0]),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Stloc_S, ev.LocalIndex),
+                new CodeInstruction(OpCodes.Call, Method(typeof(Scp914), nameof(Scp914.OnUpgradingItems))),
 
-            var ev = new UpgradingItemsEventArgs(__instance, __instance.players.Select(player => API.Features.Player.Get(player.gameObject)).ToList(), __instance.items, __instance.knobState);
+                // this.players.Clear();
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Scp914Machine), nameof(Scp914Machine.players))),
+                new CodeInstruction(OpCodes.Callvirt, Method(typeof(List<CharacterClassManager>), nameof(List<CharacterClassManager>.Clear))),
 
-            Scp914.OnUpgradingItems(ev);
+                // this.items.AddRange(ev.Players.Select(player => player.ReferenceHub.characterClassManager).ToList());
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Scp914Machine), nameof(Scp914Machine.players))),
+                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(UpgradingItemsEventArgs), nameof(UpgradingItemsEventArgs.Players))),
+                new CodeInstruction(OpCodes.Call, Method(typeof(UpgradingItems), nameof(UpgradingItems.FromPlayersToCharacterClassManagers))),
+                new CodeInstruction(OpCodes.Callvirt, Method(typeof(List<CharacterClassManager>), nameof(List<CharacterClassManager>.AddRange))),
+            });
 
-            var players = ev.Players.Select(player => player.ReferenceHub.characterClassManager).ToList();
+            // The second index offset.
+            offset = 1;
+            var endFinallyOffset = 6;
 
-            __instance.MoveObjects(ev.Items, players);
+            // Search for the fifth "call".
+            index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Leave_S) + offset;
 
-            if (ev.IsAllowed)
-                __instance.UpgradeObjects(ev.Items, players);
+            // Set the return label to the first "endfinally" .
+            var returnLabel = newInstructions[index + endFinallyOffset].WithLabels(generator.DefineLabel()).labels[0];
 
-            return false;
+            newInstructions.InsertRange(index, new[]
+            {
+                // if (!ev.IsAllowed)
+                //   return;
+                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex).MoveBlocksFrom(newInstructions[index]),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(UpgradingItemsEventArgs), nameof(UpgradingItemsEventArgs.IsAllowed))),
+                new CodeInstruction(OpCodes.Brfalse_S, returnLabel),
+            });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+
+        private static List<API.Features.Player> FromCharacterClassManagersToPlayers(List<CharacterClassManager> characterClassManagers)
+        {
+            return characterClassManagers.Select(player => API.Features.Player.Get(player.gameObject)).ToList();
+        }
+
+        private static List<CharacterClassManager> FromPlayersToCharacterClassManagers(List<API.Features.Player> players)
+        {
+            return players.Select(player => player.ReferenceHub.characterClassManager).ToList();
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Scp914/UpgradingItems.cs
+++ b/Exiled.Events/Patches/Events/Scp914/UpgradingItems.cs
@@ -68,7 +68,7 @@ namespace Exiled.Events.Patches.Events.Scp914
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(Scp914Machine), nameof(Scp914Machine.players))),
                 new CodeInstruction(OpCodes.Callvirt, Method(typeof(List<CharacterClassManager>), nameof(List<CharacterClassManager>.Clear))),
 
-                // this.items.AddRange(ev.Players.Select(player => player.ReferenceHub.characterClassManager).ToList());
+                // this.players.AddRange(ev.Players.Select(player => player.ReferenceHub.characterClassManager).ToList());
                 new CodeInstruction(OpCodes.Ldarg_0),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(Scp914Machine), nameof(Scp914Machine.players))),
                 new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),

--- a/Exiled.Events/Patches/Events/Server/ReportingCheater.cs
+++ b/Exiled.Events/Patches/Events/Server/ReportingCheater.cs
@@ -32,11 +32,7 @@ namespace Exiled.Events.Patches.Events.Server
             if (reportedUserId == reporterUserId)
                 reporter.SendToClient(__instance.connectionToClient, "You can't report yourself!" + Environment.NewLine, "yellow");
 
-            var ev = new ReportingCheaterEventArgs(
-                API.Features.Player.Get(reporterUserId),
-                API.Features.Player.Get(reportedUserId),
-                ServerConsole.Port,
-                reason);
+            var ev = new ReportingCheaterEventArgs(API.Features.Player.Get(reporterUserId), API.Features.Player.Get(reportedUserId), ServerConsole.Port, reason);
 
             Server.OnReportingCheater(ev);
 

--- a/Exiled.Events/Patches/Events/Server/RestartingRound.cs
+++ b/Exiled.Events/Patches/Events/Server/RestartingRound.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.Events.Patches.Events.Server
 {
-#pragma warning disable SA1313
     using HarmonyLib;
 
     /// <summary>

--- a/Exiled.Events/Patches/Events/Server/SendingConsoleCommand.cs
+++ b/Exiled.Events/Patches/Events/Server/SendingConsoleCommand.cs
@@ -34,7 +34,7 @@ namespace Exiled.Events.Patches.Events.Server
             if (!string.IsNullOrEmpty(ev.ReturnMessage))
                 __instance.GCT.SendToClient(__instance.connectionToClient, ev.ReturnMessage, ev.Color);
 
-            return ev.Allow;
+            return ev.IsAllowed;
         }
     }
 }

--- a/Exiled.Events/Patches/Fixes/CharacterClassManagerLoadSpam.cs
+++ b/Exiled.Events/Patches/Fixes/CharacterClassManagerLoadSpam.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.Events.Patches.Fixes
 {
-#pragma warning disable SA1313
     using System.Collections.Generic;
     using System.Reflection;
     using System.Reflection.Emit;

--- a/Exiled.Events/Patches/Generic/Scp096MaxShield.cs
+++ b/Exiled.Events/Patches/Generic/Scp096MaxShield.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.Events.Patches.Generic
 {
-#pragma warning disable SA1118
 #pragma warning disable SA1313
     using HarmonyLib;
 
@@ -19,9 +18,9 @@ namespace Exiled.Events.Patches.Generic
     [HarmonyPatch(typeof(Scp096), nameof(Scp096.MaxShield), MethodType.Getter)]
     internal static class Scp096MaxShield
     {
-        private static bool Prefix(Scp096 __instance, ref float __result)
+        private static bool Prefix(ref float __result)
         {
-            __result = Exiled.API.Features.Scp096.MaxShield;
+            __result = API.Features.Scp096.MaxShield;
             return false;
         }
     }

--- a/Exiled.Events/Patches/Generic/ServerNamePatch.cs
+++ b/Exiled.Events/Patches/Generic/ServerNamePatch.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.Events.Patches.Generic
 {
-#pragma warning disable SA1313
     using HarmonyLib;
 
     using static Exiled.Events.Events;
@@ -23,7 +22,7 @@ namespace Exiled.Events.Patches.Generic
             if (!Instance.Config.IsNameTrackingEnabled)
                 return;
 
-            ServerConsole._serverName += $"<color=#00000000><size=1>Exiled {Instance.RequiredExiledVersion.ToString(3)}</size></color>";
+            ServerConsole._serverName += $"<color=#00000000><size=1>Exiled {Instance.Version.ToString(3)}</size></color>";
         }
     }
 }

--- a/Exiled.Events/Patches/Generic/StaminaUsagePatch.cs
+++ b/Exiled.Events/Patches/Generic/StaminaUsagePatch.cs
@@ -19,9 +19,6 @@ namespace Exiled.Events.Patches.Generic
     [HarmonyPatch(typeof(Stamina), nameof(Stamina.ProcessStamina))]
     internal class StaminaUsagePatch
     {
-        private static bool Prefix(Stamina __instance)
-        {
-            return Player.Get(__instance._hub)?.IsUsingStamina ?? true;
-        }
+        private static bool Prefix(Stamina __instance) => Player.Get(__instance._hub)?.IsUsingStamina ?? true;
     }
 }

--- a/Exiled.Example/Events/ItemHandler.cs
+++ b/Exiled.Example/Events/ItemHandler.cs
@@ -1,11 +1,11 @@
 // -----------------------------------------------------------------------
-// <copyright file="Item.cs" company="Exiled Team">
+// <copyright file="ItemHandler.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Exiled.Example.Handlers
+namespace Exiled.Example.Events
 {
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
@@ -13,15 +13,15 @@ namespace Exiled.Example.Handlers
     /// <summary>
     /// Handles Map events.
     /// </summary>
-    internal sealed class Item
+    internal sealed class ItemHandler
     {
-        /// <inheritdoc cref="Events.Handlers.Item.OnChangingDurability(ChangingDurabilityEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Item.OnChangingDurability(ChangingDurabilityEventArgs)"/>
         public void OnChangingDurability(ChangingDurabilityEventArgs ev)
         {
             Log.Info($"Item {ev.OldItem.id} durability of {ev.OldItem.durability} is changing");
         }
 
-        /// <inheritdoc cref="Events.Handlers.Item.OnChangingAttachments(ChangingAttachmentsEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Item.OnChangingAttachments(ChangingAttachmentsEventArgs)"/>
         public void OnChangingAttachments(ChangingAttachmentsEventArgs ev)
         {
             Log.Info($"Item {ev.NewItem.id} attachments are changing, old ones:\n[SIGHT ({ev.OldItem.modSight})] [BARREL ({ev.OldItem.modBarrel})] [OTHER ({ev.OldItem.modOther})]");

--- a/Exiled.Example/Events/MapHandler.cs
+++ b/Exiled.Example/Events/MapHandler.cs
@@ -1,26 +1,31 @@
 // -----------------------------------------------------------------------
-// <copyright file="Map.cs" company="Exiled Team">
+// <copyright file="MapHandler.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Exiled.Example.Handlers
+namespace Exiled.Example.Events
 {
     using System.Linq;
-
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
 
     /// <summary>
     /// Handles Map events.
     /// </summary>
-    internal sealed class Map
+    internal sealed class MapHandler
     {
-        /// <inheritdoc cref="Events.Handlers.Map.OnExplodingGrenade(ExplodingGrenadeEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Map.OnExplodingGrenade(ExplodingGrenadeEventArgs)"/>
         public void OnExplodingGrenade(ExplodingGrenadeEventArgs ev)
         {
             Log.Info($"A frag grenade thrown by {ev.Thrower.Nickname} is exploding: {ev.Grenade.name}\n[Targets]\n\n{string.Join("\n", ev.TargetToDamages.Select(player => $"[{player.Key.Nickname} ({player.Value} HP)]"))}");
+        }
+
+        /// <inheritdoc cref="Exiled.Events.Handlers.Map.OnGeneratorActivated(GeneratorActivatedEventArgs)"/>
+        public void OnGeneratorActivated(GeneratorActivatedEventArgs ev)
+        {
+            Log.Info($"A generator has been activated in {ev.Generator.CurRoom}!");
         }
     }
 }

--- a/Exiled.Example/Events/PlayerHandler.cs
+++ b/Exiled.Example/Events/PlayerHandler.cs
@@ -1,12 +1,14 @@
 // -----------------------------------------------------------------------
-// <copyright file="Player.cs" company="Exiled Team">
+// <copyright file="PlayerHandler.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Exiled.Example.Handlers
+namespace Exiled.Example.Events
 {
+    using System;
+
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
 
@@ -15,69 +17,69 @@ namespace Exiled.Example.Handlers
     /// <summary>
     /// Handles player events.
     /// </summary>
-    internal sealed class Player
+    internal sealed class PlayerHandler
     {
-        /// <inheritdoc cref="Events.Handlers.Player.OnDied(DiedEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnDied(DiedEventArgs)"/>
         public void OnDied(DiedEventArgs ev)
         {
             Log.Info($"{ev.Target?.Nickname} ({ev.Target?.Role}) died from {ev.HitInformations.GetDamageName()}! {ev.Killer?.Nickname} ({ev.Killer?.Role}) killed him!");
         }
 
-        /// <inheritdoc cref="Events.Handlers.Player.OnChangingRole(ChangingRoleEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnChangingRole(ChangingRoleEventArgs)"/>
         public void OnChangingRole(ChangingRoleEventArgs ev)
         {
             Log.Info($"{ev.Player?.Nickname} ({ev.Player?.Role}) is changing his role! The new role will be {ev?.NewRole}!");
         }
 
-        /// <inheritdoc cref="Events.Handlers.Player.OnChangingItem(ChangingItemEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnChangingItem(ChangingItemEventArgs)"/>
         public void OnChangingItem(ChangingItemEventArgs ev)
         {
             Log.Info($"{ev.Player?.Nickname} is changing his {ev.OldItem.id} item to {ev.NewItem.id}!");
         }
 
-        /// <inheritdoc cref="Events.Handlers.Scp106.OnTeleporting(TeleportingEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Scp106.OnTeleporting(TeleportingEventArgs)"/>
         public void OnTeleporting(TeleportingEventArgs ev)
         {
             Log.Info($"{ev.Player?.Nickname} is teleporting to {ev.PortalPosition} as SCP-106!");
         }
 
-        /// <inheritdoc cref="Events.Handlers.Scp106.OnContaining(ContainingEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Scp106.OnContaining(ContainingEventArgs)"/>
         public void OnContaining(ContainingEventArgs ev)
         {
             Log.Info($"{ev.Player?.Nickname} is being contained as SCP-106!");
         }
 
-        /// <inheritdoc cref="Events.Handlers.Scp106.OnCreatingPortal(CreatingPortalEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Scp106.OnCreatingPortal(CreatingPortalEventArgs)"/>
         public void OnCreatingPortal(CreatingPortalEventArgs ev)
         {
             Log.Info($"{ev.Player?.Nickname} is creating a portal as SCP-106, in the position: {ev.Position}");
         }
 
-        /// <inheritdoc cref="Events.Handlers.Scp914.OnActivating(ActivatingEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Scp914.OnActivating(ActivatingEventArgs)"/>
         public void OnActivating(ActivatingEventArgs ev)
         {
             Log.Info($"{ev.Player?.Nickname} is activating SCP-914!");
         }
 
-        /// <inheritdoc cref="Events.Handlers.Player.OnFailingEscapePocketDimension(FailingEscapePocketDimensionEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnFailingEscapePocketDimension(FailingEscapePocketDimensionEventArgs)"/>
         public void OnFailingEscapePocketDimension(FailingEscapePocketDimensionEventArgs ev)
         {
             Log.Info($"{ev.Player?.Nickname} is failing to escape from the pocket dimension!");
         }
 
-        /// <inheritdoc cref="Events.Handlers.Player.OnEscapingPocketDimension(EscapingPocketDimensionEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnEscapingPocketDimension(EscapingPocketDimensionEventArgs)"/>
         public void OnEscapingPocketDimension(EscapingPocketDimensionEventArgs ev)
         {
             Log.Info($"{ev.Player?.Nickname} is escaping from the pocket dimension and will be teleported at {ev.TeleportPosition}");
         }
 
-        /// <inheritdoc cref="Events.Handlers.Scp914.OnChangingKnobSetting(ChangingKnobSettingEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Scp914.OnChangingKnobSetting(ChangingKnobSettingEventArgs)"/>
         public void OnChangingKnobSetting(ChangingKnobSettingEventArgs ev)
         {
             Log.Info($"{ev.Player?.Nickname} is changing the knob setting of SCP-914 to {ev.KnobSetting}");
         }
 
-        /// <inheritdoc cref="Events.Handlers.Player.OnJoined(JoinedEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnJoined(JoinedEventArgs)"/>
         public void OnVerified(VerifiedEventArgs ev)
         {
             if (!Instance.Config.JoinedBroadcast.Show)
@@ -86,10 +88,22 @@ namespace Exiled.Example.Handlers
             ev.Player.Broadcast(Instance.Config.JoinedBroadcast.Duration, Instance.Config.JoinedBroadcast.Content, Instance.Config.JoinedBroadcast.Type);
         }
 
-        /// <inheritdoc cref="Events.Handlers.Player.OnUnlockingGenerator(UnlockingGeneratorEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnUnlockingGenerator(UnlockingGeneratorEventArgs)"/>
         public void OnUnlockingGenerator(UnlockingGeneratorEventArgs ev)
         {
             Log.Info($"{ev.Player?.Nickname} is trying to unlock a generator in {ev.Generator?.CurRoom} room");
+        }
+
+        /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnDestroying(DestroyingEventArgs)"/>
+        public void OnDestroying(DestroyingEventArgs ev)
+        {
+            Log.Info($"{ev.Player.Nickname} ({ev.Player.Role}) is leaving the server!");
+        }
+
+        /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnDying(DyingEventArgs)"/>
+        public void OnDying(DyingEventArgs ev)
+        {
+            Log.Info($"{ev.Target.Nickname} ({ev.Target.Role}) is getting killed by {ev.Killer.Nickname} ({ev.Killer.Role})!");
         }
     }
 }

--- a/Exiled.Example/Events/Scp096Handler.cs
+++ b/Exiled.Example/Events/Scp096Handler.cs
@@ -1,0 +1,24 @@
+// -----------------------------------------------------------------------
+// <copyright file="Scp096Handler.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Example.Events
+{
+    using Exiled.API.Features;
+    using Exiled.Events.EventArgs;
+
+    /// <summary>
+    /// Handles SCP-096 events.
+    /// </summary>
+    internal sealed class Scp096Handler
+    {
+        /// <inheritdoc cref="Exiled.Events.Handlers.Scp096.OnAddingTarget(AddingTargetEventArgs)"/>
+        public void OnAddingTarget(AddingTargetEventArgs ev)
+        {
+            Log.Info($"{ev.Target.Nickname} is being added to {ev.Scp096.Nickname} targets! AHP to add: {ev.AhpToAdd}, Enrage time to add: {ev.EnrageTimeToAdd}");
+        }
+    }
+}

--- a/Exiled.Example/Events/Scp914Handler.cs
+++ b/Exiled.Example/Events/Scp914Handler.cs
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------
+// <copyright file="Scp914Handler.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Example.Events
+{
+    using Exiled.API.Extensions;
+    using Exiled.API.Features;
+    using Exiled.Events.EventArgs;
+
+    /// <summary>
+    /// Handles SCP-914 events.
+    /// </summary>
+    internal sealed class Scp914Handler
+    {
+        /// <inheritdoc cref="Exiled.Events.Handlers.Scp914.OnUpgradingItems(UpgradingItemsEventArgs)"/>
+        public void OnUpgradingItems(UpgradingItemsEventArgs ev)
+        {
+            Log.Info($"Items ({ev.Items.Count}):\n{ev.Items.ToString(false)}\nand players ({ev.Players.Count}):\n{ev.Players.ToString(false)}\nare being processed inside SCP-914, which is set on {ev.KnobSetting}.");
+        }
+    }
+}

--- a/Exiled.Example/Events/ServerHandler.cs
+++ b/Exiled.Example/Events/ServerHandler.cs
@@ -1,11 +1,11 @@
 // -----------------------------------------------------------------------
-// <copyright file="Server.cs" company="Exiled Team">
+// <copyright file="ServerHandler.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Exiled.Example.Handlers
+namespace Exiled.Example.Events
 {
     using Exiled.API.Enums;
     using Exiled.API.Features;
@@ -14,15 +14,15 @@ namespace Exiled.Example.Handlers
     /// <summary>
     /// Handles server-related events.
     /// </summary>
-    internal sealed class Server
+    internal sealed class ServerHandler
     {
-        /// <inheritdoc cref="Events.Handlers.Server.OnWaitingForPlayers"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Server.OnWaitingForPlayers"/>
         public void OnWaitingForPlayers()
         {
             Log.Info("I'm waiting for players!"); // This is an example of information messages sent to your console!
         }
 
-        /// <inheritdoc cref="Events.Handlers.Server.OnEndingRound(EndingRoundEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Server.OnEndingRound(EndingRoundEventArgs)"/>
         public void OnEndingRound(EndingRoundEventArgs ev)
         {
             Log.Debug($"The round is ending, fetching leading team...");

--- a/Exiled.Example/Events/WarheadHandler.cs
+++ b/Exiled.Example/Events/WarheadHandler.cs
@@ -1,11 +1,11 @@
 // -----------------------------------------------------------------------
-// <copyright file="Warhead.cs" company="Exiled Team">
+// <copyright file="WarheadHandler.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Exiled.Example.Handlers
+namespace Exiled.Example.Events
 {
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
@@ -13,15 +13,15 @@ namespace Exiled.Example.Handlers
     /// <summary>
     /// Handles warhead events.
     /// </summary>
-    internal sealed class Warhead
+    internal sealed class WarheadHandler
     {
-        /// <inheritdoc cref="Events.Handlers.Warhead.OnStopping(StoppingEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Warhead.OnStopping(StoppingEventArgs)"/>
         public void OnStopping(StoppingEventArgs ev)
         {
             Log.Info($"{ev.Player?.Nickname} stopped the warhead!");
         }
 
-        /// <inheritdoc cref="Events.Handlers.Warhead.OnStarting(StartingEventArgs)"/>
+        /// <inheritdoc cref="Exiled.Events.Handlers.Warhead.OnStarting(StartingEventArgs)"/>
         public void OnStarting(StartingEventArgs ev)
         {
             Log.Info($"{ev.Player?.Nickname} started the warhead!");

--- a/Exiled.Example/Example.cs
+++ b/Exiled.Example/Example.cs
@@ -7,23 +7,24 @@
 
 namespace Exiled.Example
 {
-    using System;
-
     using Exiled.API.Enums;
     using Exiled.API.Features;
+    using Exiled.Example.Events;
 
     /// <summary>
     /// The example plugin.
     /// </summary>
     public class Example : Plugin<Config>
     {
-        private static Example singleton = new Example();
+        private static readonly Example Singleton = new Example();
 
-        private Handlers.Server server;
-        private Handlers.Player player;
-        private Handlers.Warhead warhead;
-        private Handlers.Map map;
-        private Handlers.Item item;
+        private ServerHandler serverHandler;
+        private PlayerHandler playerHandler;
+        private WarheadHandler warheadHandler;
+        private MapHandler mapHandler;
+        private ItemHandler itemHandler;
+        private Scp914Handler scp914Handler;
+        private Scp096Handler scp096Handler;
 
         private Example()
         {
@@ -32,7 +33,7 @@ namespace Exiled.Example
         /// <summary>
         /// Gets the only existing instance of this plugin.
         /// </summary>
-        public static Example Instance => singleton;
+        public static Example Instance => Singleton;
 
         /// <inheritdoc/>
         public override PluginPriority Priority { get; } = PluginPriority.Last;
@@ -62,37 +63,46 @@ namespace Exiled.Example
         /// </summary>
         private void RegisterEvents()
         {
-            server = new Handlers.Server();
-            player = new Handlers.Player();
-            warhead = new Handlers.Warhead();
-            map = new Handlers.Map();
-            item = new Handlers.Item();
+            serverHandler = new ServerHandler();
+            playerHandler = new PlayerHandler();
+            warheadHandler = new WarheadHandler();
+            mapHandler = new MapHandler();
+            itemHandler = new ItemHandler();
+            scp914Handler = new Scp914Handler();
+            scp096Handler = new Scp096Handler();
 
-            Events.Handlers.Server.WaitingForPlayers += server.OnWaitingForPlayers;
-            Events.Handlers.Server.EndingRound += server.OnEndingRound;
+            Exiled.Events.Handlers.Server.WaitingForPlayers += serverHandler.OnWaitingForPlayers;
+            Exiled.Events.Handlers.Server.EndingRound += serverHandler.OnEndingRound;
 
-            Events.Handlers.Player.Died += player.OnDied;
-            Events.Handlers.Player.ChangingRole += player.OnChangingRole;
-            Events.Handlers.Player.ChangingItem += player.OnChangingItem;
-            Events.Handlers.Player.Verified += player.OnVerified;
-            Events.Handlers.Player.FailingEscapePocketDimension += player.OnFailingEscapePocketDimension;
-            Events.Handlers.Player.EscapingPocketDimension += player.OnEscapingPocketDimension;
-            Events.Handlers.Player.UnlockingGenerator += player.OnUnlockingGenerator;
+            Exiled.Events.Handlers.Player.Destroying += playerHandler.OnDestroying;
+            Exiled.Events.Handlers.Player.Dying += playerHandler.OnDying;
+            Exiled.Events.Handlers.Player.Died += playerHandler.OnDied;
+            Exiled.Events.Handlers.Player.ChangingRole += playerHandler.OnChangingRole;
+            Exiled.Events.Handlers.Player.ChangingItem += playerHandler.OnChangingItem;
+            Exiled.Events.Handlers.Player.Verified += playerHandler.OnVerified;
+            Exiled.Events.Handlers.Player.FailingEscapePocketDimension += playerHandler.OnFailingEscapePocketDimension;
+            Exiled.Events.Handlers.Player.EscapingPocketDimension += playerHandler.OnEscapingPocketDimension;
+            Exiled.Events.Handlers.Player.UnlockingGenerator += playerHandler.OnUnlockingGenerator;
 
-            Events.Handlers.Warhead.Stopping += warhead.OnStopping;
-            Events.Handlers.Warhead.Starting += warhead.OnStarting;
+            Exiled.Events.Handlers.Warhead.Stopping += warheadHandler.OnStopping;
+            Exiled.Events.Handlers.Warhead.Starting += warheadHandler.OnStarting;
 
-            Events.Handlers.Scp106.Teleporting += player.OnTeleporting;
-            Events.Handlers.Scp106.Containing += player.OnContaining;
-            Events.Handlers.Scp106.CreatingPortal += player.OnCreatingPortal;
+            Exiled.Events.Handlers.Scp106.Teleporting += playerHandler.OnTeleporting;
+            Exiled.Events.Handlers.Scp106.Containing += playerHandler.OnContaining;
+            Exiled.Events.Handlers.Scp106.CreatingPortal += playerHandler.OnCreatingPortal;
 
-            Events.Handlers.Scp914.Activating += player.OnActivating;
-            Events.Handlers.Scp914.ChangingKnobSetting += player.OnChangingKnobSetting;
+            Exiled.Events.Handlers.Scp914.Activating += playerHandler.OnActivating;
+            Exiled.Events.Handlers.Scp914.ChangingKnobSetting += playerHandler.OnChangingKnobSetting;
 
-            Events.Handlers.Map.ExplodingGrenade += map.OnExplodingGrenade;
+            Exiled.Events.Handlers.Map.ExplodingGrenade += mapHandler.OnExplodingGrenade;
+            Exiled.Events.Handlers.Map.GeneratorActivated += mapHandler.OnGeneratorActivated;
 
-            Events.Handlers.Item.ChangingDurability += item.OnChangingDurability;
-            Events.Handlers.Item.ChangingAttachments += item.OnChangingAttachments;
+            Exiled.Events.Handlers.Item.ChangingDurability += itemHandler.OnChangingDurability;
+            Exiled.Events.Handlers.Item.ChangingAttachments += itemHandler.OnChangingAttachments;
+
+            Exiled.Events.Handlers.Scp914.UpgradingItems += scp914Handler.OnUpgradingItems;
+
+            Exiled.Events.Handlers.Scp096.AddingTarget += scp096Handler.OnAddingTarget;
         }
 
         /// <summary>
@@ -100,37 +110,46 @@ namespace Exiled.Example
         /// </summary>
         private void UnregisterEvents()
         {
-            Events.Handlers.Server.WaitingForPlayers -= server.OnWaitingForPlayers;
-            Events.Handlers.Server.EndingRound -= server.OnEndingRound;
+            Exiled.Events.Handlers.Server.WaitingForPlayers -= serverHandler.OnWaitingForPlayers;
+            Exiled.Events.Handlers.Server.EndingRound -= serverHandler.OnEndingRound;
 
-            Events.Handlers.Player.Died -= player.OnDied;
-            Events.Handlers.Player.ChangingRole -= player.OnChangingRole;
-            Events.Handlers.Player.ChangingItem -= player.OnChangingItem;
-            Events.Handlers.Player.Verified -= player.OnVerified;
-            Events.Handlers.Player.FailingEscapePocketDimension -= player.OnFailingEscapePocketDimension;
-            Events.Handlers.Player.EscapingPocketDimension -= player.OnEscapingPocketDimension;
-            Events.Handlers.Player.UnlockingGenerator -= player.OnUnlockingGenerator;
+            Exiled.Events.Handlers.Player.Destroying -= playerHandler.OnDestroying;
+            Exiled.Events.Handlers.Player.Dying -= playerHandler.OnDying;
+            Exiled.Events.Handlers.Player.Died -= playerHandler.OnDied;
+            Exiled.Events.Handlers.Player.ChangingRole -= playerHandler.OnChangingRole;
+            Exiled.Events.Handlers.Player.ChangingItem -= playerHandler.OnChangingItem;
+            Exiled.Events.Handlers.Player.Verified -= playerHandler.OnVerified;
+            Exiled.Events.Handlers.Player.FailingEscapePocketDimension -= playerHandler.OnFailingEscapePocketDimension;
+            Exiled.Events.Handlers.Player.EscapingPocketDimension -= playerHandler.OnEscapingPocketDimension;
+            Exiled.Events.Handlers.Player.UnlockingGenerator -= playerHandler.OnUnlockingGenerator;
 
-            Events.Handlers.Warhead.Stopping -= warhead.OnStopping;
-            Events.Handlers.Warhead.Starting -= warhead.OnStarting;
+            Exiled.Events.Handlers.Warhead.Stopping -= warheadHandler.OnStopping;
+            Exiled.Events.Handlers.Warhead.Starting -= warheadHandler.OnStarting;
 
-            Events.Handlers.Scp106.Teleporting -= player.OnTeleporting;
-            Events.Handlers.Scp106.Containing -= player.OnContaining;
-            Events.Handlers.Scp106.CreatingPortal -= player.OnCreatingPortal;
+            Exiled.Events.Handlers.Scp106.Teleporting -= playerHandler.OnTeleporting;
+            Exiled.Events.Handlers.Scp106.Containing -= playerHandler.OnContaining;
+            Exiled.Events.Handlers.Scp106.CreatingPortal -= playerHandler.OnCreatingPortal;
 
-            Events.Handlers.Scp914.Activating -= player.OnActivating;
-            Events.Handlers.Scp914.ChangingKnobSetting -= player.OnChangingKnobSetting;
+            Exiled.Events.Handlers.Scp914.Activating -= playerHandler.OnActivating;
+            Exiled.Events.Handlers.Scp914.ChangingKnobSetting -= playerHandler.OnChangingKnobSetting;
 
-            Events.Handlers.Map.ExplodingGrenade -= map.OnExplodingGrenade;
+            Exiled.Events.Handlers.Map.ExplodingGrenade -= mapHandler.OnExplodingGrenade;
+            Exiled.Events.Handlers.Map.GeneratorActivated -= mapHandler.OnGeneratorActivated;
 
-            Events.Handlers.Item.ChangingDurability -= item.OnChangingDurability;
-            Events.Handlers.Item.ChangingAttachments -= item.OnChangingAttachments;
+            Exiled.Events.Handlers.Item.ChangingDurability -= itemHandler.OnChangingDurability;
+            Exiled.Events.Handlers.Item.ChangingAttachments -= itemHandler.OnChangingAttachments;
 
-            server = null;
-            player = null;
-            warhead = null;
-            map = null;
-            item = null;
+            Exiled.Events.Handlers.Scp914.UpgradingItems -= scp914Handler.OnUpgradingItems;
+
+            Exiled.Events.Handlers.Scp096.AddingTarget -= scp096Handler.OnAddingTarget;
+
+            serverHandler = null;
+            playerHandler = null;
+            warheadHandler = null;
+            mapHandler = null;
+            itemHandler = null;
+            scp914Handler = null;
+            scp096Handler = null;
         }
     }
 }


### PR DESCRIPTION
`[Exiled.Events]`
+ Changed OnAddingTarget, OnUpgradingItems and OnGeneratorActivated into transpilers.
+ Some clean up.
+ Marked SendingConsoleCommandEventArgs::Allow as obsolete.
+ Added GeneratorActivatedEventArgs::IsAllowed.

`[Exiled.Example]`
+ Renamed Handlers folder into Events and its classes.
+ Added some events.