### PR TITLE
Fix for SCP-096 being able to enter 'pre-windup' with no targets.

### DIFF
--- a/Exiled.Events/Patches/Fixes/Scp096FailEnrageFix.cs
+++ b/Exiled.Events/Patches/Fixes/Scp096FailEnrageFix.cs
@@ -31,7 +31,7 @@ namespace Exiled.Events.Patches.Fixes
         /// <returns>New <see cref="CodeInstruction"/>.</returns>
         internal static IEnumerable<CodeInstruction> FixInstructions(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
-            List<CodeInstruction> newInstructions = new List<CodeInstruction>(instructions);
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
 
             const int offset = 1;
 
@@ -50,7 +50,8 @@ namespace Exiled.Events.Patches.Fixes
 
             newInstructions[newInstructions.Count - 1].WithLabels(returnLabel);
 
-            return newInstructions;
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
         }
     }
 
@@ -60,15 +61,7 @@ namespace Exiled.Events.Patches.Fixes
     [HarmonyPatch(typeof(Scp096), nameof(Scp096.PreWindup))]
     internal static class Scp096FailEnrageFix
     {
-        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
-        {
-            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(InstructionBuilder.FixInstructions(instructions, generator));
-
-            for (int z = 0; z < newInstructions.Count; z++)
-                yield return newInstructions[z];
-
-            ListPool<CodeInstruction>.Shared.Return(newInstructions);
-        }
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator) => InstructionBuilder.FixInstructions(instructions, generator);
     }
 
     /// <summary>
@@ -77,14 +70,6 @@ namespace Exiled.Events.Patches.Fixes
     [HarmonyPatch(typeof(Scp096), nameof(Scp096.Windup))]
     internal static class Scp096WindupFix
     {
-        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
-        {
-            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(InstructionBuilder.FixInstructions(instructions, generator));
-
-            for (int z = 0; z < newInstructions.Count; z++)
-                yield return newInstructions[z];
-
-            ListPool<CodeInstruction>.Shared.Return(newInstructions);
-        }
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator) => InstructionBuilder.FixInstructions(instructions, generator);
     }
 }

--- a/Exiled.Events/Patches/Fixes/Scp096FailEnrageFix.cs
+++ b/Exiled.Events/Patches/Fixes/Scp096FailEnrageFix.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Fixes
 {
 #pragma warning disable SA1118
 #pragma warning disable SA1402
+#pragma warning disable SA1649
     using System.Collections.Generic;
     using System.Reflection.Emit;
     using HarmonyLib;
@@ -18,14 +19,19 @@ namespace Exiled.Events.Patches.Fixes
     using static HarmonyLib.AccessTools;
 
     /// <summary>
-    /// patches <see cref="Scp096.PreWindup"/>.
+    /// Handles building new instructions.
     /// </summary>
-    [HarmonyPatch(typeof(Scp096), nameof(Scp096.PreWindup))]
-    internal static class Scp096FailEnrageFix
+    internal static class InstructionBuilder
     {
-        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        /// <summary>
+        /// Builds new instructions for enrage fix transpilers.
+        /// </summary>
+        /// <param name="instructions"><see cref="CodeInstruction"/>.</param>
+        /// <param name="generator"><see cref="ILGenerator"/>.</param>
+        /// <returns>New <see cref="CodeInstruction"/>.</returns>
+        internal static IEnumerable<CodeInstruction> FixInstructions(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
-            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+            List<CodeInstruction> newInstructions = new List<CodeInstruction>(instructions);
 
             const int offset = 1;
 
@@ -43,6 +49,20 @@ namespace Exiled.Events.Patches.Fixes
             });
 
             newInstructions[newInstructions.Count - 1].WithLabels(returnLabel);
+
+            return newInstructions;
+        }
+    }
+
+    /// <summary>
+    /// patches <see cref="Scp096.PreWindup"/>.
+    /// </summary>
+    [HarmonyPatch(typeof(Scp096), nameof(Scp096.PreWindup))]
+    internal static class Scp096FailEnrageFix
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(InstructionBuilder.FixInstructions(instructions, generator));
 
             for (int z = 0; z < newInstructions.Count; z++)
                 yield return newInstructions[z];
@@ -59,24 +79,7 @@ namespace Exiled.Events.Patches.Fixes
     {
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
-            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
-
-            const int offset = 1;
-
-            // Find the only "throw" call
-            int index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Throw) + offset;
-
-            Label returnLabel = generator.DefineLabel();
-
-            newInstructions.InsertRange(index, new[]
-            {
-                new CodeInstruction(OpCodes.Ldarg_0).MoveLabelsFrom(newInstructions[index]),
-                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Scp096), nameof(Scp096._targets))),
-                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(HashSet<ReferenceHub>), nameof(HashSet<ReferenceHub>.Count))),
-                new CodeInstruction(OpCodes.Brfalse_S, returnLabel),
-            });
-
-            newInstructions[newInstructions.Count - 1].WithLabels(returnLabel);
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(InstructionBuilder.FixInstructions(instructions, generator));
 
             for (int z = 0; z < newInstructions.Count; z++)
                 yield return newInstructions[z];

--- a/Exiled.Events/Patches/Fixes/Scp096FailEnrageFix.cs
+++ b/Exiled.Events/Patches/Fixes/Scp096FailEnrageFix.cs
@@ -52,6 +52,8 @@ namespace Exiled.Events.Patches.Fixes
 
             for (int z = 0; z < newInstructions.Count; z++)
                 yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
         }
     }
 

--- a/Exiled.Events/Patches/Fixes/Scp096FailEnrageFix.cs
+++ b/Exiled.Events/Patches/Fixes/Scp096FailEnrageFix.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-// <copyright file="Scp096PreWindupFix.cs" company="Exiled Team">
+// <copyright file="Scp096FailEnrageFix.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>
@@ -21,7 +21,7 @@ namespace Exiled.Events.Patches.Fixes
     /// patches <see cref="Scp096.PreWindup"/>.
     /// </summary>
     [HarmonyPatch(typeof(Scp096), nameof(Scp096.PreWindup))]
-    internal static class Scp096PreWindupFix
+    internal static class Scp096FailEnrageFix
     {
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {

--- a/Exiled.Events/Patches/Fixes/Scp096PreWindupFix.cs
+++ b/Exiled.Events/Patches/Fixes/Scp096PreWindupFix.cs
@@ -59,7 +59,7 @@ namespace Exiled.Events.Patches.Fixes
     {
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
-            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent();
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
 
             const int offset = 1;
 

--- a/Exiled.Events/Patches/Fixes/Scp096PreWindupFix.cs
+++ b/Exiled.Events/Patches/Fixes/Scp096PreWindupFix.cs
@@ -1,0 +1,51 @@
+// -----------------------------------------------------------------------
+// <copyright file="Scp096PreWindupFix.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Fixes
+{
+#pragma warning disable SA1118
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
+    using HarmonyLib;
+    using NorthwoodLib.Pools;
+    using PlayableScps;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    /// patches <see cref="Scp096.PreWindup"/>.
+    /// </summary>
+    [HarmonyPatch(typeof(Scp096), nameof(Scp096.PreWindup))]
+    internal static class Scp096PreWindupFix
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            const int offset = 1;
+
+            // Find the only "throw" call
+            int index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Throw) + offset;
+
+            Label returnLabel = generator.DefineLabel();
+
+            newInstructions.InsertRange(index, new[]
+            {
+                new CodeInstruction(OpCodes.Ldarg_0).MoveLabelsFrom(newInstructions[index]),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Scp096), nameof(Scp096._targets))),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(HashSet<ReferenceHub>), nameof(HashSet<ReferenceHub>.Count))),
+                new CodeInstruction(OpCodes.Brfalse_S, returnLabel),
+                new CodeInstruction(OpCodes.Ret).WithLabels(returnLabel),
+            });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Fixes/Scp096PreWindupFix.cs
+++ b/Exiled.Events/Patches/Fixes/Scp096PreWindupFix.cs
@@ -39,8 +39,43 @@ namespace Exiled.Events.Patches.Fixes
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(Scp096), nameof(Scp096._targets))),
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(HashSet<ReferenceHub>), nameof(HashSet<ReferenceHub>.Count))),
                 new CodeInstruction(OpCodes.Brfalse_S, returnLabel),
-                new CodeInstruction(OpCodes.Ret).WithLabels(returnLabel),
             });
+
+            newInstructions[newInstructions.Count - 1].WithLabels(returnLabel);
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+
+    /// <summary>
+    /// Patches <see cref="Scp096.Windup"/>.
+    /// </summary>
+    [HarmonyPatch(typeof(Scp096), nameof(Scp096.Windup))]
+    internal static class Scp096WindupFix
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent();
+
+            const int offset = 1;
+
+            // Find the only "throw" call
+            int index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Throw) + offset;
+
+            Label returnLabel = generator.DefineLabel();
+
+            newInstructions.InsertRange(index, new[]
+            {
+                new CodeInstruction(OpCodes.Ldarg_0).MoveLabelsFrom(newInstructions[index]),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Scp096), nameof(Scp096._targets))),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(HashSet<ReferenceHub>), nameof(HashSet<ReferenceHub>.Count))),
+                new CodeInstruction(OpCodes.Brfalse_S, returnLabel),
+            });
+
+            newInstructions[newInstructions.Count - 1].WithLabels(returnLabel);
 
             for (int z = 0; z < newInstructions.Count; z++)
                 yield return newInstructions[z];

--- a/Exiled.Events/Patches/Fixes/Scp096PreWindupFix.cs
+++ b/Exiled.Events/Patches/Fixes/Scp096PreWindupFix.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Patches.Fixes
 {
 #pragma warning disable SA1118
+#pragma warning disable SA1402
     using System.Collections.Generic;
     using System.Reflection.Emit;
     using HarmonyLib;


### PR DESCRIPTION
When a target is being added, if ev.IsAllowed is set to false in Scp096.AddingTarget event, and there are no other targets, SCP-096 will still enter the 'pre-windup' enraging animation, even if their targets list is empty.

This patch prevents that behavior, returning the function if _targets HashSet is empty.