### PR TITLE
Allows NW to be aware of custom items that may impact gameplay

### DIFF
--- a/Exiled.API/Extensions/MirrorExtensions.cs
+++ b/Exiled.API/Extensions/MirrorExtensions.cs
@@ -128,7 +128,7 @@ namespace Exiled.API.Extensions
         /// <param name="player">Only this player can see info.</param>
         /// <param name="target">Target to set info.</param>
         /// <param name="info">Setting info.</param>
-        public static void SetPlayerInfoForTargetOnly(this Player player, Player target, string info) => SendFakeSyncVar(player, target.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_customPlayerInfoString), info);
+        public static void SetPlayerInfoForTargetOnly(this Player player, Player target, string info) => player.SendFakeSyncVar(target.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_customPlayerInfoString), info);
 
         /// <summary>
         /// Change <see cref="Player"/> character model for appearance.
@@ -160,7 +160,7 @@ namespace Exiled.API.Extensions
         /// <param name="targetType"><see cref="Mirror.NetworkBehaviour"/>'s type.</param>
         /// <param name="propertyName">Property name starting with Network.</param>
         /// <param name="value">Value of send to target.</param>
-        public static void SendFakeSyncVar(Player target, NetworkIdentity behaviorOwner, Type targetType, string propertyName, object value)
+        public static void SendFakeSyncVar(this Player target, NetworkIdentity behaviorOwner, Type targetType, string propertyName, object value)
         {
             Action<NetworkWriter> customSyncVarGenerator = (targetWriter) =>
             {

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -92,6 +92,11 @@ namespace Exiled.CustomItems.API.Features
         public HashSet<Pickup> Spawned { get; } = new HashSet<Pickup>();
 
         /// <summary>
+        /// Gets a value indicating whether whether or not this item causes things to happen that may be considered hacks, and thus be shown to global moderators as being present in a player's inventory when they gban them.
+        /// </summary>
+        public bool ShouldMessageOnGban { get; } = false;
+
+        /// <summary>
         /// Gets a <see cref="CustomItem"/> with a specific ID.
         /// </summary>
         /// <param name="id">The <see cref="CustomItem"/> ID.</param>
@@ -594,6 +599,8 @@ namespace Exiled.CustomItems.API.Features
                 ev.Player.RemoveItem(item);
 
                 Spawn(ev.Player, item);
+
+                Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }
         }
 
@@ -614,6 +621,8 @@ namespace Exiled.CustomItems.API.Features
                 InsideInventories.Remove(item.uniq);
 
                 Spawn(ev.Target, item);
+
+                Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Target.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }
         }
 
@@ -634,6 +643,8 @@ namespace Exiled.CustomItems.API.Features
                 InsideInventories.Remove(item.uniq);
 
                 Spawn(ev.NewRole.GetRandomSpawnPoint(), item);
+
+                Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }
         }
 

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -715,8 +715,14 @@ namespace Exiled.CustomItems.API.Features
                 return;
             }
 
-            foreach (Player player in Player.Get(RoleType.Spectator))
-                player.SendFakeSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync), $"{ev.Player.Nickname} (CustomItem: {Name})");
+            if (ShouldMessageOnGban)
+            {
+                foreach (Player player in Player.Get(RoleType.Spectator))
+                {
+                    player.SendFakeSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync), $"{ev.Player.Nickname} (CustomItem: {Name})");
+                }
+            }
+
             OnChanging(ev);
         }
 

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -94,6 +94,7 @@ namespace Exiled.CustomItems.API.Features
         /// <summary>
         /// Gets a value indicating whether whether or not this item causes things to happen that may be considered hacks, and thus be shown to global moderators as being present in a player's inventory when they gban them.
         /// </summary>
+        [YamlIgnore]
         public bool ShouldMessageOnGban { get; } = false;
 
         /// <summary>

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -710,8 +710,13 @@ namespace Exiled.CustomItems.API.Features
         private void OnInternalChanging(ChangingItemEventArgs ev)
         {
             if (!Check(ev.NewItem))
+            {
+                Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
                 return;
+            }
 
+            foreach (Player player in Player.Get(RoleType.Spectator))
+                player.SendFakeSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync), $"{ev.Player.Nickname} (CustomItem: {Name})");
             OnChanging(ev);
         }
 

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -95,7 +95,7 @@ namespace Exiled.CustomItems.API.Features
         /// Gets a value indicating whether whether or not this item causes things to happen that may be considered hacks, and thus be shown to global moderators as being present in a player's inventory when they gban them.
         /// </summary>
         [YamlIgnore]
-        public bool ShouldMessageOnGban { get; } = false;
+        public virtual bool ShouldMessageOnGban { get; } = false;
 
         /// <summary>
         /// Gets a <see cref="CustomItem"/> with a specific ID.

--- a/Exiled.CustomItems/Commands/List/InsideInventories.cs
+++ b/Exiled.CustomItems/Commands/List/InsideInventories.cs
@@ -19,6 +19,8 @@ namespace Exiled.CustomItems.Commands.List
 
     using NorthwoodLib.Pools;
 
+    using RemoteAdmin;
+
     /// <inheritdoc/>
     internal sealed class InsideInventories : ICommand
     {
@@ -43,7 +45,7 @@ namespace Exiled.CustomItems.Commands.List
         /// <inheritdoc/>
         public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
         {
-            if (!sender.CheckPermission("customitems.list.insideinventories"))
+            if (!sender.CheckPermission("customitems.list.insideinventories") && (sender is PlayerCommandSender playerSender && !playerSender.QueryProcessor.Roles.RaEverywhere))
             {
                 response = "Permission Denied, required: customitems.list.insideinventories";
                 return false;

--- a/Exiled.CustomItems/Events/PlayerHandler.cs
+++ b/Exiled.CustomItems/Events/PlayerHandler.cs
@@ -20,36 +20,28 @@ namespace Exiled.CustomItems
         /// <inheritdoc cref="ChangingRoleEventArgs"/>
         public void OnChangingRole(ChangingRoleEventArgs ev)
         {
-            switch (ev.NewRole == RoleType.Spectator)
+            if (ev.NewRole == RoleType.Spectator)
             {
-                case true:
+                foreach (Player player in Player.List)
                 {
-                    foreach (Player player in Player.List)
+                    if (player == ev.Player)
+                        continue;
+
+                    if (CustomItem.TryGet(player, out CustomItem item))
                     {
-                        if (player == ev.Player)
-                            continue;
-
-                        if (CustomItem.TryGet(player, out CustomItem item))
-                        {
-                            if (item.ShouldMessageOnGban)
-                                ev.Player.SendFakeSyncVar(player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync), $"{ev.Player.Nickname} (CustomItem: {item.Name})");
-                        }
+                        if (item.ShouldMessageOnGban)
+                            ev.Player.SendFakeSyncVar(player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync), $"{ev.Player.Nickname} (CustomItem: {item.Name})");
                     }
-
-                    break;
                 }
-
-                case false:
+            }
+            else
+            {
+                foreach (Player player in Player.List)
                 {
-                    foreach (Player player in Player.List)
-                    {
-                        if (player == ev.Player)
-                            continue;
+                    if (player == ev.Player)
+                        continue;
 
-                        ev.Player.SendFakeSyncVar(player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync), player.Nickname);
-                    }
-
-                    break;
+                    ev.Player.SendFakeSyncVar(player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync), player.Nickname);
                 }
             }
         }

--- a/Exiled.CustomItems/Events/PlayerHandler.cs
+++ b/Exiled.CustomItems/Events/PlayerHandler.cs
@@ -17,6 +17,7 @@ namespace Exiled.CustomItems
     /// </summary>
     internal sealed class PlayerHandler
     {
+        /// <inheritdoc cref="ChangingRoleEventArgs"/>
         public void OnChangingRole(ChangingRoleEventArgs ev)
         {
             switch (ev.NewRole == RoleType.Spectator)
@@ -30,7 +31,8 @@ namespace Exiled.CustomItems
 
                         if (CustomItem.TryGet(player, out CustomItem item))
                         {
-                            ev.Player.SendFakeSyncVar(player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync), $"{ev.Player.Nickname} (CustomItem: {item.Name})");
+                            if (item.ShouldMessageOnGban)
+                                ev.Player.SendFakeSyncVar(player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync), $"{ev.Player.Nickname} (CustomItem: {item.Name})");
                         }
                     }
 

--- a/Exiled.CustomItems/Events/PlayerHandler.cs
+++ b/Exiled.CustomItems/Events/PlayerHandler.cs
@@ -1,0 +1,55 @@
+// -----------------------------------------------------------------------
+// <copyright file="PlayerHandler.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.CustomItems
+{
+    using Exiled.API.Extensions;
+    using Exiled.API.Features;
+    using Exiled.CustomItems.API.Features;
+    using Exiled.Events.EventArgs;
+
+    /// <summary>
+    /// Handles Player events for the CustomItem API.
+    /// </summary>
+    internal sealed class PlayerHandler
+    {
+        public void OnChangingRole(ChangingRoleEventArgs ev)
+        {
+            switch (ev.NewRole == RoleType.Spectator)
+            {
+                case true:
+                {
+                    foreach (Player player in Player.List)
+                    {
+                        if (player == ev.Player)
+                            continue;
+
+                        if (CustomItem.TryGet(player, out CustomItem item))
+                        {
+                            ev.Player.SendFakeSyncVar(player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync), $"{ev.Player.Nickname} (CustomItem: {item.Name})");
+                        }
+                    }
+
+                    break;
+                }
+
+                case false:
+                {
+                    foreach (Player player in Player.List)
+                    {
+                        if (player == ev.Player)
+                            continue;
+
+                        ev.Player.SendFakeSyncVar(player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync), player.Nickname);
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Exiled.CustomItems/Events/ServerHandler.cs
+++ b/Exiled.CustomItems/Events/ServerHandler.cs
@@ -38,7 +38,7 @@ namespace Exiled.CustomItems
                     {
                         if (item.ShouldMessageOnGban)
                         {
-                            builder.AppendLine(item.Name + " - " + item.Description);
+                            builder.Append(item.Name).Append(" - ").Append(item.Description).AppendLine();
                         }
                     }
 

--- a/Exiled.CustomItems/Events/ServerHandler.cs
+++ b/Exiled.CustomItems/Events/ServerHandler.cs
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServerHandler.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.CustomItems
+{
+    using System.Collections.Generic;
+    using System.Text;
+
+    using Exiled.API.Features;
+    using Exiled.CustomItems.API.Features;
+    using Exiled.Events.EventArgs;
+
+    using NorthwoodLib.Pools;
+
+    /// <summary>
+    /// Handles Server events for the CustomItems API.
+    /// </summary>
+    internal sealed class ServerHandler
+    {
+        /// <inheritdoc cref="Events.Handlers.Server.OnSendingRemoteAdminCommand"/>
+        public void OnRemoteAdminCommand(SendingRemoteAdminCommandEventArgs ev)
+        {
+            if (ev.Name.ToLower() == "gban-kick" && ev.Sender.ReferenceHub.queryProcessor._sender.ServerRoles.RaEverywhere)
+            {
+                Player player = Player.Get(string.Join(" ", ev.Arguments));
+                if (player == null)
+                    return;
+
+                if (CustomItem.TryGet(player, out IEnumerable<CustomItem> customItems))
+                {
+                    StringBuilder builder = StringBuilderPool.Shared.Rent();
+
+                    foreach (CustomItem item in customItems)
+                    {
+                        if (item.ShouldMessageOnGban)
+                        {
+                            builder.AppendLine(item.Name + " - " + item.Description);
+                        }
+                    }
+
+                    string itemNames = StringBuilderPool.Shared.ToStringReturn(builder);
+
+                    if (!string.IsNullOrEmpty(itemNames))
+                    {
+                        ev.Sender.SendConsoleMessage(
+                            $"{player.Nickname} has been globally banned while in possession of the following items: {itemNames}\n" +
+                            "Note: The creator(s) of these items have specifically flagged these items as doing something that may cause suspicion of hacking.",
+                            "red");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Exiled.CustomItems/Events/ServerHandler.cs
+++ b/Exiled.CustomItems/Events/ServerHandler.cs
@@ -26,31 +26,30 @@ namespace Exiled.CustomItems
         {
             if (ev.Name.ToLower() == "gban-kick" && ev.Sender.ReferenceHub.queryProcessor._sender.ServerRoles.RaEverywhere)
             {
-                Player player = Player.Get(string.Join(" ", ev.Arguments));
-                if (player == null)
+                if (!(Player.Get(string.Join(" ", ev.Arguments)) is Player player))
                     return;
 
-                if (CustomItem.TryGet(player, out IEnumerable<CustomItem> customItems))
+                if (!CustomItem.TryGet(player, out IEnumerable<CustomItem> customItems))
+                    return;
+
+                StringBuilder builder = StringBuilderPool.Shared.Rent();
+
+                foreach (CustomItem item in customItems)
                 {
-                    StringBuilder builder = StringBuilderPool.Shared.Rent();
-
-                    foreach (CustomItem item in customItems)
+                    if (item.ShouldMessageOnGban)
                     {
-                        if (item.ShouldMessageOnGban)
-                        {
-                            builder.Append(item.Name).Append(" - ").Append(item.Description).AppendLine();
-                        }
+                        builder.Append(item.Name).Append(" - ").Append(item.Description).AppendLine();
                     }
+                }
 
-                    string itemNames = StringBuilderPool.Shared.ToStringReturn(builder);
+                string itemNames = StringBuilderPool.Shared.ToStringReturn(builder);
 
-                    if (!string.IsNullOrEmpty(itemNames))
-                    {
-                        ev.Sender.SendConsoleMessage(
-                            $"{player.Nickname} has been globally banned while in possession of the following items: {itemNames}\n" +
-                            "Note: The creator(s) of these items have specifically flagged these items as doing something that may cause suspicion of hacking.",
-                            "red");
-                    }
+                if (!string.IsNullOrEmpty(itemNames))
+                {
+                    ev.Sender.SendConsoleMessage(
+                        $"{player.Nickname} has been globally banned while in possession of the following items: {itemNames}\n" +
+                        "Note: The creator(s) of these items have specifically flagged these items as doing something that may cause suspicion of hacking.",
+                        "red");
                 }
             }
         }


### PR DESCRIPTION
Currently, there are no items implemented in the Exiled-Team CustomItems that is not obviously a custom item and not a hack of some kind. (With the possible exception of shotgun, but it creates impact decals for every round it shoots, so it should be easy enough to see it's shooting multiple bullets at a time not some kinda damage hack)

A recent PR into CustomItems features a gun that is essentially server-side aimbot. 
This has raised a concerning thought: How would Northwood be able to determine the difference between someone using this item to kill a room full of people quickly, vs someone using an aimbot hack?

This PR is the answer to that question.

1. Players with a CustomItem in their hand will have their nickname changed to include the item's name, but only visible to spectators, as to not ruin immersion/etc to active players in the game.
2. Gives gmods access to the ``ci list ii {player}`` command, allowing them to see what custom item(s) the player has in their inventory, without needing local plugin permissions set.
3. When a gmod gbans someone, they will be sent a message to their console stating that they banned a player with a potentially 'suspicious' item, and that they should re-review their ban proof footage to determine if the ban may have been given to an innocent player using a custom item.

While 2 is always active, 1 & 3 will only function if CustomItem.ShouldMessageOnGban is true.
This is a public get-only bool, that defaults to false, and must be specifically set to true by the creator of the item. This is to ensure that gmods are not constantly spammed with item names that are not needed to be known (stuff like Letal Injection, SCP-1499, EMP grenades, etc) when they use the gban command, and so that only sensitive items will overwrite the player's nickname to spectators.