### PR TITLE
Sorting config keys alphabetically instead

### DIFF
--- a/Exiled.Loader/ConfigManager.cs
+++ b/Exiled.Loader/ConfigManager.cs
@@ -52,16 +52,14 @@ namespace Exiled.Loader
         /// </summary>
         /// <param name="rawConfigs">The raw configs to be loaded.</param>
         /// <returns>Returns a dictionary of loaded configs.</returns>
-        public static Dictionary<string, IConfig> Load(string rawConfigs)
+        public static SortedDictionary<string, IConfig> Load(string rawConfigs)
         {
             try
             {
                 Log.Info("Loading plugin configs...");
 
-                rawConfigs = Regex.Replace(rawConfigs, @"\ !.*", string.Empty).Replace("!Dictionary[string,IConfig]", string.Empty);
-
                 Dictionary<string, object> rawDeserializedConfigs = Deserializer.Deserialize<Dictionary<string, object>>(rawConfigs) ?? new Dictionary<string, object>();
-                Dictionary<string, IConfig> deserializedConfigs = new Dictionary<string, IConfig>();
+                SortedDictionary<string, IConfig> deserializedConfigs = new SortedDictionary<string, IConfig>(StringComparer.Ordinal);
 
                 if (!rawDeserializedConfigs.TryGetValue("exiled_loader", out object rawDeserializedConfig))
                 {
@@ -145,7 +143,7 @@ namespace Exiled.Loader
         /// </summary>
         /// <param name="configs">The configs to be saved.</param>
         /// <returns>Returns a value indicating whether the configs have been saved successfully or not.</returns>
-        public static bool Save(Dictionary<string, IConfig> configs)
+        public static bool Save(SortedDictionary<string, IConfig> configs)
         {
             try
             {

--- a/Exiled.Loader/ConfigManager.cs
+++ b/Exiled.Loader/ConfigManager.cs
@@ -10,7 +10,6 @@ namespace Exiled.Loader
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Text.RegularExpressions;
 
     using Exiled.API.Extensions;
     using Exiled.API.Features;
@@ -47,12 +46,16 @@ namespace Exiled.Loader
             .IgnoreUnmatchedProperties()
             .Build();
 
+        /// <inheritdoc cref="LoadSorted(string)"/>
+        [Obsolete("Replaced with LoadSorted(string)", true)]
+        public static Dictionary<string, IConfig> Load(string rawConfigs) => new Dictionary<string, IConfig>(LoadSorted(rawConfigs));
+
         /// <summary>
         /// Loads all plugin configs.
         /// </summary>
         /// <param name="rawConfigs">The raw configs to be loaded.</param>
         /// <returns>Returns a dictionary of loaded configs.</returns>
-        public static SortedDictionary<string, IConfig> Load(string rawConfigs)
+        public static SortedDictionary<string, IConfig> LoadSorted(string rawConfigs)
         {
             try
             {
@@ -115,7 +118,7 @@ namespace Exiled.Loader
         /// Reads, Loads and Saves plugin configs.
         /// </summary>
         /// <returns>Returns a value indicating if the reloading process has been completed successfully or not.</returns>
-        public static bool Reload() => Save(Load(Read()));
+        public static bool Reload() => Save(LoadSorted(Read()));
 
         /// <summary>
         /// Saves plugin configs.
@@ -137,6 +140,10 @@ namespace Exiled.Loader
                 return false;
             }
         }
+
+        /// <inheritdoc cref="Save(SortedDictionary{string, IConfig})"/>
+        [Obsolete("Replaced with Save(SortedDictionary{string, IConfig})", true)]
+        public static bool Save(Dictionary<string, IConfig> configs) => Save(new SortedDictionary<string, IConfig>(configs));
 
         /// <summary>
         /// Saves plugin configs.


### PR DESCRIPTION
So I removed the call to `Regex::Replace` because it was too old and nobody has anything like that. Apparently it'd break plugins using those methods because they now return `SortedDictionary` type, but that's their issue, right?