### PR TITLE
Move RoleType.GetRandomSpawnPoint extension to Extensions.Role

### DIFF
--- a/Exiled.API/Extensions/Role.cs
+++ b/Exiled.API/Extensions/Role.cs
@@ -92,5 +92,17 @@ namespace Exiled.API.Extensions
                     return Team.RIP;
             }
         }
+
+        /// <summary>
+        /// Gets a random spawn point of a <see cref="RoleType"/>.
+        /// </summary>
+        /// <param name="roleType">The <see cref="RoleType"/> to get the spawn point from.</param>
+        /// <returns>Returns the spawn point <see cref="Vector3"/>.</returns>
+        public static Vector3 GetRandomSpawnPoint(this RoleType roleType)
+        {
+            GameObject randomPosition = CharacterClassManager._spawnpointManager.GetRandomPosition(roleType);
+
+            return randomPosition == null ? Vector3.zero : randomPosition.transform.position;
+        }
     }
 }

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -401,7 +401,7 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="roleType">The <see cref="RoleType"/> to get the spawn point from.</param>
         /// <returns>Returns the spawn point <see cref="Vector3"/>.</returns>
-        [Obsolete("Moved to Exiled.API.Extensions.Role.")]
+        [Obsolete("Moved to Exiled.API.Extensions.Role.GetRandomSpawnPoint(RoleType).")]
         public static Vector3 GetRandomSpawnPoint(this RoleType roleType)
         {
             return Extensions.Role.GetRandomSpawnPoint(roleType);

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -397,6 +397,17 @@ namespace Exiled.API.Features
         public static void ClearBroadcasts() => Server.Broadcast.RpcClearElements();
 
         /// <summary>
+        /// Gets a random spawn point of a <see cref="RoleType"/>.
+        /// </summary>
+        /// <param name="roleType">The <see cref="RoleType"/> to get the spawn point from.</param>
+        /// <returns>Returns the spawn point <see cref="Vector3"/>.</returns>
+        [Obsolete("Moved to Exiled.API.Extensions.Role.")]
+        public static Vector3 GetRandomSpawnPoint(this RoleType roleType)
+        {
+            return Extensions.Role.GetRandomSpawnPoint(roleType);
+        }
+
+        /// <summary>
         /// Starts the light containment zone decontamination process.
         /// </summary>
         public static void StartDecontamination()

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -401,7 +401,7 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="roleType">The <see cref="RoleType"/> to get the spawn point from.</param>
         /// <returns>Returns the spawn point <see cref="Vector3"/>.</returns>
-        [Obsolete("Moved to Exiled.API.Extensions.Role.GetRandomSpawnPoint(RoleType).")]
+        [Obsolete("Moved to Exiled.API.Extensions.Role.GetRandomSpawnPoint(RoleType).", true)]
         public static Vector3 GetRandomSpawnPoint(this RoleType roleType)
         {
             return Extensions.Role.GetRandomSpawnPoint(roleType);

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -397,17 +397,6 @@ namespace Exiled.API.Features
         public static void ClearBroadcasts() => Server.Broadcast.RpcClearElements();
 
         /// <summary>
-        /// Gets a random spawn point of a <see cref="RoleType"/>.
-        /// </summary>
-        /// <param name="roleType">The <see cref="RoleType"/> to get the spawn point from.</param>
-        /// <returns>Returns the spawn point <see cref="Vector3"/>.</returns>
-        [Obsolete("Moved to Exiled.API.Extensions.Role.")]
-        public static Vector3 GetRandomSpawnPoint(this RoleType roleType)
-        {
-            return Extensions.Role.GetRandomSpawnPoint(roleType);
-        }
-
-        /// <summary>
         /// Starts the light containment zone decontamination process.
         /// </summary>
         public static void StartDecontamination()

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -401,11 +401,10 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="roleType">The <see cref="RoleType"/> to get the spawn point from.</param>
         /// <returns>Returns the spawn point <see cref="Vector3"/>.</returns>
+        [Obsolete("Moved to Exiled.API.Extensions.Role.")]
         public static Vector3 GetRandomSpawnPoint(this RoleType roleType)
         {
-            GameObject randomPosition = CharacterClassManager._spawnpointManager.GetRandomPosition(roleType);
-
-            return randomPosition == null ? Vector3.zero : randomPosition.transform.position;
+            return Extensions.Role.GetRandomSpawnPoint(roleType);
         }
 
         /// <summary>

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -646,7 +646,7 @@ namespace Exiled.CustomItems.API.Features
 
                 InsideInventories.Remove(item.uniq);
 
-                Spawn(ev.NewRole.GetRandomSpawnPoint(), item);
+                Spawn(Role.GetRandomSpawnPoint(ev.NewRole), item);
 
                 Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }


### PR DESCRIPTION
I feel like RoleType.GetRandomSpawnPoint is misplaced with Extensions.Role existing and it took me a minute to find that it was actually in Features.Map. I believe it makes more sense to place it in Extensions.Role.