### PR TITLE
CI.Spawn Pickup

### DIFF
--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -468,7 +468,7 @@ namespace Exiled.CustomItems.API.Features
 
                 spawned++;
 
-                Spawn(spawnPoint.Position.ToVector3);
+                Spawn(spawnPoint.Position.ToVector3, out Pickup pickup);
 
                 Log.Debug($"Spawned {Name} at {spawnPoint.Position} ({spawnPoint.Name})", Instance.Config.Debug);
             }
@@ -697,7 +697,7 @@ namespace Exiled.CustomItems.API.Features
 
                 ev.Player.RemoveItem(item);
 
-                Spawn(ev.Player, item);
+                Spawn(ev.Player, item, out Pickup pickup);
 
                 Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }
@@ -719,7 +719,7 @@ namespace Exiled.CustomItems.API.Features
 
                 InsideInventories.Remove(item.uniq);
 
-                Spawn(ev.Target, item);
+                Spawn(ev.Target, item, out Pickup pickup);
 
                 Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Target.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }
@@ -741,7 +741,7 @@ namespace Exiled.CustomItems.API.Features
 
                 InsideInventories.Remove(item.uniq);
 
-                Spawn(Role.GetRandomSpawnPoint(ev.NewRole), item);
+                Spawn(Role.GetRandomSpawnPoint(ev.NewRole), item, out Pickup pickup);
 
                 Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }
@@ -763,7 +763,7 @@ namespace Exiled.CustomItems.API.Features
 
                 InsideInventories.Remove(item.uniq);
 
-                Spawn(ev.Target, item);
+                Spawn(ev.Target, item, out Pickup pickup);
             }
         }
 
@@ -783,7 +783,7 @@ namespace Exiled.CustomItems.API.Features
 
             ev.Player.RemoveItem(ev.Item);
 
-            Spawn(ev.Player, ev.Item);
+            Spawn(ev.Player, ev.Item, out Pickup pickup);
         }
 
         private void OnInternalPickingUp(PickingUpItemEventArgs ev)
@@ -865,7 +865,7 @@ namespace Exiled.CustomItems.API.Features
                         {
                             InsideInventories.Remove(item.uniq);
 
-                            Spawn(playerToItemsPair.Key, item);
+                            Spawn(playerToItemsPair.Key, item, out Pickup pickup);
 
                             continue;
                         }

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -242,7 +242,7 @@ namespace Exiled.CustomItems.API.Features
         /// <param name="id">The ID of the <see cref="CustomItem"/> to spawn.</param>
         /// <param name="position">The <see cref="Vector3"/> location to spawn the item.</param>
         /// <returns>Returns a value indicating whether the <see cref="CustomItem"/> was spawned or not.</returns>
-        [Obsolete("Use TrySpawn method with out parameter instead.")]
+        [Obsolete("Use TrySpawn method with an out parameter modifier instead.")]
         public static bool TrySpawn(int id, Vector3 position)
         {
             if (!TryGet(id, out CustomItem item))
@@ -259,7 +259,7 @@ namespace Exiled.CustomItems.API.Features
         /// <param name="name">The name of the <see cref="CustomItem"/> to spawn.</param>
         /// <param name="position">The <see cref="Vector3"/> location to spawn the item.</param>
         /// <returns>Returns a value indicating whether the <see cref="CustomItem"/> was spawned or not.</returns>
-        [Obsolete("Use TrySpawn method with out parameter instead.")]
+        [Obsolete("Use TrySpawn method with an out parameter modifier instead.")]
         public static bool TrySpawn(string name, Vector3 position)
         {
             if (!TryGet(name, out CustomItem item))
@@ -406,7 +406,7 @@ namespace Exiled.CustomItems.API.Features
         /// <param name="x">The x coordinate.</param>
         /// <param name="y">The y coordinate.</param>
         /// <param name="z">The z coordinate.</param>
-        [Obsolete("Use Spawn method with out parameter instead.")]
+        [Obsolete("Use Spawn method with an out parameter modifier instead.")]
         public virtual void Spawn(float x, float y, float z) => Spawn(new Vector3(x, y, z));
 
         /// <summary>
@@ -416,14 +416,14 @@ namespace Exiled.CustomItems.API.Features
         /// <param name="y">The y coordinate.</param>
         /// <param name="z">The z coordinate.</param>
         /// <param name="item">The <see cref="Inventory.SyncItemInfo"/> to be spawned as a <see cref="CustomItem"/>.</param>
-        [Obsolete("Use Spawn method with out parameter instead.")]
+        [Obsolete("Use Spawn method with an out parameter modifier instead.")]
         public virtual void Spawn(float x, float y, float z, Inventory.SyncItemInfo item) => Spawn(new Vector3(x, y, z), item);
 
         /// <summary>
         /// Spawns the <see cref="CustomItem"/> where a specific <see cref="Player"/> is.
         /// </summary>
         /// <param name="player">The <see cref="Player"/> position where the <see cref="CustomItem"/> will be spawned.</param>
-        [Obsolete("Use Spawn method with out parameter instead.")]
+        [Obsolete("Use Spawn method with an out parameter modifier instead.")]
         public virtual void Spawn(Player player) => Spawn(player.Position);
 
         /// <summary>
@@ -431,14 +431,14 @@ namespace Exiled.CustomItems.API.Features
         /// </summary>
         /// <param name="player">The <see cref="Player"/> position where the <see cref="CustomItem"/> will be spawned.</param>
         /// <param name="item">The <see cref="Inventory.SyncItemInfo"/> to be spawned as a <see cref="CustomItem"/>.</param>
-        [Obsolete("Use Spawn method with out parameter instead.")]
+        [Obsolete("Use Spawn method with an out parameter modifier instead.")]
         public virtual void Spawn(Player player, Inventory.SyncItemInfo item) => Spawn(player.Position, item);
 
         /// <summary>
         /// Spawns the <see cref="CustomItem"/> in a specific position.
         /// </summary>
         /// <param name="position">The <see cref="Vector3"/> where the <see cref="CustomItem"/> will be spawned.</param>
-        [Obsolete("Use Spawn method with out parameter instead.")]
+        [Obsolete("Use Spawn method with an out parameter modifier instead.")]
         public virtual void Spawn(Vector3 position) => Spawn(position, out _);
 
         /// <summary>
@@ -446,7 +446,7 @@ namespace Exiled.CustomItems.API.Features
         /// </summary>
         /// <param name="position">The <see cref="Vector3"/> where the <see cref="CustomItem"/> will be spawned.</param>
         /// <param name="item">The <see cref="Inventory.SyncItemInfo"/> to be spawned as a <see cref="CustomItem"/>.</param>
-        [Obsolete("Use Spawn method with out parameter instead.")]
+        [Obsolete("Use Spawn method with an out parameter modifier instead.")]
         public virtual void Spawn(Vector3 position, Inventory.SyncItemInfo item) => Spawn(position, item, out _);
 
         /// <summary>

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -203,13 +203,16 @@ namespace Exiled.CustomItems.API.Features
         /// </summary>
         /// <param name="id">The ID of the <see cref="CustomItem"/> to spawn.</param>
         /// <param name="position">The <see cref="Vector3"/> location to spawn the item.</param>
+        /// <param name="pickup">The <see cref="Pickup"/> instance of the <see cref="CustomItem"/>.</param>
         /// <returns>Returns a value indicating whether the <see cref="CustomItem"/> was spawned or not.</returns>
-        public static bool TrySpawn(int id, Vector3 position)
+        public static bool TrySpawn(int id, Vector3 position, out Pickup pickup)
         {
+            pickup = default;
+
             if (!TryGet(id, out CustomItem item))
                 return false;
 
-            item.Spawn(position);
+            pickup = item.Spawn(position);
 
             return true;
         }
@@ -219,13 +222,16 @@ namespace Exiled.CustomItems.API.Features
         /// </summary>
         /// <param name="name">The name of the <see cref="CustomItem"/> to spawn.</param>
         /// <param name="position">The <see cref="Vector3"/> location to spawn the item.</param>
+        /// <param name="pickup">The <see cref="Pickup"/> instance of the <see cref="CustomItem"/>.</param>
         /// <returns>Returns a value indicating whether the <see cref="CustomItem"/> was spawned or not.</returns>
-        public static bool TrySpawn(string name, Vector3 position)
+        public static bool TrySpawn(string name, Vector3 position, out Pickup pickup)
         {
+            pickup = default;
+
             if (!TryGet(name, out CustomItem item))
                 return false;
 
-            item.Spawn(position);
+            pickup = item.Spawn(position);
 
             return true;
         }
@@ -317,7 +323,8 @@ namespace Exiled.CustomItems.API.Features
         /// <param name="x">The x coordinate.</param>
         /// <param name="y">The y coordinate.</param>
         /// <param name="z">The z coordinate.</param>
-        public virtual void Spawn(float x, float y, float z) => Spawn(new Vector3(x, y, z));
+        /// <returns>Returns the Pickup of the <see cref="CustomItem"/>.</returns>
+        public virtual Pickup Spawn(float x, float y, float z) => Spawn(new Vector3(x, y, z));
 
         /// <summary>
         /// Spawns a <see cref="Inventory.SyncItemInfo"/> as a <see cref="CustomItem"/> in a specific location.
@@ -326,33 +333,50 @@ namespace Exiled.CustomItems.API.Features
         /// <param name="y">The y coordinate.</param>
         /// <param name="z">The z coordinate.</param>
         /// <param name="item">The <see cref="Inventory.SyncItemInfo"/> to be spawned as a <see cref="CustomItem"/>.</param>
-        public virtual void Spawn(float x, float y, float z, Inventory.SyncItemInfo item) => Spawn(new Vector3(x, y, z), item);
+        /// <returns>Returns the Pickup of the <see cref="CustomItem"/>.</returns>
+        public virtual Pickup Spawn(float x, float y, float z, Inventory.SyncItemInfo item) => Spawn(new Vector3(x, y, z), item);
 
         /// <summary>
         /// Spawns the <see cref="CustomItem"/> where a specific <see cref="Player"/> is.
         /// </summary>
         /// <param name="player">The <see cref="Player"/> position where the <see cref="CustomItem"/> will be spawned.</param>
-        public virtual void Spawn(Player player) => Spawn(player.Position);
+        /// <returns>Returns the Pickup of the <see cref="CustomItem"/>.</returns>
+        public virtual Pickup Spawn(Player player) => Spawn(player.Position);
 
         /// <summary>
         /// Spawns a <see cref="Inventory.SyncItemInfo"/> as a <see cref="CustomItem"/> where a specific <see cref="Player"/> is.
         /// </summary>
         /// <param name="player">The <see cref="Player"/> position where the <see cref="CustomItem"/> will be spawned.</param>
         /// <param name="item">The <see cref="Inventory.SyncItemInfo"/> to be spawned as a <see cref="CustomItem"/>.</param>
-        public virtual void Spawn(Player player, Inventory.SyncItemInfo item) => Spawn(player.Position, item);
+        /// <returns>Returns the Pickup of the <see cref="CustomItem"/>.</returns>
+        public virtual Pickup Spawn(Player player, Inventory.SyncItemInfo item) => Spawn(player.Position, item);
 
         /// <summary>
         /// Spawns the <see cref="CustomItem"/> in a specific position.
         /// </summary>
         /// <param name="position">The <see cref="Vector3"/> where the <see cref="CustomItem"/> will be spawned.</param>
-        public virtual void Spawn(Vector3 position) => Spawned.Add(Item.Spawn(Type, Durability, position));
+        /// <returns>Returns the Pickup of the <see cref="CustomItem"/>.</returns>
+        public virtual Pickup Spawn(Vector3 position)
+        {
+            var pickup = Item.Spawn(Type, Durability, position);
+
+            Spawned.Add(pickup);
+            return pickup;
+        }
 
         /// <summary>
         /// Spawns a <see cref="Inventory.SyncItemInfo"/> as a <see cref="CustomItem"/> in a specific position.
         /// </summary>
         /// <param name="position">The <see cref="Vector3"/> where the <see cref="CustomItem"/> will be spawned.</param>
         /// <param name="item">The <see cref="Inventory.SyncItemInfo"/> to be spawned as a <see cref="CustomItem"/>.</param>
-        public virtual void Spawn(Vector3 position, Inventory.SyncItemInfo item) => Spawned.Add(Item.Spawn(item, position));
+        /// <returns>Returns the Pickup of the <see cref="CustomItem"/>.</returns>
+        public virtual Pickup Spawn(Vector3 position, Inventory.SyncItemInfo item)
+        {
+            var pickup = Item.Spawn(item, position);
+
+            Spawned.Add(pickup);
+            return pickup;
+        }
 
         /// <summary>
         /// Spawns <see cref="CustomItem"/>s inside <paramref name="spawnPoints"/>.

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -212,7 +212,7 @@ namespace Exiled.CustomItems.API.Features
             if (!TryGet(id, out CustomItem item))
                 return false;
 
-            pickup = item.Spawn(position);
+            item.Spawn(position, out pickup);
 
             return true;
         }
@@ -231,7 +231,41 @@ namespace Exiled.CustomItems.API.Features
             if (!TryGet(name, out CustomItem item))
                 return false;
 
-            pickup = item.Spawn(position);
+            item.Spawn(position, out pickup);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Tries to spawn a specific <see cref="CustomItem"/> at a specific <see cref="Vector3"/> position.
+        /// </summary>
+        /// <param name="id">The ID of the <see cref="CustomItem"/> to spawn.</param>
+        /// <param name="position">The <see cref="Vector3"/> location to spawn the item.</param>
+        /// <returns>Returns a value indicating whether the <see cref="CustomItem"/> was spawned or not.</returns>
+        [Obsolete("Use TrySpawn method with out parameter instead.")]
+        public static bool TrySpawn(int id, Vector3 position)
+        {
+            if (!TryGet(id, out CustomItem item))
+                return false;
+
+            item.Spawn(position);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Tries to spawn a specific <see cref="CustomItem"/> at a specific <see cref="Vector3"/> position.
+        /// </summary>
+        /// <param name="name">The name of the <see cref="CustomItem"/> to spawn.</param>
+        /// <param name="position">The <see cref="Vector3"/> location to spawn the item.</param>
+        /// <returns>Returns a value indicating whether the <see cref="CustomItem"/> was spawned or not.</returns>
+        [Obsolete("Use TrySpawn method with out parameter instead.")]
+        public static bool TrySpawn(string name, Vector3 position)
+        {
+            if (!TryGet(name, out CustomItem item))
+                return false;
+
+            item.Spawn(position);
 
             return true;
         }
@@ -323,8 +357,8 @@ namespace Exiled.CustomItems.API.Features
         /// <param name="x">The x coordinate.</param>
         /// <param name="y">The y coordinate.</param>
         /// <param name="z">The z coordinate.</param>
-        /// <returns>Returns the Pickup of the <see cref="CustomItem"/>.</returns>
-        public virtual Pickup Spawn(float x, float y, float z) => Spawn(new Vector3(x, y, z));
+        /// <param name="pickup">The <see cref="Pickup"/> component of the spawned <see cref="CustomItem"/>.</param>
+        public virtual void Spawn(float x, float y, float z, out Pickup pickup) => Spawn(new Vector3(x, y, z), out pickup);
 
         /// <summary>
         /// Spawns a <see cref="Inventory.SyncItemInfo"/> as a <see cref="CustomItem"/> in a specific location.
@@ -333,50 +367,87 @@ namespace Exiled.CustomItems.API.Features
         /// <param name="y">The y coordinate.</param>
         /// <param name="z">The z coordinate.</param>
         /// <param name="item">The <see cref="Inventory.SyncItemInfo"/> to be spawned as a <see cref="CustomItem"/>.</param>
-        /// <returns>Returns the Pickup of the <see cref="CustomItem"/>.</returns>
-        public virtual Pickup Spawn(float x, float y, float z, Inventory.SyncItemInfo item) => Spawn(new Vector3(x, y, z), item);
+        /// <param name="pickup">The <see cref="Pickup"/> component of the spawned <see cref="CustomItem"/>.</param>
+        public virtual void Spawn(float x, float y, float z, Inventory.SyncItemInfo item, out Pickup pickup) => Spawn(new Vector3(x, y, z), item, out pickup);
 
         /// <summary>
         /// Spawns the <see cref="CustomItem"/> where a specific <see cref="Player"/> is.
         /// </summary>
         /// <param name="player">The <see cref="Player"/> position where the <see cref="CustomItem"/> will be spawned.</param>
-        /// <returns>Returns the Pickup of the <see cref="CustomItem"/>.</returns>
-        public virtual Pickup Spawn(Player player) => Spawn(player.Position);
+        /// <param name="pickup">The <see cref="Pickup"/> component of the spawned <see cref="CustomItem"/>.</param>
+        public virtual void Spawn(Player player, out Pickup pickup) => Spawn(player.Position, out pickup);
 
         /// <summary>
         /// Spawns a <see cref="Inventory.SyncItemInfo"/> as a <see cref="CustomItem"/> where a specific <see cref="Player"/> is.
         /// </summary>
         /// <param name="player">The <see cref="Player"/> position where the <see cref="CustomItem"/> will be spawned.</param>
         /// <param name="item">The <see cref="Inventory.SyncItemInfo"/> to be spawned as a <see cref="CustomItem"/>.</param>
-        /// <returns>Returns the Pickup of the <see cref="CustomItem"/>.</returns>
-        public virtual Pickup Spawn(Player player, Inventory.SyncItemInfo item) => Spawn(player.Position, item);
+        /// <param name="pickup">The <see cref="Pickup"/> component of the spawned <see cref="CustomItem"/>.</param>
+        public virtual void Spawn(Player player, Inventory.SyncItemInfo item, out Pickup pickup) => Spawn(player.Position, item, out pickup);
 
         /// <summary>
         /// Spawns the <see cref="CustomItem"/> in a specific position.
         /// </summary>
         /// <param name="position">The <see cref="Vector3"/> where the <see cref="CustomItem"/> will be spawned.</param>
-        /// <returns>Returns the Pickup of the <see cref="CustomItem"/>.</returns>
-        public virtual Pickup Spawn(Vector3 position)
-        {
-            var pickup = Item.Spawn(Type, Durability, position);
-
-            Spawned.Add(pickup);
-            return pickup;
-        }
+        /// <param name="pickup">The <see cref="Pickup"/> component of the spawned <see cref="CustomItem"/>.</param>
+        public virtual void Spawn(Vector3 position, out Pickup pickup) => Spawned.Add(pickup = Item.Spawn(Type, Durability, position));
 
         /// <summary>
         /// Spawns a <see cref="Inventory.SyncItemInfo"/> as a <see cref="CustomItem"/> in a specific position.
         /// </summary>
         /// <param name="position">The <see cref="Vector3"/> where the <see cref="CustomItem"/> will be spawned.</param>
         /// <param name="item">The <see cref="Inventory.SyncItemInfo"/> to be spawned as a <see cref="CustomItem"/>.</param>
-        /// <returns>Returns the Pickup of the <see cref="CustomItem"/>.</returns>
-        public virtual Pickup Spawn(Vector3 position, Inventory.SyncItemInfo item)
-        {
-            var pickup = Item.Spawn(item, position);
+        /// <param name="pickup">The <see cref="Pickup"/> component of the spawned <see cref="CustomItem"/>.</param>
+        public virtual void Spawn(Vector3 position, Inventory.SyncItemInfo item, out Pickup pickup) => Spawned.Add(pickup = Item.Spawn(item, position));
 
-            Spawned.Add(pickup);
-            return pickup;
-        }
+        /// <summary>
+        /// Spawns the <see cref="CustomItem"/> in a specific location.
+        /// </summary>
+        /// <param name="x">The x coordinate.</param>
+        /// <param name="y">The y coordinate.</param>
+        /// <param name="z">The z coordinate.</param>
+        [Obsolete("Use Spawn method with out parameter instead.")]
+        public virtual void Spawn(float x, float y, float z) => Spawn(new Vector3(x, y, z));
+
+        /// <summary>
+        /// Spawns a <see cref="Inventory.SyncItemInfo"/> as a <see cref="CustomItem"/> in a specific location.
+        /// </summary>
+        /// <param name="x">The x coordinate.</param>
+        /// <param name="y">The y coordinate.</param>
+        /// <param name="z">The z coordinate.</param>
+        /// <param name="item">The <see cref="Inventory.SyncItemInfo"/> to be spawned as a <see cref="CustomItem"/>.</param>
+        [Obsolete("Use Spawn method with out parameter instead.")]
+        public virtual void Spawn(float x, float y, float z, Inventory.SyncItemInfo item) => Spawn(new Vector3(x, y, z), item);
+
+        /// <summary>
+        /// Spawns the <see cref="CustomItem"/> where a specific <see cref="Player"/> is.
+        /// </summary>
+        /// <param name="player">The <see cref="Player"/> position where the <see cref="CustomItem"/> will be spawned.</param>
+        [Obsolete("Use Spawn method with out parameter instead.")]
+        public virtual void Spawn(Player player) => Spawn(player.Position);
+
+        /// <summary>
+        /// Spawns a <see cref="Inventory.SyncItemInfo"/> as a <see cref="CustomItem"/> where a specific <see cref="Player"/> is.
+        /// </summary>
+        /// <param name="player">The <see cref="Player"/> position where the <see cref="CustomItem"/> will be spawned.</param>
+        /// <param name="item">The <see cref="Inventory.SyncItemInfo"/> to be spawned as a <see cref="CustomItem"/>.</param>
+        [Obsolete("Use Spawn method with out parameter instead.")]
+        public virtual void Spawn(Player player, Inventory.SyncItemInfo item) => Spawn(player.Position, item);
+
+        /// <summary>
+        /// Spawns the <see cref="CustomItem"/> in a specific position.
+        /// </summary>
+        /// <param name="position">The <see cref="Vector3"/> where the <see cref="CustomItem"/> will be spawned.</param>
+        [Obsolete("Use Spawn method with out parameter instead.")]
+        public virtual void Spawn(Vector3 position) => Spawn(position, out var pickup);
+
+        /// <summary>
+        /// Spawns a <see cref="Inventory.SyncItemInfo"/> as a <see cref="CustomItem"/> in a specific position.
+        /// </summary>
+        /// <param name="position">The <see cref="Vector3"/> where the <see cref="CustomItem"/> will be spawned.</param>
+        /// <param name="item">The <see cref="Inventory.SyncItemInfo"/> to be spawned as a <see cref="CustomItem"/>.</param>
+        [Obsolete("Use Spawn method with out parameter instead.")]
+        public virtual void Spawn(Vector3 position, Inventory.SyncItemInfo item) => Spawn(position, item, out var pickup);
 
         /// <summary>
         /// Spawns <see cref="CustomItem"/>s inside <paramref name="spawnPoints"/>.

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -439,7 +439,7 @@ namespace Exiled.CustomItems.API.Features
         /// </summary>
         /// <param name="position">The <see cref="Vector3"/> where the <see cref="CustomItem"/> will be spawned.</param>
         [Obsolete("Use Spawn method with out parameter instead.")]
-        public virtual void Spawn(Vector3 position) => Spawn(position, out var pickup);
+        public virtual void Spawn(Vector3 position) => Spawn(position, out _);
 
         /// <summary>
         /// Spawns a <see cref="Inventory.SyncItemInfo"/> as a <see cref="CustomItem"/> in a specific position.
@@ -447,7 +447,7 @@ namespace Exiled.CustomItems.API.Features
         /// <param name="position">The <see cref="Vector3"/> where the <see cref="CustomItem"/> will be spawned.</param>
         /// <param name="item">The <see cref="Inventory.SyncItemInfo"/> to be spawned as a <see cref="CustomItem"/>.</param>
         [Obsolete("Use Spawn method with out parameter instead.")]
-        public virtual void Spawn(Vector3 position, Inventory.SyncItemInfo item) => Spawn(position, item, out var pickup);
+        public virtual void Spawn(Vector3 position, Inventory.SyncItemInfo item) => Spawn(position, item, out _);
 
         /// <summary>
         /// Spawns <see cref="CustomItem"/>s inside <paramref name="spawnPoints"/>.
@@ -468,7 +468,7 @@ namespace Exiled.CustomItems.API.Features
 
                 spawned++;
 
-                Spawn(spawnPoint.Position.ToVector3, out Pickup pickup);
+                Spawn(spawnPoint.Position.ToVector3, out _);
 
                 Log.Debug($"Spawned {Name} at {spawnPoint.Position} ({spawnPoint.Name})", Instance.Config.Debug);
             }
@@ -697,7 +697,7 @@ namespace Exiled.CustomItems.API.Features
 
                 ev.Player.RemoveItem(item);
 
-                Spawn(ev.Player, item, out Pickup pickup);
+                Spawn(ev.Player, item, out _);
 
                 Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }
@@ -719,7 +719,7 @@ namespace Exiled.CustomItems.API.Features
 
                 InsideInventories.Remove(item.uniq);
 
-                Spawn(ev.Target, item, out Pickup pickup);
+                Spawn(ev.Target, item, out _);
 
                 Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Target.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }
@@ -741,7 +741,7 @@ namespace Exiled.CustomItems.API.Features
 
                 InsideInventories.Remove(item.uniq);
 
-                Spawn(Role.GetRandomSpawnPoint(ev.NewRole), item, out Pickup pickup);
+                Spawn(Role.GetRandomSpawnPoint(ev.NewRole), item, out _);
 
                 Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }
@@ -763,7 +763,7 @@ namespace Exiled.CustomItems.API.Features
 
                 InsideInventories.Remove(item.uniq);
 
-                Spawn(ev.Target, item, out Pickup pickup);
+                Spawn(ev.Target, item, out _);
             }
         }
 
@@ -783,7 +783,7 @@ namespace Exiled.CustomItems.API.Features
 
             ev.Player.RemoveItem(ev.Item);
 
-            Spawn(ev.Player, ev.Item, out Pickup pickup);
+            Spawn(ev.Player, ev.Item, out _);
         }
 
         private void OnInternalPickingUp(PickingUpItemEventArgs ev)
@@ -865,7 +865,7 @@ namespace Exiled.CustomItems.API.Features
                         {
                             InsideInventories.Remove(item.uniq);
 
-                            Spawn(playerToItemsPair.Key, item, out Pickup pickup);
+                            Spawn(playerToItemsPair.Key, item, out _);
 
                             continue;
                         }

--- a/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -67,7 +67,7 @@ namespace Exiled.CustomItems.API.Features
         }
 
         /// <inheritdoc/>
-        [Obsolete("Use Spawn method with out parameter instead.")]
+        [Obsolete("Use Spawn method with an out parameter modifier instead.")]
         public override void Spawn(Vector3 position)
         {
             Pickup pickup = Item.Spawn(Type, ClipSize, position, default, Modifiers.SightType, Modifiers.BarrelType, Modifiers.OtherType);

--- a/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -59,7 +59,13 @@ namespace Exiled.CustomItems.API.Features
         public override float Durability { get; set; }
 
         /// <inheritdoc/>
-        public override void Spawn(Vector3 position) => Spawned.Add(Item.Spawn(Type, ClipSize, position, default, Modifiers.SightType, Modifiers.BarrelType, Modifiers.OtherType));
+        public override Pickup Spawn(Vector3 position)
+        {
+            var pickup = Item.Spawn(Type, ClipSize, position, default, Modifiers.SightType, Modifiers.BarrelType, Modifiers.OtherType);
+
+            Spawned.Add(pickup);
+            return pickup;
+        }
 
         /// <inheritdoc/>
         public override void Give(Player player, bool displayMessage)

--- a/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -67,6 +67,7 @@ namespace Exiled.CustomItems.API.Features
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use Spawn method with out parameter instead.")]
         public override void Spawn(Vector3 position)
         {
             Pickup pickup = Item.Spawn(Type, ClipSize, position, default, Modifiers.SightType, Modifiers.BarrelType, Modifiers.OtherType);

--- a/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -59,12 +59,19 @@ namespace Exiled.CustomItems.API.Features
         public override float Durability { get; set; }
 
         /// <inheritdoc/>
-        public override Pickup Spawn(Vector3 position)
+        public override void Spawn(Vector3 position, out Pickup pickup)
         {
-            var pickup = Item.Spawn(Type, ClipSize, position, default, Modifiers.SightType, Modifiers.BarrelType, Modifiers.OtherType);
+            pickup = Item.Spawn(Type, ClipSize, position, default, Modifiers.SightType, Modifiers.BarrelType, Modifiers.OtherType);
 
             Spawned.Add(pickup);
-            return pickup;
+        }
+
+        /// <inheritdoc/>
+        public override void Spawn(Vector3 position)
+        {
+            Pickup pickup = Item.Spawn(Type, ClipSize, position, default, Modifiers.SightType, Modifiers.BarrelType, Modifiers.OtherType);
+
+            Spawned.Add(pickup);
         }
 
         /// <inheritdoc/>

--- a/Exiled.CustomItems/Commands/Spawn.cs
+++ b/Exiled.CustomItems/Commands/Spawn.cs
@@ -94,7 +94,7 @@ namespace Exiled.CustomItems.Commands
                 return false;
             }
 
-            item.Spawn(position);
+            item.Spawn(position, out _);
 
             response = $"{item.Name} ({item.Type}) has been spawned at {position}.";
             return true;


### PR DESCRIPTION
I hate naming my PRs.
- Added out param for CustomItem.TrySpawn() method.
- CustomItem.Spawn() now returns the Pickup component.
With stuff like this the dev can modify different settings of that specific pickup, or even access the GameObject & other components, which is necessary for some implementations.