### PR TITLE
Add ChangedRole event

### DIFF
--- a/Exiled.Events/EventArgs/ChangedRoleEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangedRoleEventArgs.cs
@@ -21,9 +21,9 @@ namespace Exiled.Events.EventArgs
         /// Initializes a new instance of the <see cref="ChangedRoleEventArgs"/> class.
         /// </summary>
         /// <param name="player"><inheritdoc cref="Player"/></param>
-        /// <param name="newRole"><inheritdoc cref="NewRole"/></param>
+        /// <param name="oldRole"><inheritdoc cref="OldRole"/></param>
         /// <param name="items"><inheritdoc cref="Items"/></param>
-        /// <param name="shouldPreservePosition"><inheritdoc cref="ShouldPreservePosition"/></param>
+        /// <param name="preservedPosition"><inheritdoc cref="PreservedPosition"/></param>
         /// <param name="isEscaped"><inheritdoc cref="IsEscaped"/></param>
         public ChangedRoleEventArgs(Player player, RoleType oldRole, List<ItemType> items, bool preservedPosition, bool isEscaped)
         {

--- a/Exiled.Events/EventArgs/ChangedRoleEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangedRoleEventArgs.cs
@@ -1,0 +1,62 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ChangedRoleEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Exiled.API.Features;
+
+    /// <summary>
+    /// Contains all informations after player's <see cref="RoleType"/> changes.
+    /// </summary>
+    public class ChangedRoleEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangedRoleEventArgs"/> class.
+        /// </summary>
+        /// <param name="player"><inheritdoc cref="Player"/></param>
+        /// <param name="newRole"><inheritdoc cref="NewRole"/></param>
+        /// <param name="items"><inheritdoc cref="Items"/></param>
+        /// <param name="shouldPreservePosition"><inheritdoc cref="ShouldPreservePosition"/></param>
+        /// <param name="isEscaped"><inheritdoc cref="IsEscaped"/></param>
+        public ChangedRoleEventArgs(Player player, RoleType oldRole, List<ItemType> items, bool preservedPosition, bool isEscaped)
+        {
+            Player = player;
+            OldRole = oldRole;
+            Items = items.AsReadOnly();
+            PreservedPosition = preservedPosition;
+            IsEscaped = isEscaped;
+        }
+
+        /// <summary>
+        /// Gets the player whose <see cref="RoleType"/> has changed.
+        /// </summary>
+        public Player Player { get; }
+
+        /// <summary>
+        /// Gets the player's previous role.
+        /// </summary>
+        public RoleType OldRole { get; }
+
+        /// <summary>
+        /// Gets base items that the player has received.
+        /// </summary>
+        public IReadOnlyList<ItemType> Items { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the player escaped or not.
+        /// </summary>
+        public bool IsEscaped { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the position has been preserved after changing the role.
+        /// </summary>
+        public bool PreservedPosition { get; }
+    }
+}

--- a/Exiled.Events/EventArgs/ChangedRoleEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangedRoleEventArgs.cs
@@ -23,14 +23,14 @@ namespace Exiled.Events.EventArgs
         /// <param name="player"><inheritdoc cref="Player"/></param>
         /// <param name="oldRole"><inheritdoc cref="OldRole"/></param>
         /// <param name="items"><inheritdoc cref="Items"/></param>
-        /// <param name="preservedPosition"><inheritdoc cref="PreservedPosition"/></param>
+        /// <param name="hasPreservedPosition"><inheritdoc cref="HasPreservedPosition"/></param>
         /// <param name="isEscaped"><inheritdoc cref="IsEscaped"/></param>
-        public ChangedRoleEventArgs(Player player, RoleType oldRole, List<ItemType> items, bool preservedPosition, bool isEscaped)
+        public ChangedRoleEventArgs(Player player, RoleType oldRole, List<ItemType> items, bool hasPreservedPosition, bool isEscaped)
         {
             Player = player;
             OldRole = oldRole;
             Items = items.AsReadOnly();
-            PreservedPosition = preservedPosition;
+            HasPreservedPosition = hasPreservedPosition;
             IsEscaped = isEscaped;
         }
 
@@ -57,6 +57,6 @@ namespace Exiled.Events.EventArgs
         /// <summary>
         /// Gets a value indicating whether the position has been preserved after changing the role.
         /// </summary>
-        public bool PreservedPosition { get; }
+        public bool HasPreservedPosition { get; }
     }
 }

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -126,6 +126,11 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<ChangingRoleEventArgs> ChangingRole;
 
         /// <summary>
+        /// Invoked after changing a player's role.
+        /// </summary>
+        public static event CustomEventHandler<ChangedRoleEventArgs> ChangedRole;
+
+        /// <summary>
         /// Invoked before throwing a grenade.
         /// </summary>
         public static event CustomEventHandler<ThrowingGrenadeEventArgs> ThrowingGrenade;
@@ -419,6 +424,12 @@ namespace Exiled.Events.Handlers
         /// </summary>
         /// <param name="ev">The <see cref="ChangingRoleEventArgs"/> instance.</param>
         public static void OnChangingRole(ChangingRoleEventArgs ev) => ChangingRole.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called after changing a player's role.
+        /// </summary>
+        /// <param name="ev">The <see cref="ChangedRoleEventArgs"/> instance.</param>
+        public static void OnChangedRole(ChangedRoleEventArgs ev) => ChangedRole.InvokeSafely(ev);
 
         /// <summary>
         /// Called before throwing a grenade.

--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -42,8 +42,10 @@ namespace Exiled.Events.Patches.Events.Player
                     return false;
                 }
 
+                var player = API.Features.Player.Get(ply);
+
                 var startItemsList = ListPool<ItemType>.Shared.Rent(__instance.Classes.SafeGet(classid).startItems);
-                var changingRoleEventArgs = new ChangingRoleEventArgs(API.Features.Player.Get(ply), classid, startItemsList, lite, escape);
+                var changingRoleEventArgs = new ChangingRoleEventArgs(player, classid, startItemsList, lite, escape);
 
                 Player.OnChangingRole(changingRoleEventArgs);
 
@@ -60,7 +62,7 @@ namespace Exiled.Events.Patches.Events.Player
 
                 if (escape)
                 {
-                    var escapingEventArgs = new EscapingEventArgs(API.Features.Player.Get(ply), classid);
+                    var escapingEventArgs = new EscapingEventArgs(player, classid);
 
                     Player.OnEscaping(escapingEventArgs);
 
@@ -70,7 +72,7 @@ namespace Exiled.Events.Patches.Events.Player
                     classid = escapingEventArgs.NewRole;
                 }
 
-                var oldRole = API.Features.Player.Get(ply).Role;
+                var oldRole = player.Role;
 
                 ply.GetComponent<CharacterClassManager>().SetClassIDAdv(classid, lite, escape);
                 ply.GetComponent<PlayerStats>().SetHPAmount(__instance.Classes.SafeGet(classid).maxHP);
@@ -78,7 +80,7 @@ namespace Exiled.Events.Patches.Events.Player
 
                 if (lite)
                 {
-                    var changedRoleEventArgs = new ChangedRoleEventArgs(API.Features.Player.Get(ply), oldRole, startItemsList, true, escape);
+                    var changedRoleEventArgs = new ChangedRoleEventArgs(player, oldRole, startItemsList, true, escape);
                     Player.OnChangedRole(changedRoleEventArgs);
 
                     ListPool<ItemType>.Shared.Return(startItemsList);
@@ -158,7 +160,7 @@ namespace Exiled.Events.Patches.Events.Player
 
                 ListPool<Inventory.SyncItemInfo>.Shared.Return(list);
 
-                var changedRoleEventArgs1 = new ChangedRoleEventArgs(API.Features.Player.Get(ply), oldRole, startItemsList, false, escape);
+                var changedRoleEventArgs1 = new ChangedRoleEventArgs(player, oldRole, startItemsList, false, escape);
                 Player.OnChangedRole(changedRoleEventArgs1);
 
                 ListPool<ItemType>.Shared.Return(startItemsList);

--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -72,7 +72,7 @@ namespace Exiled.Events.Patches.Events.Player
                     classid = escapingEventArgs.NewRole;
                 }
 
-                var oldRole = player.Role;
+                var changedRoleEventArgs = new ChangedRoleEventArgs(player, player.Role, startItemsList, lite, escape);
 
                 ply.GetComponent<CharacterClassManager>().SetClassIDAdv(classid, lite, escape);
                 ply.GetComponent<PlayerStats>().SetHPAmount(__instance.Classes.SafeGet(classid).maxHP);
@@ -80,7 +80,6 @@ namespace Exiled.Events.Patches.Events.Player
 
                 if (lite)
                 {
-                    var changedRoleEventArgs = new ChangedRoleEventArgs(player, oldRole, startItemsList, true, escape);
                     Player.OnChangedRole(changedRoleEventArgs);
 
                     ListPool<ItemType>.Shared.Return(startItemsList);
@@ -160,8 +159,7 @@ namespace Exiled.Events.Patches.Events.Player
 
                 ListPool<Inventory.SyncItemInfo>.Shared.Return(list);
 
-                var changedRoleEventArgs1 = new ChangedRoleEventArgs(player, oldRole, startItemsList, false, escape);
-                Player.OnChangedRole(changedRoleEventArgs1);
+                Player.OnChangedRole(changedRoleEventArgs);
 
                 ListPool<ItemType>.Shared.Return(startItemsList);
                 return false;

--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -70,12 +70,17 @@ namespace Exiled.Events.Patches.Events.Player
                     classid = escapingEventArgs.NewRole;
                 }
 
+                var oldRole = API.Features.Player.Get(ply).Role;
+
                 ply.GetComponent<CharacterClassManager>().SetClassIDAdv(classid, lite, escape);
                 ply.GetComponent<PlayerStats>().SetHPAmount(__instance.Classes.SafeGet(classid).maxHP);
                 ply.GetComponent<FirstPersonController>().ResetStamina();
 
                 if (lite)
                 {
+                    var changedRoleEventArgs = new ChangedRoleEventArgs(API.Features.Player.Get(ply), oldRole, startItemsList, true, escape);
+                    Player.OnChangedRole(changedRoleEventArgs);
+
                     ListPool<ItemType>.Shared.Return(startItemsList);
                     return false;
                 }
@@ -93,8 +98,6 @@ namespace Exiled.Events.Patches.Events.Player
                 {
                     component.AddNewItem(id, -4.65664672E+11f, 0, 0, 0);
                 }
-
-                ListPool<ItemType>.Shared.Return(startItemsList);
 
                 if (escape && CharacterClassManager.KeepItemsAfterEscaping)
                 {
@@ -154,6 +157,11 @@ namespace Exiled.Events.Patches.Events.Player
                 }
 
                 ListPool<Inventory.SyncItemInfo>.Shared.Return(list);
+
+                var changedRoleEventArgs1 = new ChangedRoleEventArgs(API.Features.Player.Get(ply), oldRole, startItemsList, false, escape);
+                Player.OnChangedRole(changedRoleEventArgs1);
+
+                ListPool<ItemType>.Shared.Return(startItemsList);
                 return false;
             }
             catch (Exception e)


### PR DESCRIPTION
There is an issue with ChangingRole that causes it to run many times, with IsAllowed and IsEscaped set to true if IsAllowed is set to false in Escaping event. The Escaping event is the only way to accurately view escapes, but it is not possible to do the same with role changes. This new event occurs after a role is changed, to allow responding to the event correctly.