### PR TITLE
Plugin load logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+# JetBrains Rider cache/options directory
+.idea/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -140,6 +140,8 @@ namespace Exiled.Loader
                     continue;
 
                 Locations[assembly] = assemblyPath;
+
+                Log.Info($"Loaded plugin {assembly.GetName().Name}@{assembly.GetName().Version.ToString(3)}");
             }
 
             foreach (Assembly assembly in Locations.Keys)
@@ -319,7 +321,7 @@ namespace Exiled.Loader
             if (requiredVersion.Major != actualVersion.Major)
             {
                 // Assume that if the Required Major version is greater than the Actual Major version,
-                // Exled is outdated
+                // Exiled is outdated
                 if (requiredVersion.Major > actualVersion.Major)
                 {
                     Log.Error($"You're running an older version of Exiled ({Version.ToString(3)})! {plugin.Name} won't be loaded! " +
@@ -359,7 +361,7 @@ namespace Exiled.Loader
 
                     Dependencies.Add(assembly);
 
-                    Log.Info($"Loaded dependency {assembly.FullName}");
+                    Log.Info($"Loaded dependency {assembly.GetName().Name}@{assembly.GetName().Version.ToString(3)}");
                 }
 
                 Log.Info("Dependencies loaded successfully!");


### PR DESCRIPTION
The point of it is that we only log that a plugin is enabled and not loaded, but we log when a dependency is loaded. I recently released an update for my plugin, it required the newest version of Exiled and breaks when it's not, so when the guy said he updated the plugin, I couldn't check it by logs because it was throwing an exception while enabling, I'd spend less time understanding this issue if I saw the plugin version.