### PR TITLE
Allow Handcuffing event.IsAllowed to override team checks.

### DIFF
--- a/Exiled.Events/Patches/Events/Player/Handcuffing.cs
+++ b/Exiled.Events/Patches/Events/Player/Handcuffing.cs
@@ -36,7 +36,7 @@ namespace Exiled.Events.Patches.Events.Player
             // The index offset.
             var offset = 1;
 
-            // Search for the last "ldloc.2".
+            // Search for the last "stloc.3".
             var index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Stloc_3) + offset;
 
             // var ev = new HandcuffingEventArgs(Player.Get(this.gameObject), Player.Get(target), flag);

--- a/Exiled.Events/Patches/Events/Player/Handcuffing.cs
+++ b/Exiled.Events/Patches/Events/Player/Handcuffing.cs
@@ -34,10 +34,10 @@ namespace Exiled.Events.Patches.Events.Player
             var newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
 
             // The index offset.
-            var offset = 1;
+            var offset = 0;
 
-            // Search for the last "stloc.3".
-            var index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Stloc_3) + offset;
+            // Search for the last "ldloc.3".
+            var index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Ldloc_3) + offset;
 
             // var ev = new HandcuffingEventArgs(Player.Get(this.gameObject), Player.Get(target), flag);
             //

--- a/Exiled.Events/Patches/Events/Player/Handcuffing.cs
+++ b/Exiled.Events/Patches/Events/Player/Handcuffing.cs
@@ -71,9 +71,7 @@ namespace Exiled.Events.Patches.Events.Player
             });
 
             for (int z = 0; z < newInstructions.Count; z++)
-            {
                 yield return newInstructions[z];
-            }
 
             ListPool<CodeInstruction>.Shared.Return(newInstructions);
         }


### PR DESCRIPTION
This update will have the Handcuffing event still be called regardless of the team checks. If the target is on the same team as the cuffer, `ev.IsAllowed` will default to `false`, but if set to `true`, the player will still be handcuffed. Other than that it works the exact same.