### PR TITLE
Fix DoorExtensions.GetDoorType (String.GetBefore)

### DIFF
--- a/Exiled.API/Extensions/String.cs
+++ b/Exiled.API/Extensions/String.cs
@@ -144,7 +144,7 @@ namespace Exiled.API.Extensions
         {
             var start = input.IndexOf(symbol);
             if (start != 0)
-                input = input.Substring(0, input.Length - start);
+                input = input.Substring(0, start);
 
             return input;
         }


### PR DESCRIPTION
DoorExtensions.GetDoorType now returns correct DoorType