### PR TITLE
Fixed Cassie not saying unit names, when their colors were changed

### DIFF
--- a/Exiled.Events/Patches/Fixes/CassieNotSayingUnitNamesFix.cs
+++ b/Exiled.Events/Patches/Fixes/CassieNotSayingUnitNamesFix.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-// <copyright file="NineTailedFoxNamingRuleFix.cs" company="Exiled Team">
+// <copyright file="CassieNotSayingUnitNamesFix.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>
@@ -7,7 +7,6 @@
 
 namespace Exiled.Events.Patches.Fixes
 {
-    #pragma warning disable SA1600
     #pragma warning disable SA1313
 
     using System.Text.RegularExpressions;
@@ -19,10 +18,10 @@ namespace Exiled.Events.Patches.Fixes
     using Respawning.NamingRules;
 
     /// <summary>
-    /// Fixes Cassie ignoring unit name if it changed via <see cref="Map.ChangeUnitColor(int, string)"/>.
+    /// Fixes Cassie ignoring unit name if it's changed via <see cref="Map.ChangeUnitColor(int, string)"/>.
     /// </summary>
     [HarmonyPatch(typeof(NineTailedFoxNamingRule), nameof(NineTailedFoxNamingRule.GetCassieUnitName))]
-    public static class NineTailedFoxNamingRuleFix
+    public static class CassieNotSayingUnitNamesFix
     {
         private static bool Prefix(NineTailedFoxNamingRule __instance, string regular, ref string __result)
         {

--- a/Exiled.Events/Patches/Fixes/CassieNotSayingUnitNamesFix.cs
+++ b/Exiled.Events/Patches/Fixes/CassieNotSayingUnitNamesFix.cs
@@ -25,20 +25,17 @@ namespace Exiled.Events.Patches.Fixes
     {
         private static bool Prefix(NineTailedFoxNamingRule __instance, string regular, ref string __result)
         {
-            string result;
             try
             {
                 string[] array = Regex.Replace(regular, "<[^>]*?>", string.Empty).Split(new char[] { '-' });
 
-                result = $"NATO_{array[0][0]} {array[1]}";
+                __result = $"NATO_{array[0][0]} {array[1]}";
             }
             catch
             {
                 Log.Error("Error, couldn't convert '" + regular + "' into a CASSIE-readable form.");
-                result = "ERROR";
+                __result = "ERROR";
             }
-
-            __result = result;
 
             return false;
         }

--- a/Exiled.Events/Patches/Fixes/NineTailedFoxNamingRuleFix.cs
+++ b/Exiled.Events/Patches/Fixes/NineTailedFoxNamingRuleFix.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+// <copyright file="NineTailedFoxNamingRuleFix.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Fixes
+{
+    #pragma warning disable SA1600
+    #pragma warning disable SA1313
+
+    using System.Text.RegularExpressions;
+
+    using Exiled.API.Features;
+
+    using HarmonyLib;
+
+    using Respawning.NamingRules;
+
+    /// <summary>
+    /// Fixes Cassie ignoring unit name if it changed via <see cref="Map.ChangeUnitColor(int, string)"/>.
+    /// </summary>
+    [HarmonyPatch(typeof(NineTailedFoxNamingRule), nameof(NineTailedFoxNamingRule.GetCassieUnitName))]
+    public static class NineTailedFoxNamingRuleFix
+    {
+        private static bool Prefix(NineTailedFoxNamingRule __instance, string regular, ref string __result)
+        {
+            string result;
+            try
+            {
+                string[] array = Regex.Replace(regular, "<[^>]*?>", string.Empty).Split(new char[] { '-' });
+
+                result = $"NATO_{array[0][0]} {array[1]}";
+            }
+            catch
+            {
+                Log.Error("Error, couldn't convert '" + regular + "' into a CASSIE-readable form.");
+                result = "ERROR";
+            }
+
+            __result = result;
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Cassie ignored unit names that were changed by `Map.ChangeUnitColor` method.
Using Regex I've removed color formatting when Cassie gets the unit name.