### PR TITLE
Fixed not setting correctly item in player's hand

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -648,7 +648,11 @@ namespace Exiled.API.Features
         public Inventory.SyncItemInfo CurrentItem
         {
             get => Inventory.GetItemInHand();
-            set => Inventory.SetCurItem(value.id);
+            set
+            {
+                Inventory.SetCurItem(value.id);
+                Inventory.CallCmdSetUnic(value.uniq);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed issue where after setting item and then getting it, it returned item that was previously in hand