### PR TITLE
ChangingMicroHIDState and UsingMicroHIDEnergy events

### DIFF
--- a/Exiled.Events/EventArgs/ChangingMicroHIDStateEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingMicroHIDStateEventArgs.cs
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChangingMicroHIDStateEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+
+    using Exiled.API.Features;
+
+    /// <summary>
+    /// Contains all information before MicroHID state is changed.
+    /// </summary>
+    public class ChangingMicroHIDStateEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangingMicroHIDStateEventArgs"/> class.
+        /// </summary>
+        /// <param name="player"><inheritdoc cref="Player"/></param>
+        /// <param name="oldState"><inheritdoc cref="OldState"/></param>
+        /// <param name="newState"><inheritdoc cref="NewState"/></param>
+        /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
+        public ChangingMicroHIDStateEventArgs(Player player, MicroHID.MicroHidState oldState, MicroHID.MicroHidState newState, bool isAllowed = true)
+        {
+            Player = player;
+            OldState = oldState;
+            NewState = newState;
+            IsAllowed = isAllowed;
+        }
+
+        /// <summary>
+        /// Gets the player who's using the MicroHID.
+        /// </summary>
+        public Player Player { get; }
+
+        /// <summary>
+        /// Gets the old MicroHID state.
+        /// </summary>
+        public MicroHID.MicroHidState OldState { get; }
+
+        /// <summary>
+        /// Gets or sets the new MicroHID state.
+        /// </summary>
+        public MicroHID.MicroHidState NewState { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the MicroHID state can be changed or not.
+        /// </summary>
+        public bool IsAllowed { get; set; }
+    }
+}

--- a/Exiled.Events/EventArgs/UsingMicroHIDEnergyEventArgs.cs
+++ b/Exiled.Events/EventArgs/UsingMicroHIDEnergyEventArgs.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------
+// <copyright file="UsingMicroHIDEnergyEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+
+    using Exiled.API.Features;
+
+    /// <summary>
+    /// Contains all information before MicroHID energy is changed.
+    /// </summary>
+    public class UsingMicroHIDEnergyEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsingMicroHIDEnergyEventArgs"/> class.
+        /// </summary>
+        /// <param name="player"><inheritdoc cref="Player"/></param>
+        /// <param name="currentState"><inheritdoc cref="CurrentState"/></param>
+        /// <param name="oldValue"><inheritdoc cref="OldValue"/></param>
+        /// <param name="newValue"><inheritdoc cref="NewValue"/></param>
+        /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
+        public UsingMicroHIDEnergyEventArgs(Player player, MicroHID.MicroHidState currentState, float oldValue, float newValue, bool isAllowed = true)
+        {
+            Player = player;
+            CurrentState = currentState;
+            OldValue = oldValue;
+            NewValue = newValue;
+            IsAllowed = isAllowed;
+        }
+
+        /// <summary>
+        /// Gets the player who's using the MicroHID.
+        /// </summary>
+        public Player Player { get; }
+
+        /// <summary>
+        /// Gets the current state of the MicroHID.
+        /// </summary>
+        public MicroHID.MicroHidState CurrentState { get; }
+
+        /// <summary>
+        /// Gets the old MicroHID energy value.
+        /// </summary>
+        public float OldValue { get; }
+
+        /// <summary>
+        /// Gets or sets the new MicroHID energy value.
+        /// </summary>
+        public float NewValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the MicroHID energy can be changed or not.
+        /// </summary>
+        public bool IsAllowed { get; set; }
+    }
+}

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -311,6 +311,16 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<ChangingRadioPresetEventArgs> ChangingRadioPreset;
 
         /// <summary>
+        /// Invoked before a player's MicroHID state is changed.
+        /// </summary>
+        public static event CustomEventHandler<ChangingMicroHIDStateEventArgs> ChangingMicroHIDState;
+
+        /// <summary>
+        /// Invoked before a player's MicroHID energy is changed.
+        /// </summary>
+        public static event CustomEventHandler<UsingMicroHIDEnergyEventArgs> UsingMicroHIDEnergy;
+
+        /// <summary>
         /// Called before pre-authenticating a player.
         /// </summary>
         /// <param name="ev">The <see cref="PreAuthenticatingEventArgs"/> instance.</param>
@@ -651,5 +661,17 @@ namespace Exiled.Events.Handlers
         /// </summary>
         /// <param name="ev">The <see cref="ChangingRadioPresetEventArgs"/> instance.</param>
         public static void OnChangingRadioPreset(ChangingRadioPresetEventArgs ev) => ChangingRadioPreset.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a player's MicroHID state is changed.
+        /// </summary>
+        /// <param name="ev">The <see cref="ChangingRadioPresetEventArgs"/> instance.</param>
+        public static void OnChangingMicroHIDState(ChangingMicroHIDStateEventArgs ev) => ChangingMicroHIDState.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a player's MicroHID energy is changed.
+        /// </summary>
+        /// <param name="ev">The <see cref="UsingMicroHIDEnergyEventArgs"/> instance.</param>
+        public static void OnUsingMicroHIDEnergy(UsingMicroHIDEnergyEventArgs ev) => UsingMicroHIDEnergy.InvokeSafely(ev);
     }
 }

--- a/Exiled.Events/Patches/Events/Player/ChangingMicroHIDState.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingMicroHIDState.cs
@@ -1,0 +1,42 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChangingMicroHIDState.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+#pragma warning disable SA1313
+
+    using Exiled.API.Features;
+    using Exiled.Events.EventArgs;
+
+    using HarmonyLib;
+
+    /// <summary>
+    /// Patches <see cref="MicroHID.NetworkCurrentHidState"/>.
+    /// Adds the <see cref="Handlers.Player.OnChangingMicroHIDState"/> event.
+    /// </summary>
+    [HarmonyPatch(typeof(MicroHID), nameof(MicroHID.NetworkCurrentHidState), MethodType.Setter)]
+    internal static class ChangingMicroHIDState
+    {
+        private static bool Prefix(MicroHID __instance, ref MicroHID.MicroHidState value)
+        {
+            // NetworkCurrentHid state is set each frame, so this  is to prevent calling the method each frame.
+            if (__instance.CurrentHidState == value)
+                return true;
+
+            var ev = new ChangingMicroHIDStateEventArgs(Player.Get(__instance.gameObject), __instance.CurrentHidState, value);
+
+            Handlers.Player.OnChangingMicroHIDState(ev);
+
+            if (!ev.IsAllowed)
+                return false;
+
+            value = ev.NewState;
+
+            return true;
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/UsingMicroHIDEnergy.cs
+++ b/Exiled.Events/Patches/Events/Player/UsingMicroHIDEnergy.cs
@@ -1,0 +1,38 @@
+// -----------------------------------------------------------------------
+// <copyright file="UsingMicroHIDEnergy.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+#pragma warning disable SA1313
+
+    using Exiled.API.Features;
+    using Exiled.Events.EventArgs;
+
+    using HarmonyLib;
+
+    /// <summary>
+    /// Patches <see cref="MicroHID.NetworkEnergy"/>.
+    /// Adds the <see cref="Handlers.Player.OnUsingMicroHIDEnergy"/> event.
+    /// </summary>
+    [HarmonyPatch(typeof(MicroHID), nameof(MicroHID.NetworkEnergy), MethodType.Setter)]
+    internal static class UsingMicroHIDEnergy
+    {
+        private static bool Prefix(MicroHID __instance, ref float value)
+        {
+            var ev = new UsingMicroHIDEnergyEventArgs(Player.Get(__instance.gameObject), __instance.CurrentHidState, __instance.Energy, value);
+
+            Handlers.Player.OnUsingMicroHIDEnergy(ev);
+
+            if (!ev.IsAllowed)
+                return false;
+
+            value = ev.NewValue;
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
I've added 2 new events:
`ChangingMicroHIDState` - it is called when the MicroHID changes it's state, for example from idle to rolling
`UsingMicroHIDEnergy` - it is called when the MicroHID uses it's energy