### PR TITLE
graceful exceptions

### DIFF
--- a/EXILED.props
+++ b/EXILED.props
@@ -13,16 +13,20 @@
     <OutputPath>$(MSBuildThisFileDirectory)\bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
 
+  <!-- The package version gang -->
+  <PropertyGroup>
+    <HarmonyVersion>2.0.4</HarmonyVersion>
+    <YamlDotNetVersion>9.1.4</YamlDotNetVersion>
+    <StyleCopVersion>1.1.118</StyleCopVersion>
+    <SemanticVersioningVersion>1.3.0</SemanticVersioningVersion>
+    <BenDemystifierVersion>0.4.1</BenDemystifierVersion>
+  </PropertyGroup>
+
   <PropertyGroup>
     <!-- This is the global version and is used for all projects that don't have a version -->
     <Version Condition="$(Version) == ''">2.10.0-beta</Version>
     <!-- Enables public beta warning via the PUBLIC_BETA constant -->
     <PublicBeta>false</PublicBeta>
-
-    <HarmonyVersion>2.0.4</HarmonyVersion>
-    <YamlDotNetVersion>9.1.4</YamlDotNetVersion>
-    <StyleCopVersion>1.1.118</StyleCopVersion>
-    <SemanticVersioningVersion>1.3.0</SemanticVersioningVersion>
 
     <Copyright>Copyright © $(Authors) 2020 - $([System.DateTime]::Now.ToString("yyyy"))</Copyright>
     <RepositoryType>Git</RepositoryType>

--- a/Exiled.API/Exiled.API.csproj
+++ b/Exiled.API/Exiled.API.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopVersion)" IncludeAssets="All" PrivateAssets="All" />
     <PackageReference Include="YamlDotNet" Version="$(YamlDotNetVersion)" />
+    <PackageReference Include="Ben.Demystifier" Version="$(BenDemystifierVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -5,12 +5,11 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System.Diagnostics;
-
 namespace Exiled.API.Features
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using System.Reflection;
     using System.Runtime.CompilerServices;

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -5,6 +5,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System.Diagnostics;
+
 namespace Exiled.API.Features
 {
     using System;
@@ -504,7 +506,7 @@ namespace Exiled.API.Features
                 }
                 catch (Exception exception)
                 {
-                    Log.Error($"{nameof(Scale)} error: {exception}");
+                    Log.Error($"{nameof(Scale)}:\n{exception.ToStringDemystified()}");
                 }
             }
         }
@@ -1058,7 +1060,7 @@ namespace Exiled.API.Features
             }
             catch (Exception exception)
             {
-                Log.Error($"{typeof(Player).FullName}.{nameof(Get)} error: {exception}");
+                Log.Error($"{typeof(Player).FullName}.{nameof(Get)}: {exception.ToStringDemystified()}");
                 return null;
             }
         }

--- a/Exiled.CustomItems/API/Components/CollisionHandler.cs
+++ b/Exiled.CustomItems/API/Components/CollisionHandler.cs
@@ -5,6 +5,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System.Diagnostics;
+
 namespace Exiled.CustomItems.API.Components
 {
     using System;
@@ -52,7 +54,7 @@ namespace Exiled.CustomItems.API.Components
             }
             catch (Exception exception)
             {
-                Log.Error($"{nameof(OnCollisionEnter)} error:\n{exception}");
+                Log.Error($"{nameof(OnCollisionEnter)} error:\n{exception.ToStringDemystified()}");
             }
         }
     }

--- a/Exiled.CustomItems/API/Components/CollisionHandler.cs
+++ b/Exiled.CustomItems/API/Components/CollisionHandler.cs
@@ -5,11 +5,10 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System.Diagnostics;
-
 namespace Exiled.CustomItems.API.Components
 {
     using System;
+    using System.Diagnostics;
 
     using Exiled.API.Features;
 

--- a/Exiled.CustomItems/Exiled.CustomItems.csproj
+++ b/Exiled.CustomItems/Exiled.CustomItems.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopVersion)" IncludeAssets="All" PrivateAssets="All" />
     <PackageReference Include="YamlDotNet" Version="$(YamlDotNetVersion)" />
     <PackageReference Include="Lib.Harmony" Version="$(HarmonyVersion)" />
+    <PackageReference Include="Ben.Demystifier" Version="$(BenDemystifierVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Exiled.Events/Events.cs
+++ b/Exiled.Events/Events.cs
@@ -5,12 +5,11 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System.Diagnostics;
-
 namespace Exiled.Events
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Reflection;
 
     using Exiled.API.Enums;

--- a/Exiled.Events/Events.cs
+++ b/Exiled.Events/Events.cs
@@ -5,6 +5,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System.Diagnostics;
+
 namespace Exiled.Events
 {
     using System;
@@ -183,7 +185,7 @@ namespace Exiled.Events
             }
             catch (Exception exception)
             {
-                Log.Error($"Patching by attributes failed!\n{exception}");
+                Log.Error($"Patching by attributes failed!\n{exception.ToStringDemystified()}");
             }
         }
 
@@ -197,7 +199,7 @@ namespace Exiled.Events
             }
             catch (Exception e)
             {
-                Log.Error($"Patching in the inner types failed!\n{e}");
+                Log.Error($"Patching in the inner types failed!\n{e.ToStringDemystified()}");
             }
         }
 

--- a/Exiled.Events/Exiled.Events.csproj
+++ b/Exiled.Events/Exiled.Events.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopVersion)" IncludeAssets="All" PrivateAssets="All" />
     <PackageReference Include="YamlDotNet" Version="$(YamlDotNetVersion)" />
     <PackageReference Include="Lib.Harmony" Version="$(HarmonyVersion)" />
+    <PackageReference Include="Ben.Demystifier" Version="$(BenDemystifierVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Exiled.Events/Extensions/Event.cs
+++ b/Exiled.Events/Extensions/Event.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Extensions
 {
     using System;
+    using System.Diagnostics;
 
     using Exiled.API.Features;
 
@@ -70,7 +71,7 @@ namespace Exiled.Events.Extensions
         private static void LogException(Exception ex, string methodName, string sourceClassName, string eventName)
         {
             Log.Error($"Method \"{methodName}\" of the class \"{sourceClassName}\" caused an exception when handling the event \"{eventName}\"");
-            Log.Error(ex);
+            Log.Error(ex.ToStringDemystified());
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
+++ b/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.Patches.Events.Map
 #pragma warning disable SA1313
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
 
     using CustomPlayerEffects;
 
@@ -66,7 +67,7 @@ namespace Exiled.Events.Patches.Events.Map
             }
             catch (Exception exception)
             {
-                Log.Error($"{typeof(ExplodingFlashGrenade).FullName}:\n{exception}");
+                Log.Error($"{typeof(ExplodingFlashGrenade).FullName}:\n{exception.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/BanningAndKicking.cs
+++ b/Exiled.Events/Patches/Events/Player/BanningAndKicking.cs
@@ -159,7 +159,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.BanningAndKicking: {e}\n{e.ToStringDemystified()}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.BanningAndKicking:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/BanningAndKicking.cs
+++ b/Exiled.Events/Patches/Events/Player/BanningAndKicking.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -158,7 +159,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.BanningAndKicking: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.BanningAndKicking: {e}\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/ChangingGroup.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingGroup.cs
@@ -35,7 +35,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingGrounp: {e}\n{e.ToStringDemystified()}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingGrounp:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/ChangingGroup.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingGroup.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -34,7 +35,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingGrounp: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingGrounp: {e}\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/ChangingIntercomMuteStatus.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingIntercomMuteStatus.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -48,7 +49,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"{typeof(ChangingIntercomMuteStatus).FullName}.{nameof(Prefix)}:\n{e}");
+                Exiled.API.Features.Log.Error($"{typeof(ChangingIntercomMuteStatus).FullName}.{nameof(Prefix)}:\n{e.ToStringDemystified()}");
                 return true;
             }
         }

--- a/Exiled.Events/Patches/Events/Player/ChangingItem.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingItem.cs
@@ -57,7 +57,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingItem: {e}\n{e.ToStringDemystified()}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingItem:\n{e.ToStringDemystified()}");
             }
         }
     }

--- a/Exiled.Events/Patches/Events/Player/ChangingItem.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingItem.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -56,7 +57,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingItem: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingItem: {e}\n{e.ToStringDemystified()}");
             }
         }
     }

--- a/Exiled.Events/Patches/Events/Player/ChangingMuteStatus.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingMuteStatus.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -48,7 +49,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"{typeof(ChangingMuteStatus).FullName}.{nameof(Prefix)}:\n{e}");
+                Exiled.API.Features.Log.Error($"{typeof(ChangingMuteStatus).FullName}.{nameof(Prefix)}:\n{e.ToStringDemystified()}");
                 return true;
             }
         }

--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.Patches.Events.Player
 #pragma warning disable SA1313
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -166,7 +167,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingRole: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingRole: {e}\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -167,7 +167,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingRole: {e}\n{e.ToStringDemystified()}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingRole:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/DequippedMedicalItem.cs
+++ b/Exiled.Events/Patches/Events/Player/DequippedMedicalItem.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -35,7 +36,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"{typeof(DequippedMedicalItem).FullName}:\n{e}");
+                Exiled.API.Features.Log.Error($"{typeof(DequippedMedicalItem).FullName}:\n{e.ToStringDemystified()}");
             }
         }
     }

--- a/Exiled.Events/Patches/Events/Player/Destroying.cs
+++ b/Exiled.Events/Patches/Events/Player/Destroying.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Patches.Events.Player
 {
     using System;
+    using System.Diagnostics;
 
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
@@ -39,7 +40,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception exception)
             {
-                Log.Error($"{typeof(Destroying).FullName}.{nameof(Prefix)}:\n{exception}");
+                Log.Error($"{typeof(Destroying).FullName}.{nameof(Prefix)}:\n{exception.ToStringDemystified()}");
             }
         }
     }

--- a/Exiled.Events/Patches/Events/Player/EnteringFemurBreaker.cs
+++ b/Exiled.Events/Patches/Events/Player/EnteringFemurBreaker.cs
@@ -62,7 +62,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.EnteringFemurBreaker: {e}\n{e.ToStringDemystified()}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.EnteringFemurBreaker:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/EnteringFemurBreaker.cs
+++ b/Exiled.Events/Patches/Events/Player/EnteringFemurBreaker.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -61,7 +62,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.EnteringFemurBreaker: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.EnteringFemurBreaker: {e}\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/Hurting.cs
+++ b/Exiled.Events/Patches/Events/Player/Hurting.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -73,7 +74,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.Hurting: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.Hurting: {e}\n{e.ToStringDemystified()}");
                 return true;
             }
         }

--- a/Exiled.Events/Patches/Events/Player/Hurting.cs
+++ b/Exiled.Events/Patches/Events/Player/Hurting.cs
@@ -74,7 +74,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.Hurting: {e}\n{e.ToStringDemystified()}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.Hurting:\n{e.ToStringDemystified()}");
                 return true;
             }
         }

--- a/Exiled.Events/Patches/Events/Player/InsertingGeneratorTablet.cs
+++ b/Exiled.Events/Patches/Events/Player/InsertingGeneratorTablet.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -104,7 +105,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception exception)
             {
-                API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.InsertingGeneratorTablet: {exception}\n{exception.StackTrace}");
+                API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.InsertingGeneratorTablet:\n{exception.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/InteractingDoor.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingDoor.cs
@@ -13,6 +13,7 @@ namespace Exiled.Events.Patches.Events.Player
 #pragma warning disable SA1513
 #pragma warning disable SA1512
     using System;
+    using System.Diagnostics;
 
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
@@ -110,7 +111,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception ex)
             {
-                Log.Error($"{typeof(InteractingDoor).FullName}.{nameof(Prefix)}:\n{ex}");
+                Log.Error($"{typeof(InteractingDoor).FullName}.{nameof(Prefix)}:\n{ex.ToStringDemystified()}");
                 return true;
             }
         }

--- a/Exiled.Events/Patches/Events/Player/InteractingElevator.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingElevator.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
 
@@ -56,7 +57,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.InteractingElevator:\n{e}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.InteractingElevator:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/InteractingLocker.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingLocker.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -95,7 +96,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.InteractingLocker:\n{e}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.InteractingLocker:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/IntercomSpeaking.cs
+++ b/Exiled.Events/Patches/Events/Player/IntercomSpeaking.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -56,7 +57,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.IntercomSpeaking: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.IntercomSpeaking:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/ItemDrop.cs
+++ b/Exiled.Events/Patches/Events/Player/ItemDrop.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -57,7 +58,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ItemDrop: {e}\n{e.StackTrace}");
+                API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ItemDrop:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/Joined.cs
+++ b/Exiled.Events/Patches/Events/Player/Joined.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.Patches.Events.Player
 #pragma warning disable SA1313
 #pragma warning disable SA1600 // Elements should be documented
     using System;
+    using System.Diagnostics;
 
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
@@ -59,7 +60,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception exception)
             {
-                Log.Error($"{typeof(Joined).FullName}:\n{exception}");
+                Log.Error($"{typeof(Joined).FullName}:\n{exception.ToStringDemystified()}");
             }
         }
     }

--- a/Exiled.Events/Patches/Events/Player/Kicked.cs
+++ b/Exiled.Events/Patches/Events/Player/Kicked.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Patches.Events.Player
 {
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -40,7 +41,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.Kicked: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.Kicked:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/Left.cs
+++ b/Exiled.Events/Patches/Events/Player/Left.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
@@ -42,7 +43,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception exception)
             {
-                Log.Error($"{typeof(Left).FullName}.{nameof(Prefix)}:\n{exception}");
+                Log.Error($"{typeof(Left).FullName}.{nameof(Prefix)}:\n{exception.ToStringDemystified()}");
             }
         }
     }

--- a/Exiled.Events/Patches/Events/Player/PickingUpAmmo.cs
+++ b/Exiled.Events/Patches/Events/Player/PickingUpAmmo.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
@@ -40,7 +41,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception exception)
             {
-                Log.Error($"{typeof(PickingUpAmmo).FullName}\n{exception}");
+                Log.Error($"{typeof(PickingUpAmmo).FullName}\n{exception.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/PickingUpItem.cs
+++ b/Exiled.Events/Patches/Events/Player/PickingUpItem.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
@@ -40,7 +41,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception exception)
             {
-                Log.Error($"{typeof(PickingUpItem).FullName}\n{exception}");
+                Log.Error($"{typeof(PickingUpItem).FullName}\n{exception.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/ReceivingStatusEffect.cs
+++ b/Exiled.Events/Patches/Events/Player/ReceivingStatusEffect.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using CustomPlayerEffects;
 
@@ -53,7 +54,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Log.Error($"RecievingEffect: {e}");
+                Log.Error($"RecievingEffect:\n{e.ToStringDemystified()}");
                 return true;
             }
         }

--- a/Exiled.Events/Patches/Events/Player/ReloadingWeapon.cs
+++ b/Exiled.Events/Patches/Events/Player/ReloadingWeapon.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -46,7 +47,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ReloadingWeapon: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ReloadingWeapon:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/RemovingHandcuffs.cs
+++ b/Exiled.Events/Patches/Events/Player/RemovingHandcuffs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -48,7 +49,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.RemovingHandcuffs: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.RemovingHandcuffs:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/RemovingHandcuffsByTeammate.cs
+++ b/Exiled.Events/Patches/Events/Player/RemovingHandcuffsByTeammate.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -49,7 +50,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.RemovingHandcuffsByTeammate: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.RemovingHandcuffsByTeammate:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/Spawning.cs
+++ b/Exiled.Events/Patches/Events/Player/Spawning.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -160,7 +161,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"({typeof(Spawning).FullName}.{nameof(Prefix)}):\n{e}");
+                Exiled.API.Features.Log.Error($"({typeof(Spawning).FullName}.{nameof(Prefix)}):\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/SpawningRagdoll.cs
+++ b/Exiled.Events/Patches/Events/Player/SpawningRagdoll.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -47,7 +48,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.SpawningRagdoll: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.SpawningRagdoll:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/StoppingMedicalItem.cs
+++ b/Exiled.Events/Patches/Events/Player/StoppingMedicalItem.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -45,7 +46,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.StoppingMedicalItem: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.StoppingMedicalItem:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/SyncingData.cs
+++ b/Exiled.Events/Patches/Events/Player/SyncingData.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -39,7 +40,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.SyncingData: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.SyncingData:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/ThrowingGrenade.cs
+++ b/Exiled.Events/Patches/Events/Player/ThrowingGrenade.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.API.Enums;
     using Exiled.Events.EventArgs;
@@ -41,7 +42,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ThrowingGrenade: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ThrowingGrenade:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/TriggeringTesla.cs
+++ b/Exiled.Events/Patches/Events/Player/TriggeringTesla.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.Patches.Events.Player
 #pragma warning disable SA1313
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
@@ -50,7 +51,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.TriggeringTesla: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.TriggeringTesla:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/UsingMedicalItem.cs
+++ b/Exiled.Events/Patches/Events/Player/UsingMedicalItem.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1313
     using System;
+    using System.Diagnostics;
 
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
@@ -55,7 +56,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception exception)
             {
-                Log.Error($"Exiled.Events.Patches.Events.Player.UsingMedicalItem: {exception}\n{exception.StackTrace}");
+                Log.Error($"Exiled.Events.Patches.Events.Player.UsingMedicalItem:\n{exception.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/Verified.cs
+++ b/Exiled.Events/Patches/Events/Player/Verified.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Player
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Reflection;
     using System.Reflection.Emit;
 
@@ -76,7 +77,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception ex)
             {
-                Log.Error($"{typeof(Verified).FullName}.{nameof(CallEvent)}:\n{ex}");
+                Log.Error($"{typeof(Verified).FullName}.{nameof(CallEvent)}:\n{ex.ToStringDemystified()}");
             }
         }
     }

--- a/Exiled.Events/Patches/Events/Server/RespawningTeam.cs
+++ b/Exiled.Events/Patches/Events/Server/RespawningTeam.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.Patches.Events.Server
 #pragma warning disable SA1313
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
 
     using Exiled.Events.EventArgs;
@@ -125,7 +126,7 @@ namespace Exiled.Events.Patches.Events.Server
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Server.RespawningTeam: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Server.RespawningTeam:\n{e.ToStringDemystified()}");
 
                 return true;
             }

--- a/Exiled.Loader/ConfigManager.cs
+++ b/Exiled.Loader/ConfigManager.cs
@@ -9,6 +9,7 @@ namespace Exiled.Loader
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using Exiled.API.Extensions;
     using Exiled.API.Features;
@@ -82,7 +83,7 @@ namespace Exiled.Loader
                         }
                         catch (YamlException yamlException)
                         {
-                            Log.Error($"{plugin.Name} configs could not be loaded, some of them are in a wrong format, default configs will be loaded instead! {yamlException}");
+                            Log.Error($"{plugin.Name} configs could not be loaded, some of them are in a wrong format, default configs will be loaded instead!\n{yamlException.ToStringDemystified()}");
 
                             deserializedConfigs.Add(plugin.Prefix, plugin.Config);
                         }
@@ -95,7 +96,7 @@ namespace Exiled.Loader
             }
             catch (Exception exception)
             {
-                Log.Error($"An error has occurred while loading configs! {exception}");
+                Log.Error($"An error has occurred while loading configs!\n{exception.ToStringDemystified()}");
 
                 return null;
             }
@@ -122,7 +123,7 @@ namespace Exiled.Loader
             }
             catch (Exception exception)
             {
-                Log.Error($"An error has occurred while saving configs to {Paths.Config} path: {exception}");
+                Log.Error($"An error has occurred while saving configs to {Paths.Config} path:\n{exception.ToStringDemystified()}");
 
                 return false;
             }
@@ -148,7 +149,7 @@ namespace Exiled.Loader
             }
             catch (YamlException yamlException)
             {
-                Log.Error($"An error has occurred while serializing configs: {yamlException}");
+                Log.Error($"An error has occurred while serializing configs:\n{yamlException.ToStringDemystified()}");
 
                 return false;
             }
@@ -167,7 +168,7 @@ namespace Exiled.Loader
             }
             catch (Exception exception)
             {
-                Log.Error($"An error has occurred while reading configs from {Paths.Config} path: {exception}");
+                Log.Error($"An error has occurred while reading configs from {Paths.Config} path:\n{exception.ToStringDemystified()}");
             }
 
             return string.Empty;

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -120,8 +120,7 @@ namespace Exiled.Loader
         /// </summary>
         public static IDeserializer Deserializer { get; } = new DeserializerBuilder()
             .WithNamingConvention(UnderscoredNamingConvention.Instance)
-            .WithNodeDeserializer(inner => new ValidatingNodeDeserializer(inner),
-                deserializer => deserializer.InsteadOf<ObjectNodeDeserializer>())
+            .WithNodeDeserializer(inner => new ValidatingNodeDeserializer(inner), deserializer => deserializer.InsteadOf<ObjectNodeDeserializer>())
             .IgnoreFields()
             .IgnoreUnmatchedProperties()
             .Build();

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -39,15 +39,11 @@ namespace Exiled.Loader
             Log.Warn("You are running a public beta build. It is not compatible with another version of the game.");
 #endif
 
-            Log.SendRaw(
-                $"{Assembly.GetExecutingAssembly().GetName().Name} - Version {Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion}",
-                ConsoleColor.DarkRed);
+            Log.SendRaw($"{Assembly.GetExecutingAssembly().GetName().Name} - Version {Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion}", ConsoleColor.DarkRed);
 
             if (MultiAdminFeatures.MultiAdminUsed)
             {
-                Log.SendRaw(
-                    $"Detected MultiAdmin! Version: {MultiAdminFeatures.MultiAdminVersion} | Features: {MultiAdminFeatures.MultiAdminModFeatures}",
-                    ConsoleColor.Cyan);
+                Log.SendRaw($"Detected MultiAdmin! Version: {MultiAdminFeatures.MultiAdminVersion} | Features: {MultiAdminFeatures.MultiAdminModFeatures}", ConsoleColor.Cyan);
                 MultiAdminFeatures.CallEvent(MultiAdminFeatures.EventType.SERVER_START);
                 MultiAdminFeatures.CallAction(MultiAdminFeatures.ActionType.SET_SUPPORTED_FEATURES, MultiAdminFeatures.ModFeatures.All);
             }
@@ -71,8 +67,7 @@ namespace Exiled.Loader
         /// <summary>
         /// Gets the plugins list.
         /// </summary>
-        public static SortedSet<IPlugin<IConfig>> Plugins { get; } =
-            new SortedSet<IPlugin<IConfig>>(PluginPriorityComparer.Instance);
+        public static SortedSet<IPlugin<IConfig>> Plugins { get; } = new SortedSet<IPlugin<IConfig>>(PluginPriorityComparer.Instance);
 
         /// <summary>
         /// Gets a dictionary containing the file paths of assemblies.
@@ -97,8 +92,7 @@ namespace Exiled.Loader
         /// <summary>
         /// Gets a value indicating whether the debug should be shown or not.
         /// </summary>
-        public static bool ShouldDebugBeShown => Config.Environment == EnvironmentType.Testing ||
-                                                 Config.Environment == EnvironmentType.Development;
+        public static bool ShouldDebugBeShown => Config.Environment == EnvironmentType.Testing || Config.Environment == EnvironmentType.Development;
 
         /// <summary>
         /// Gets plugin dependencies.
@@ -221,8 +215,7 @@ namespace Exiled.Loader
             {
                 foreach (Type type in assembly.GetTypes().Where(type => !type.IsAbstract && !type.IsInterface))
                 {
-                    if (!type.BaseType.IsGenericType || (type.BaseType.GetGenericTypeDefinition() != typeof(Plugin<>) &&
-                                                         type.BaseType.GetGenericTypeDefinition() != typeof(Plugin<,>)))
+                    if (!type.BaseType.IsGenericType || (type.BaseType.GetGenericTypeDefinition() != typeof(Plugin<>) && type.BaseType.GetGenericTypeDefinition() != typeof(Plugin<,>)))
                     {
                         Log.Debug($"\"{type.FullName}\" does not inherit from Plugin<TConfig>, skipping.", ShouldDebugBeShown);
                         continue;
@@ -241,14 +234,9 @@ namespace Exiled.Loader
                     }
                     else
                     {
-                        Log.Debug(
-                            $"Constructor wasn't found, searching for a property with the {type.FullName} type...",
-                            ShouldDebugBeShown);
+                        Log.Debug($"Constructor wasn't found, searching for a property with the {type.FullName} type...", ShouldDebugBeShown);
 
-                        var value = Array
-                            .Find(
-                                type.GetProperties(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public),
-                                property => property.PropertyType == type)?.GetValue(null);
+                        var value = Array.Find(type.GetProperties(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public), property => property.PropertyType == type)?.GetValue(null);
 
                         if (value != null)
                             plugin = value as IPlugin<IConfig>;
@@ -256,8 +244,7 @@ namespace Exiled.Loader
 
                     if (plugin == null)
                     {
-                        Log.Error(
-                            $"{type.FullName} is a valid plugin, but it cannot be instantiated! It either doesn't have a public default constructor without any arguments or a static property of the {type.FullName} type!");
+                        Log.Error($"{type.FullName} is a valid plugin, but it cannot be instantiated! It either doesn't have a public default constructor without any arguments or a static property of the {type.FullName} type!");
 
                         continue;
                     }
@@ -272,8 +259,7 @@ namespace Exiled.Loader
             }
             catch (Exception exception)
             {
-                Log.Error(
-                    $"Error while initializing plugin {assembly.GetName().Name} (at {assembly.GetPath()})!\n{exception.ToStringDemystified()}");
+                Log.Error($"Error while initializing plugin {assembly.GetName().Name} (at {assembly.GetPath()})!\n{exception.ToStringDemystified()}");
             }
 
             return null;
@@ -296,8 +282,7 @@ namespace Exiled.Loader
                 }
                 catch (Exception exception)
                 {
-                    Log.Error(
-                        $"Plugin \"{plugin.Name}\" threw an exception while enabling:\n{exception.ToStringDemystified()}");
+                    Log.Error($"Plugin \"{plugin.Name}\" threw an exception while enabling:\n{exception.ToStringDemystified()}");
                 }
             }
         }
@@ -321,8 +306,7 @@ namespace Exiled.Loader
                 }
                 catch (Exception exception)
                 {
-                    Log.Error(
-                        $"Plugin \"{plugin.Name}\" threw an exception while reloading:\n{exception.ToStringDemystified()}");
+                    Log.Error($"Plugin \"{plugin.Name}\" threw an exception while reloading:\n{exception.ToStringDemystified()}");
                 }
             }
 
@@ -350,8 +334,7 @@ namespace Exiled.Loader
                 }
                 catch (Exception exception)
                 {
-                    Log.Error(
-                        $"Plugin \"{plugin.Name}\" threw an exception while disabling:\n{exception.ToStringDemystified()}");
+                    Log.Error($"Plugin \"{plugin.Name}\" threw an exception while disabling:\n{exception.ToStringDemystified()}");
                 }
             }
         }
@@ -369,16 +352,15 @@ namespace Exiled.Loader
                 // Exiled is outdated
                 if (requiredVersion.Major > actualVersion.Major)
                 {
-                    Log.Error(
-                        $"You're running an older version of Exiled ({Version.ToString(3)})! {plugin.Name} won't be loaded! " +
-                        $"Required version to load it: {plugin.RequiredExiledVersion.ToString(3)}");
+                    Log.Error($"You're running an older version of Exiled ({Version.ToString(3)})! {plugin.Name} won't be loaded! " +
+                              $"Required version to load it: {plugin.RequiredExiledVersion.ToString(3)}");
 
                     return true;
                 }
                 else if (requiredVersion.Major < actualVersion.Major && !Config.ShouldLoadOutdatedPlugins)
                 {
                     Log.Error($"You're running an older version of {plugin.Name} ({plugin.Version.ToString(3)})! " +
-                              $"Its Required Major version is {requiredVersion.Major}, but excepted {actualVersion.Major}. ");
+                              $"Its Required Major version is {requiredVersion.Major}, but excepted {actualVersion.Major}.");
 
                     return true;
                 }

--- a/Exiled.Loader/TranslationManager.cs
+++ b/Exiled.Loader/TranslationManager.cs
@@ -9,6 +9,7 @@ namespace Exiled.Loader
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
 
     using Exiled.API.Extensions;
@@ -57,7 +58,7 @@ namespace Exiled.Loader
                         }
                         catch (YamlException yamlException)
                         {
-                            Log.Error($"{plugin.Name} translations could not be loaded, some of them are in a wrong format, default translations will be loaded instead! {yamlException}");
+                            Log.Error($"{plugin.Name} translations could not be loaded, some of them are in a wrong format, default translations will be loaded instead!\n{yamlException.ToStringDemystified()}");
 
                             deserializedTranslations.Add(plugin.Prefix, plugin.InternalTranslation);
                         }
@@ -70,7 +71,7 @@ namespace Exiled.Loader
             }
             catch (Exception exception)
             {
-                Log.Error($"An error has occurred while loading translations! {exception}");
+                Log.Error($"An error has occurred while loading translations!\n{exception.ToStringDemystified()}");
 
                 return null;
             }
@@ -97,7 +98,7 @@ namespace Exiled.Loader
             }
             catch (Exception exception)
             {
-                Log.Error($"An error has occurred while saving translations to {Paths.Translations} path: {exception}");
+                Log.Error($"An error has occurred while saving translations to {Paths.Translations} path:\n{exception.ToStringDemystified()}");
 
                 return false;
             }
@@ -119,7 +120,7 @@ namespace Exiled.Loader
             }
             catch (YamlException yamlException)
             {
-                Log.Error($"An error has occurred while serializing translations: {yamlException}");
+                Log.Error($"An error has occurred while serializing translations:\n{yamlException.ToStringDemystified()}");
 
                 return false;
             }
@@ -138,7 +139,7 @@ namespace Exiled.Loader
             }
             catch (Exception exception)
             {
-                Log.Error($"An error has occurred while reading translations from {Paths.Translations} path: {exception}");
+                Log.Error($"An error has occurred while reading translations from {Paths.Translations} path:\n{exception.ToStringDemystified()}");
             }
 
             return string.Empty;

--- a/Exiled.Permissions/Exiled.Permissions.csproj
+++ b/Exiled.Permissions/Exiled.Permissions.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopVersion)" IncludeAssets="All" PrivateAssets="All" />
     <PackageReference Include="YamlDotNet" Version="$(YamlDotNetVersion)" />
+    <PackageReference Include="Ben.Demystifier" Version="$(BenDemystifierVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Exiled.Permissions/Extensions/Permissions.cs
+++ b/Exiled.Permissions/Extensions/Permissions.cs
@@ -9,6 +9,7 @@ namespace Exiled.Permissions.Extensions
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -117,7 +118,7 @@ namespace Exiled.Permissions.Extensions
                     catch (YamlException exception)
                     {
                         Log.Error($"Unable to parse permission config for: {group.Key}.\n{exception.Message}.\nEnable debug to see stacktrace.");
-                        Log.Debug($"{exception.Message}\n{exception.StackTrace}");
+                        Log.Debug($"{exception.ToStringDemystified()}");
                     }
                 }
 
@@ -125,7 +126,7 @@ namespace Exiled.Permissions.Extensions
             }
             catch (Exception e)
             {
-                Log.Error($"Unable to parse permission config:\n{e}.\nMake sure your config file is setup correctly, every group defined must include inheritance and permissions values, even if they are empty.");
+                Log.Error($"Unable to parse permission config:\n{e.ToStringDemystified()}.\nMake sure your config file is setup correctly, every group defined must include inheritance and permissions values, even if they are empty.");
             }
 
             foreach (KeyValuePair<string, Group> group in Groups.Reverse())
@@ -144,7 +145,7 @@ namespace Exiled.Permissions.Extensions
                 catch (Exception e)
                 {
                     Log.Error($"Failed to load permissions/inheritance for: {group.Key}.\n{e.Message}.\nMake sure your config file is setup correctly, every group defined must include inheritance and permissions values, even if they are empty.");
-                    Log.Debug($"{e}", Instance.Config.ShouldDebugBeShown);
+                    Log.Debug($"{e.ToStringDemystified()}", Instance.Config.ShouldDebugBeShown);
                 }
             }
         }

--- a/build.ps1
+++ b/build.ps1
@@ -35,7 +35,7 @@ function CheckLastOperationStatus {
 
 function GetSolutionVersion {
     [XML]$PropsFile = Get-Content Exiled.props
-    $Version = $PropsFile.Project.PropertyGroup[2].Version
+    $Version = $PropsFile.Project.PropertyGroup[3].Version
     $Version = $Version.'#text'.Trim()
     return $Version
 }


### PR DESCRIPTION
Another bulky non-tested PR...

I know many of us (probably everyone except @sanyae2439 😅) don't fuck up with mono & dnSpy to make debugging a dll easier.
This PR doesn't include a debugger but makes all possible exceptions graceful (see https://github.com/benaadams/Ben.Demystifier#make-error-logs-more-productive).

Not sure if this will help anyone except server owners with erroring plugins by reducing the size of the logs (probably). 