### PR TITLE
Add ConfigVector3

### DIFF
--- a/Exiled.API/Features/ConfigVector3.cs
+++ b/Exiled.API/Features/ConfigVector3.cs
@@ -1,0 +1,76 @@
+// -----------------------------------------------------------------------
+// <copyright file="ConfigVector3.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Features
+{
+    using UnityEngine;
+
+    using YamlDotNet.Serialization;
+
+    /// <summary>
+    /// A helper struct used for storing Vector3s in config.
+    /// </summary>
+    public struct ConfigVector3 
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigVector3"/> struct.
+        /// </summary>
+        /// <param name="x">The x coordinate.</param>
+        /// <param name="y">The y coordinate.</param>
+        /// <param name="z">The z coordinate.</param>
+        public Badge(float x, float y, float z)
+        {
+            X = x;
+            Y = y;
+            Z = z;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigVector3"/> struct.
+        /// </summary>
+        /// <param name="vector">The <see cref="Vector3"/> containing the coordinates.</param>
+        public Badge(Vector3 vector)
+        {
+            X = vector.x;
+            Y = vector.y;
+            Z = vector.z;
+        }
+
+        private Vector3 _value = default;
+
+        /// <summary>
+        /// Gets the x value of the <see cref="Vector3"/>.
+        /// </summary>
+        public float X {get; set;}
+
+        /// <summary>
+        /// Gets the y value of the <see cref="Vector3"/>.
+        /// </summary>
+        public float Y {get; set;}
+
+        /// <summary>
+        /// Gets the z value of the <see cref="Vector3"/>.
+        /// </summary>
+        public float Z {get; set;}
+
+        /// <summary>
+        /// Gets the <see cref="Vector3"/>.
+        /// </summary>
+        [JsonIgnore]
+        public Vector3 Value 
+        {
+            get 
+            {
+                if(_value == default) {
+                    _value = new Vector3(X, Y, Z);
+                }
+
+                return _value;
+            }
+        }
+    }
+}

--- a/Exiled.API/Features/ConfigVector3.cs
+++ b/Exiled.API/Features/ConfigVector3.cs
@@ -14,8 +14,10 @@ namespace Exiled.API.Features
     /// <summary>
     /// A helper class used for storing <see cref="Vector3"/>s in config.
     /// </summary>
-    public class ConfigVector3 
+    public class ConfigVector3
     {
+        private Vector3 value = default;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigVector3"/> class.
         /// </summary>
@@ -40,34 +42,31 @@ namespace Exiled.API.Features
             Z = vector.z;
         }
 
-        private Vector3 _value = default;
-
         /// <summary>
         /// Gets the x value of the <see cref="Vector3"/>.
         /// </summary>
-        public float X {get; set;}
+        public float X { get; private set; }
 
         /// <summary>
         /// Gets the y value of the <see cref="Vector3"/>.
         /// </summary>
-        public float Y {get; set;}
+        public float Y { get; private set; }
 
         /// <summary>
         /// Gets the z value of the <see cref="Vector3"/>.
         /// </summary>
-        public float Z {get; set;}
+        public float Z { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="Vector3"/>.
         /// </summary>
         [YamlIgnore]
-        public Vector3 Value 
+        public Vector3 Value
         {
-            get 
+            get
             {
-                if(_value == default) {
+                if (_value == default)
                     _value = new Vector3(X, Y, Z);
-                }
 
                 return _value;
             }

--- a/Exiled.API/Features/ConfigVector3.cs
+++ b/Exiled.API/Features/ConfigVector3.cs
@@ -12,17 +12,17 @@ namespace Exiled.API.Features
     using YamlDotNet.Serialization;
 
     /// <summary>
-    /// A helper struct used for storing Vector3s in config.
+    /// A helper class used for storing <see cref="Vector3"/>s in config.
     /// </summary>
-    public struct ConfigVector3 
+    public class ConfigVector3 
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigVector3"/> struct.
+        /// Initializes a new instance of the <see cref="ConfigVector3"/> class.
         /// </summary>
         /// <param name="x">The x coordinate.</param>
         /// <param name="y">The y coordinate.</param>
         /// <param name="z">The z coordinate.</param>
-        public Badge(float x, float y, float z)
+        public ConfigVector3(float x, float y, float z)
         {
             X = x;
             Y = y;
@@ -30,10 +30,10 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigVector3"/> struct.
+        /// Initializes a new instance of the <see cref="ConfigVector3"/> class.
         /// </summary>
         /// <param name="vector">The <see cref="Vector3"/> containing the coordinates.</param>
-        public Badge(Vector3 vector)
+        public ConfigVector3(Vector3 vector)
         {
             X = vector.x;
             Y = vector.y;
@@ -60,7 +60,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets the <see cref="Vector3"/>.
         /// </summary>
-        [JsonIgnore]
+        [YamlIgnore]
         public Vector3 Value 
         {
             get 

--- a/Exiled.API/Features/ConfigVector3.cs
+++ b/Exiled.API/Features/ConfigVector3.cs
@@ -65,10 +65,10 @@ namespace Exiled.API.Features
         {
             get
             {
-                if (_value == default)
-                    _value = new Vector3(X, Y, Z);
+                if (value == default)
+                    value = new Vector3(X, Y, Z);
 
-                return _value;
+                return value;
             }
         }
     }

--- a/Exiled.CustomItems/API/Extensions.cs
+++ b/Exiled.CustomItems/API/Extensions.cs
@@ -72,13 +72,6 @@ namespace Exiled.CustomItems.API
         }
 
         /// <summary>
-        /// Converts a <see cref="Vector3"/> to a <see cref="Vector"/>.
-        /// </summary>
-        /// <param name="vector3">The <see cref="Vector3"/> to be converted.</param>
-        /// <returns>Returns the <see cref="Vector"/>.</returns>
-        public static Vector ToVector(this Vector3 vector3) => new Vector(vector3.x, vector3.y, vector3.z);
-
-        /// <summary>
         /// Reloads the current <see cref="Player"/>'s weapon.
         /// </summary>
         /// <param name="player">The <see cref="Player"/> who's weapon should be reloaded.</param>

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -367,7 +367,7 @@ namespace Exiled.CustomItems.API.Features
 
                 spawned++;
 
-                Spawn(spawnPoint.Position.ToVector3);
+                Spawn(spawnPoint.Position.Value);
 
                 Log.Debug($"Spawned {Name} at {spawnPoint.Position} ({spawnPoint.Name})", Instance.Config.Debug);
             }

--- a/Exiled.CustomItems/API/Features/Vector.cs
+++ b/Exiled.CustomItems/API/Features/Vector.cs
@@ -16,6 +16,7 @@ namespace Exiled.CustomItems.API.Features
     /// <summary>
     /// A yaml-serializable vector object.
     /// </summary>
+    [Obsolete("Use EXILED.API.Features.ConfigVector3.", true)]
     public struct Vector
     {
         /// <summary>

--- a/Exiled.CustomItems/API/Spawn/DynamicSpawnPoint.cs
+++ b/Exiled.CustomItems/API/Spawn/DynamicSpawnPoint.cs
@@ -39,7 +39,7 @@ namespace Exiled.CustomItems.API.Spawn
         [YamlIgnore]
         public override ConfigVector3 Position
         {
-            get => Location.GetPosition().ToVector();
+            get => new ConfigVector3(Location.GetPosition());
             set => throw new InvalidOperationException("You cannot change the spawn vector of a dynamic spawn location.");
         }
     }

--- a/Exiled.CustomItems/API/Spawn/DynamicSpawnPoint.cs
+++ b/Exiled.CustomItems/API/Spawn/DynamicSpawnPoint.cs
@@ -9,6 +9,7 @@ namespace Exiled.CustomItems.API.Spawn
 {
     using System;
 
+    using Exiled.API.Features;
     using Exiled.CustomItems.API.Features;
 
     using YamlDotNet.Serialization;
@@ -36,7 +37,7 @@ namespace Exiled.CustomItems.API.Spawn
 
         /// <inheritdoc/>
         [YamlIgnore]
-        public override Vector Position
+        public override ConfigVector3 Position
         {
             get => Location.GetPosition().ToVector();
             set => throw new InvalidOperationException("You cannot change the spawn vector of a dynamic spawn location.");

--- a/Exiled.CustomItems/API/Spawn/SpawnPoint.cs
+++ b/Exiled.CustomItems/API/Spawn/SpawnPoint.cs
@@ -7,6 +7,7 @@
 
 namespace Exiled.CustomItems.API.Spawn
 {
+    using Exiled.API.Features;
     using Exiled.CustomItems.API.Features;
 
     /// <summary>
@@ -27,6 +28,6 @@ namespace Exiled.CustomItems.API.Spawn
         /// <summary>
         /// Gets or sets this spawn point position.
         /// </summary>
-        public abstract Vector Position { get; set; }
+        public abstract ConfigVector3 Position { get; set; }
     }
 }

--- a/Exiled.CustomItems/API/Spawn/StaticSpawnPoint.cs
+++ b/Exiled.CustomItems/API/Spawn/StaticSpawnPoint.cs
@@ -7,6 +7,7 @@
 
 namespace Exiled.CustomItems.API.Spawn
 {
+    using Exiled.API.Features;
     using Exiled.CustomItems.API.Features;
 
     /// <summary>
@@ -21,6 +22,6 @@ namespace Exiled.CustomItems.API.Spawn
         public override float Chance { get; set; }
 
         /// <inheritdoc/>
-        public override Vector Position { get; set; }
+        public override ConfigVector3 Position { get; set; }
     }
 }


### PR DESCRIPTION
Because Vector3s don't actually work in config. This just wraps around it and generates a value when requested. Can be used like:
```csharp
public ConfigVector3 Position {get; set;} = new ConfigVector3(1, 1, 1);
```
Then just
```csharp
Config.Position.Value
```