### PR TITLE
Add FirstAvailable as an InfoSide for CreditTags

### DIFF
--- a/Exiled.CreditTags/Config.cs
+++ b/Exiled.CreditTags/Config.cs
@@ -19,8 +19,8 @@ namespace Exiled.CreditTags
         [Description("Is the plugin enabled?")]
         public bool IsEnabled { get; set; } = true;
 
-        [Description("Info side - Badge, CustomPlayerInfo")]
-        public InfoSide Mode { get; private set; } = InfoSide.Badge;
+        [Description("Info side - Badge, CustomPlayerInfo, FirstAvailable")]
+        public InfoSide Mode { get; private set; } = InfoSide.FirstAvailable;
 
         [Description("Overrides badge if exists")]
         public bool BadgeOverride { get; private set; } = false;

--- a/Exiled.CreditTags/CreditTags.cs
+++ b/Exiled.CreditTags/CreditTags.cs
@@ -121,28 +121,56 @@ namespace Exiled.CreditTags
 
             void ShowRank(RankType rank)
             {
+                bool canReceiveCreditBadge = force ||
+                                             (((string.IsNullOrEmpty(player.RankName) &&
+                                                string.IsNullOrEmpty(player.ReferenceHub.serverRoles.HiddenBadge)) ||
+                                               Config.BadgeOverride) && player.GlobalBadge == null);
+                bool canReceiveCreditCustomInfo =
+                    string.IsNullOrEmpty(player.CustomInfo) || Config.CustomPlayerInfoOverride;
+
                 if (Ranks.TryGetValue(rank, out var value))
                 {
                     switch (Config.Mode)
                     {
                         case InfoSide.Badge:
-                            if (force || ((string.IsNullOrEmpty(player.RankName) || Config.BadgeOverride) && player.GlobalBadge == null))
+                            if (canReceiveCreditBadge)
                             {
-                                player.RankName = value.Name;
-                                player.RankColor = value.Color;
+                              SetCreditBadge(player, value);
                             }
 
                             break;
                         case InfoSide.CustomPlayerInfo:
-                            if (string.IsNullOrEmpty(player.CustomInfo) || Config.CustomPlayerInfoOverride)
+                            if (canReceiveCreditCustomInfo)
                             {
-                                player.CustomInfo = $"<color=#{value.HexValue}>{value.Name}</color>";
+                                SetCreditCustomInfo(player, value);
+                            }
+
+                            break;
+                        case InfoSide.FirstAvailable:
+                            if (canReceiveCreditBadge)
+                            {
+                                SetCreditBadge(player, value);
+                            }
+                            else if (canReceiveCreditCustomInfo)
+                            {
+                                SetCreditCustomInfo(player, value);
                             }
 
                             break;
                     }
                 }
             }
+        }
+
+        private void SetCreditBadge(Player player, Rank value)
+        {
+            player.RankName = value.Name;
+            player.RankColor = value.Color;
+        }
+
+        private void SetCreditCustomInfo(Player player, Rank value)
+        {
+            player.CustomInfo = $"<color=#{value.HexValue}>{value.Name}</color>";
         }
 
         private void RefreshHandler() => handler = new CreditsHandler();

--- a/Exiled.CreditTags/Enums/InfoSide.cs
+++ b/Exiled.CreditTags/Enums/InfoSide.cs
@@ -20,6 +20,11 @@ namespace Exiled.CreditTags.Enums
         CustomPlayerInfo,
 
         /// <summary>
+        /// Uses Badge if available, otherwise uses CustomPlayerInfo if available
+        /// </summary>
+        FirstAvailable,
+
+        /// <summary>
         /// Includes both of them.
         /// </summary>
         Both = Badge,

--- a/Exiled.CreditTags/Enums/InfoSide.cs
+++ b/Exiled.CreditTags/Enums/InfoSide.cs
@@ -20,7 +20,7 @@ namespace Exiled.CreditTags.Enums
         CustomPlayerInfo,
 
         /// <summary>
-        /// Uses Badge if available, otherwise uses CustomPlayerInfo if available
+        /// Uses Badge if available, otherwise uses CustomPlayerInfo if available.
         /// </summary>
         FirstAvailable,
 


### PR DESCRIPTION
This PR adds FirstAvailable as an InfoSide for CreditTags. It finds the first unused spot to put the credit tag and then puts it there. 

I did change the default config option to FirstAvailable, as I believe it provides the most flexibility without any config changes by the server owner.