### PR TITLE
Fixed Player.CanSendInputs being inverted

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -914,8 +914,8 @@ namespace Exiled.API.Features
         /// </summary>
         public bool CanSendInputs
         {
-            get => ReferenceHub.fpc.NetworkforceStopInputs;
-            set => ReferenceHub.fpc.NetworkforceStopInputs = value;
+            get => !ReferenceHub.fpc.NetworkforceStopInputs;
+            set => ReferenceHub.fpc.NetworkforceStopInputs = !value;
         }
 
         /// <summary>


### PR DESCRIPTION
Because the method uses ReferenceHub.fpc.Networkforce**Stop**Inputs; setting `player.CanSendInputs` to `true` actually means forcing stopping inputs and vice versa.

Yes, the fix is literally adding two "!!".