### PR TITLE
Sending a helpful message, when an exception happens

### DIFF
--- a/Exiled.API/Features/ExceptionHandler.cs
+++ b/Exiled.API/Features/ExceptionHandler.cs
@@ -9,7 +9,8 @@ namespace Exiled.API.Features
 {
     using System;
     using System.IO;
-    using System.Linq;
+
+    using YamlDotNet.Core;
 
     /// <summary>
     /// .
@@ -25,21 +26,21 @@ namespace Exiled.API.Features
         {
             string message = null;
 
-            switch (exception.GetType().Name)
+            switch (exception)
             {
-                case "MissingMethodException":
+                case MissingMethodException _:
                     message = "This error can be fixed by updating Exiled or plugin to the latest version.";
                     break;
 
-                case "FileNotFoundException":
-                    message = $"The \"{(exception as FileNotFoundException).FileName.Split(new char[] { ',' })[0]}.dll\" file is either missing or it outdated.";
+                case FileNotFoundException fileNotFound:
+                    message = $"The \"{fileNotFound.FileName.Split(new char[] { ',' })[0]}.dll\" file is either missing or is outdated.";
                     break;
 
-                case "YamlException":
+                case YamlException _:
                     message = $"Check the line stated above. If you don't know what is the issue parse the .yml file through YAML Validator for example through this one: https://codebeautify.org/yaml-validator";
                     break;
 
-                case "BadImageFormatException":
+                case BadImageFormatException _:
                     message = $"The one or more .dll files are corrupt. Please reinstall them.";
                     break;
 
@@ -54,10 +55,9 @@ namespace Exiled.API.Features
             }
             else
             {
-                #if DEBUG
+#if DEBUG
                 Log.Send(exception.GetType().Name, Discord.LogLevel.Warn, ConsoleColor.DarkYellow);
-                #endif
-
+#endif
                 return false;
             }
         }

--- a/Exiled.API/Features/ExceptionHandler.cs
+++ b/Exiled.API/Features/ExceptionHandler.cs
@@ -1,0 +1,51 @@
+// -----------------------------------------------------------------------
+// <copyright file="ExceptionHandler.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Features
+{
+    using System;
+
+    /// <summary>
+    /// .
+    /// </summary>
+    public static class ExceptionHandler
+    {
+        /// <summary>
+        /// Tries to send a helpful message when the certain <see cref="Exception"/> occurs.
+        /// </summary>
+        /// <param name="exception">The <see cref="Exception"/> for which the solution should be found.</param>
+        /// <returns><see langword="true"/> if the <see cref="Exception"/> has help info built-in and a help message was send, otherwise <see langword="false"/>.</returns>
+        public static bool TrySendingHelpMessage(Exception exception)
+        {
+            string message = null;
+
+            switch (exception.GetType().Name)
+            {
+                case "MissingMethodException":
+                    message = "This error can be fixed via updating Exiled or plugin to the latest version.";
+                    break;
+
+                default:
+                    break;
+            }
+
+            if (message != null)
+            {
+                Log.Send(message, Discord.LogLevel.Warn, ConsoleColor.DarkYellow);
+                return true;
+            }
+            else
+            {
+                #if DEBUG
+                Log.Send(exception.GetType().Name, Discord.LogLevel.Warn, ConsoleColor.DarkYellow);
+                #endif
+
+                return false;
+            }
+        }
+    }
+}

--- a/Exiled.API/Features/ExceptionHandler.cs
+++ b/Exiled.API/Features/ExceptionHandler.cs
@@ -13,7 +13,7 @@ namespace Exiled.API.Features
     using YamlDotNet.Core;
 
     /// <summary>
-    /// .
+    /// Handles exceptions that may occur while using EXILED or plugins.
     /// </summary>
     public static class ExceptionHandler
     {
@@ -29,7 +29,7 @@ namespace Exiled.API.Features
             switch (exception)
             {
                 case MissingMethodException _:
-                    message = "This error can be fixed by updating Exiled or plugin to the latest version.";
+                    message = "This error usually means EXILED or the plugin causing it are outdated, try updating.";
                     break;
 
                 case FileNotFoundException fileNotFound:
@@ -37,11 +37,11 @@ namespace Exiled.API.Features
                     break;
 
                 case YamlException _:
-                    message = $"Check the line stated above. If you don't know what is the issue parse the .yml file through YAML Validator for example through this one: https://codebeautify.org/yaml-validator";
+                    message = $"Check the line stated above. If you don't know what is the issue parse the .yml file through a YAML Validator.";
                     break;
 
                 case BadImageFormatException _:
-                    message = $"The one or more .dll files are corrupt. Please reinstall them.";
+                    message = "The dll file stated above is likely corrupted, this can usually be fixed by re-downloading it.";
                     break;
 
                 default:

--- a/Exiled.API/Features/ExceptionHandler.cs
+++ b/Exiled.API/Features/ExceptionHandler.cs
@@ -8,6 +8,8 @@
 namespace Exiled.API.Features
 {
     using System;
+    using System.IO;
+    using System.Linq;
 
     /// <summary>
     /// .
@@ -26,7 +28,19 @@ namespace Exiled.API.Features
             switch (exception.GetType().Name)
             {
                 case "MissingMethodException":
-                    message = "This error can be fixed via updating Exiled or plugin to the latest version.";
+                    message = "This error can be fixed by updating Exiled or plugin to the latest version.";
+                    break;
+
+                case "FileNotFoundException":
+                    message = $"The \"{(exception as FileNotFoundException).FileName.Split(new char[] { ',' })[0]}.dll\" file is either missing or it outdated.";
+                    break;
+
+                case "YamlException":
+                    message = $"Check the line stated above. If you don't know what is the issue parse the .yml file through YAML Validator for example through this one: https://codebeautify.org/yaml-validator";
+                    break;
+
+                case "BadImageFormatException":
+                    message = $"The one or more .dll files are corrupt. Please reinstall them.";
                     break;
 
                 default:

--- a/Exiled.API/Features/Plugin.cs
+++ b/Exiled.API/Features/Plugin.cs
@@ -125,6 +125,7 @@ namespace Exiled.API.Features
                     catch (Exception exception)
                     {
                         Log.Error($"An error has occurred while registering a command: {exception}");
+                        ExceptionHandler.TrySendingHelpMessage(exception);
                     }
                 }
             }

--- a/Exiled.Events/Events.cs
+++ b/Exiled.Events/Events.cs
@@ -139,6 +139,7 @@ namespace Exiled.Events
             catch (Exception exception)
             {
                 Log.Error($"Patching failed!\n{exception}");
+                ExceptionHandler.TrySendingHelpMessage(exception);
             }
         }
 
@@ -184,6 +185,7 @@ namespace Exiled.Events
             catch (Exception exception)
             {
                 Log.Error($"Patching by attributes failed!\n{exception}");
+                ExceptionHandler.TrySendingHelpMessage(exception);
             }
         }
 
@@ -198,6 +200,7 @@ namespace Exiled.Events
             catch (Exception e)
             {
                 Log.Error($"Patching in the inner types failed!\n{e}");
+                ExceptionHandler.TrySendingHelpMessage(e);
             }
         }
 

--- a/Exiled.Events/Extensions/Event.cs
+++ b/Exiled.Events/Extensions/Event.cs
@@ -39,6 +39,7 @@ namespace Exiled.Events.Extensions
                 catch (Exception ex)
                 {
                     LogException(ex, handler.Method.Name, handler.Method.ReflectedType.FullName, eventName);
+                    ExceptionHandler.TrySendingHelpMessage(ex);
                 }
             }
         }
@@ -63,6 +64,7 @@ namespace Exiled.Events.Extensions
                 catch (Exception ex)
                 {
                     LogException(ex, handler.Method.Name, handler.Method.ReflectedType?.FullName, eventName);
+                    ExceptionHandler.TrySendingHelpMessage(ex);
                 }
             }
         }

--- a/Exiled.Events/Patches/Events/Player/BanningAndKicking.cs
+++ b/Exiled.Events/Patches/Events/Player/BanningAndKicking.cs
@@ -158,7 +158,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.BanningAndKicking: {e}\n{e.StackTrace}");
+                API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.BanningAndKicking: {e}\n{e.StackTrace}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/BanningAndKicking.cs
+++ b/Exiled.Events/Patches/Events/Player/BanningAndKicking.cs
@@ -158,7 +158,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.BanningAndKicking: {e}\n{e.StackTrace}");
+                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.BanningAndKicking: {e}\n{e.StackTrace}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/BanningAndKicking.cs
+++ b/Exiled.Events/Patches/Events/Player/BanningAndKicking.cs
@@ -30,138 +30,129 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(GameObject user, int duration, string reason, string issuer, bool isGlobalBan)
         {
+            if (isGlobalBan && ConfigFile.ServerConfig.GetBool("gban_ban_ip", false))
+            {
+                duration = int.MaxValue;
+            }
+
+            string userId = null;
+            string address = user.GetComponent<NetworkIdentity>().connectionToClient.address;
+
+            API.Features.Player targetPlayer = API.Features.Player.Get(user);
+            API.Features.Player issuerPlayer = API.Features.Player.Get(issuer) ?? API.Features.Server.Host;
+
             try
             {
-                if (isGlobalBan && ConfigFile.ServerConfig.GetBool("gban_ban_ip", false))
-                {
-                    duration = int.MaxValue;
-                }
+                if (ConfigFile.ServerConfig.GetBool("online_mode", false))
+                    userId = targetPlayer.UserId;
+            }
+            catch
+            {
+                ServerConsole.AddLog("Failed during issue of User ID ban (1)!");
+                return false;
+            }
 
-                string userId = null;
-                string address = user.GetComponent<NetworkIdentity>().connectionToClient.address;
+            string message = $"You have been {((duration > 0) ? "banned" : "kicked")}. ";
+            if (!string.IsNullOrEmpty(reason))
+            {
+                message = message + "Reason: " + reason;
+            }
 
-                API.Features.Player targetPlayer = API.Features.Player.Get(user);
-                API.Features.Player issuerPlayer = API.Features.Player.Get(issuer) ?? API.Features.Server.Host;
+            if (!ServerStatic.PermissionsHandler.IsVerified || !targetPlayer.IsStaffBypassEnabled)
+            {
+                if (duration > 0)
+                {
+                    var ev = new BanningEventArgs(targetPlayer, issuerPlayer, duration, reason, message);
 
-                try
-                {
-                    if (ConfigFile.ServerConfig.GetBool("online_mode", false))
-                        userId = targetPlayer.UserId;
-                }
-                catch
-                {
-                    ServerConsole.AddLog("Failed during issue of User ID ban (1)!");
-                    return false;
-                }
+                    Player.OnBanning(ev);
 
-                string message = $"You have been {((duration > 0) ? "banned" : "kicked")}. ";
-                if (!string.IsNullOrEmpty(reason))
-                {
-                    message = message + "Reason: " + reason;
-                }
+                    duration = ev.Duration;
+                    reason = ev.Reason;
+                    message = ev.FullMessage;
 
-                if (!ServerStatic.PermissionsHandler.IsVerified || !targetPlayer.IsStaffBypassEnabled)
-                {
-                    if (duration > 0)
+                    if (!ev.IsAllowed)
+                        return false;
+
+                    string originalName = string.IsNullOrEmpty(targetPlayer.Nickname)
+                        ? "(no nick)"
+                        : targetPlayer.Nickname;
+                    long issuanceTime = TimeBehaviour.CurrentTimestamp();
+                    long banExpieryTime = TimeBehaviour.GetBanExpirationTime((uint)duration);
+                    try
                     {
-                        var ev = new BanningEventArgs(targetPlayer, issuerPlayer, duration, reason, message);
-
-                        Player.OnBanning(ev);
-
-                        duration = ev.Duration;
-                        reason = ev.Reason;
-                        message = ev.FullMessage;
-
-                        if (!ev.IsAllowed)
-                            return false;
-
-                        string originalName = string.IsNullOrEmpty(targetPlayer.Nickname)
-                            ? "(no nick)"
-                            : targetPlayer.Nickname;
-                        long issuanceTime = TimeBehaviour.CurrentTimestamp();
-                        long banExpieryTime = TimeBehaviour.GetBanExpirationTime((uint)duration);
-                        try
+                        if (userId != null && !isGlobalBan)
                         {
-                            if (userId != null && !isGlobalBan)
+                            BanHandler.IssueBan(
+                                new BanDetails
+                                {
+                                    OriginalName = originalName,
+                                    Id = userId,
+                                    IssuanceTime = issuanceTime,
+                                    Expires = banExpieryTime,
+                                    Reason = reason,
+                                    Issuer = issuer,
+                                }, BanHandler.BanType.UserId);
+
+                            if (!string.IsNullOrEmpty(targetPlayer.CustomUserId))
                             {
                                 BanHandler.IssueBan(
                                     new BanDetails
                                     {
                                         OriginalName = originalName,
-                                        Id = userId,
+                                        Id = targetPlayer.CustomUserId,
                                         IssuanceTime = issuanceTime,
                                         Expires = banExpieryTime,
                                         Reason = reason,
                                         Issuer = issuer,
                                     }, BanHandler.BanType.UserId);
-
-                                if (!string.IsNullOrEmpty(targetPlayer.CustomUserId))
-                                {
-                                    BanHandler.IssueBan(
-                                        new BanDetails
-                                        {
-                                            OriginalName = originalName,
-                                            Id = targetPlayer.CustomUserId,
-                                            IssuanceTime = issuanceTime,
-                                            Expires = banExpieryTime,
-                                            Reason = reason,
-                                            Issuer = issuer,
-                                        }, BanHandler.BanType.UserId);
-                                }
                             }
-                        }
-                        catch
-                        {
-                            ServerConsole.AddLog("Failed during issue of User ID ban (2)!");
-                            return false;
-                        }
-
-                        try
-                        {
-                            if (ConfigFile.ServerConfig.GetBool("ip_banning", false) || isGlobalBan)
-                            {
-                                BanHandler.IssueBan(
-                                    new BanDetails
-                                    {
-                                        OriginalName = originalName,
-                                        Id = address,
-                                        IssuanceTime = issuanceTime,
-                                        Expires = banExpieryTime,
-                                        Reason = reason,
-                                        Issuer = issuer,
-                                    }, BanHandler.BanType.IP);
-                            }
-                        }
-                        catch
-                        {
-                            ServerConsole.AddLog("Failed during issue of IP ban!");
-                            return false;
                         }
                     }
-                    else if (duration == 0)
+                    catch
                     {
-                        var ev = new KickingEventArgs(targetPlayer, issuerPlayer, reason, message);
+                        ServerConsole.AddLog("Failed during issue of User ID ban (2)!");
+                        return false;
+                    }
 
-                        Player.OnKicking(ev);
-
-                        reason = ev.Reason;
-                        message = ev.FullMessage;
-
-                        if (!ev.IsAllowed)
-                            return false;
+                    try
+                    {
+                        if (ConfigFile.ServerConfig.GetBool("ip_banning", false) || isGlobalBan)
+                        {
+                            BanHandler.IssueBan(
+                                new BanDetails
+                                {
+                                    OriginalName = originalName,
+                                    Id = address,
+                                    IssuanceTime = issuanceTime,
+                                    Expires = banExpieryTime,
+                                    Reason = reason,
+                                    Issuer = issuer,
+                                }, BanHandler.BanType.IP);
+                        }
+                    }
+                    catch
+                    {
+                        ServerConsole.AddLog("Failed during issue of IP ban!");
+                        return false;
                     }
                 }
+                else if (duration == 0)
+                {
+                    var ev = new KickingEventArgs(targetPlayer, issuerPlayer, reason, message);
 
-                ServerConsole.Disconnect(targetPlayer.ReferenceHub.gameObject, message);
+                    Player.OnKicking(ev);
 
-                return false;
+                    reason = ev.Reason;
+                    message = ev.FullMessage;
+
+                    if (!ev.IsAllowed)
+                        return false;
+                }
             }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.BanningAndKicking: {e}\n{e.StackTrace}");
 
-                return true;
-            }
+            ServerConsole.Disconnect(targetPlayer.ReferenceHub.gameObject, message);
+
+            return false;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/ChangingGroup.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingGroup.cs
@@ -34,7 +34,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingGrounp: {e}\n{e.StackTrace}");
+                API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingGrounp: {e}\n{e.StackTrace}");
 
                 return true;
             }

--- a/Exiled.Events/Patches/Events/Player/ChangingGroup.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingGroup.cs
@@ -24,20 +24,11 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(ServerRoles __instance, UserGroup group)
         {
-            try
-            {
-                var ev = new ChangingGroupEventArgs(API.Features.Player.Get(__instance.gameObject), group);
+            var ev = new ChangingGroupEventArgs(API.Features.Player.Get(__instance.gameObject), group);
 
-                Player.OnChangingGroup(ev);
+            Player.OnChangingGroup(ev);
 
-                return ev.IsAllowed;
-            }
-            catch (Exception e)
-            {
-                API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingGrounp: {e}\n{e.StackTrace}");
-
-                return true;
-            }
+            return ev.IsAllowed;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/ChangingIntercomMuteStatus.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingIntercomMuteStatus.cs
@@ -48,7 +48,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"{typeof(ChangingIntercomMuteStatus).FullName}.{nameof(Prefix)}:\n{e}");
+                API.Features.Log.Error($"{typeof(ChangingIntercomMuteStatus).FullName}.{nameof(Prefix)}:\n{e}");
                 return true;
             }
         }

--- a/Exiled.Events/Patches/Events/Player/ChangingIntercomMuteStatus.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingIntercomMuteStatus.cs
@@ -24,33 +24,25 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(CharacterClassManager __instance, bool value)
         {
-            try
+            ChangingIntercomMuteStatusEventArgs ev = new ChangingIntercomMuteStatusEventArgs(API.Features.Player.Get(__instance._hub), value, true);
+
+            Player.OnChangingIntercomMuteStatus(ev);
+
+            if (!ev.IsAllowed)
             {
-                ChangingIntercomMuteStatusEventArgs ev = new ChangingIntercomMuteStatusEventArgs(API.Features.Player.Get(__instance._hub), value, true);
-
-                Player.OnChangingIntercomMuteStatus(ev);
-
-                if (!ev.IsAllowed)
+                if (value == true)
                 {
-                    if (value == true)
-                    {
-                        MuteHandler.RevokePersistentMute("ICOM-" + __instance.UserId);
-                    }
-                    else
-                    {
-                        MuteHandler.IssuePersistentMute("ICOM-" + __instance.UserId);
-                    }
-
-                    return false;
+                    MuteHandler.RevokePersistentMute("ICOM-" + __instance.UserId);
+                }
+                else
+                {
+                    MuteHandler.IssuePersistentMute("ICOM-" + __instance.UserId);
                 }
 
-                return true;
+                return false;
             }
-            catch (Exception e)
-            {
-                API.Features.Log.Error($"{typeof(ChangingIntercomMuteStatus).FullName}.{nameof(Prefix)}:\n{e}");
-                return true;
-            }
+
+            return true;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/ChangingItem.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingItem.cs
@@ -24,40 +24,33 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static void Prefix(Inventory __instance, int i)
         {
-            try
+            if (__instance.itemUniq == i)
+                return;
+
+            int oldItemIndex = __instance.GetItemIndex();
+
+            if (oldItemIndex == -1 && i == -1)
+                return;
+
+            Inventory.SyncItemInfo oldItem = oldItemIndex == -1
+                ? new Inventory.SyncItemInfo() { id = ItemType.None }
+                : __instance.GetItemInHand();
+            Inventory.SyncItemInfo newItem = new Inventory.SyncItemInfo() { id = ItemType.None };
+
+            foreach (Inventory.SyncItemInfo item in __instance.items)
             {
-                if (__instance.itemUniq == i)
-                    return;
-
-                int oldItemIndex = __instance.GetItemIndex();
-
-                if (oldItemIndex == -1 && i == -1)
-                    return;
-
-                Inventory.SyncItemInfo oldItem = oldItemIndex == -1
-                    ? new Inventory.SyncItemInfo() { id = ItemType.None }
-                    : __instance.GetItemInHand();
-                Inventory.SyncItemInfo newItem = new Inventory.SyncItemInfo() { id = ItemType.None };
-
-                foreach (Inventory.SyncItemInfo item in __instance.items)
-                {
-                    if (item.uniq == i)
-                        newItem = item;
-                }
-
-                var ev = new ChangingItemEventArgs(API.Features.Player.Get(__instance.gameObject), oldItem, newItem);
-
-                Player.OnChangingItem(ev);
-
-                oldItemIndex = __instance.GetItemIndex();
-
-                if (oldItemIndex != -1)
-                    __instance.items[oldItemIndex] = ev.OldItem;
+                if (item.uniq == i)
+                    newItem = item;
             }
-            catch (Exception e)
-            {
-                API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingItem: {e}\n{e.StackTrace}");
-            }
+
+            var ev = new ChangingItemEventArgs(API.Features.Player.Get(__instance.gameObject), oldItem, newItem);
+
+            Player.OnChangingItem(ev);
+
+            oldItemIndex = __instance.GetItemIndex();
+
+            if (oldItemIndex != -1)
+                __instance.items[oldItemIndex] = ev.OldItem;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/ChangingItem.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingItem.cs
@@ -56,7 +56,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingItem: {e}\n{e.StackTrace}");
+                API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingItem: {e}\n{e.StackTrace}");
             }
         }
     }

--- a/Exiled.Events/Patches/Events/Player/ChangingMuteStatus.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingMuteStatus.cs
@@ -48,7 +48,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                Exiled.API.Features.Log.Error($"{typeof(ChangingMuteStatus).FullName}.{nameof(Prefix)}:\n{e}");
+                API.Features.Log.Error($"{typeof(ChangingMuteStatus).FullName}.{nameof(Prefix)}:\n{e}");
                 return true;
             }
         }

--- a/Exiled.Events/Patches/Events/Player/ChangingMuteStatus.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingMuteStatus.cs
@@ -24,33 +24,25 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(CharacterClassManager __instance, bool value)
         {
-            try
+            ChangingMuteStatusEventArgs ev = new ChangingMuteStatusEventArgs(API.Features.Player.Get(__instance._hub), value, true);
+
+            Player.OnChangingMuteStatus(ev);
+
+            if (!ev.IsAllowed)
             {
-                ChangingMuteStatusEventArgs ev = new ChangingMuteStatusEventArgs(API.Features.Player.Get(__instance._hub), value, true);
-
-                Player.OnChangingMuteStatus(ev);
-
-                if (!ev.IsAllowed)
+                if (value == true)
                 {
-                    if (value == true)
-                    {
-                        MuteHandler.RevokePersistentMute(__instance.UserId);
-                    }
-                    else
-                    {
-                        MuteHandler.IssuePersistentMute(__instance.UserId);
-                    }
-
-                    return false;
+                    MuteHandler.RevokePersistentMute(__instance.UserId);
+                }
+                else
+                {
+                    MuteHandler.IssuePersistentMute(__instance.UserId);
                 }
 
-                return true;
+                return false;
             }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"{typeof(ChangingMuteStatus).FullName}.{nameof(Prefix)}:\n{e}");
-                return true;
-            }
+
+            return true;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/ChangingMuteStatus.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingMuteStatus.cs
@@ -48,7 +48,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception e)
             {
-                API.Features.Log.Error($"{typeof(ChangingMuteStatus).FullName}.{nameof(Prefix)}:\n{e}");
+                Exiled.API.Features.Log.Error($"{typeof(ChangingMuteStatus).FullName}.{nameof(Prefix)}:\n{e}");
                 return true;
             }
         }

--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -29,147 +29,138 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(CharacterClassManager __instance, ref RoleType classid, GameObject ply, bool lite = false, bool escape = false)
         {
-            try
+            // Somehow we've seen spam
+            // here with a NullReferenceException,
+            // so there are more null checks here
+            if (ply == null
+            || !ply.TryGetComponent<CharacterClassManager>(out var ccm)
+            || ccm == null
+            || !ccm.IsVerified)
             {
-                // Somehow we've seen spam
-                // here with a NullReferenceException,
-                // so there are more null checks here
-                if (ply == null
-                || !ply.TryGetComponent<CharacterClassManager>(out var ccm)
-                || ccm == null
-                || !ccm.IsVerified)
-                {
+                return false;
+            }
+
+            var player = API.Features.Player.Get(ply);
+
+            var startItemsList = ListPool<ItemType>.Shared.Rent(__instance.Classes.SafeGet(classid).startItems);
+            var changingRoleEventArgs = new ChangingRoleEventArgs(player, classid, startItemsList, lite, escape);
+
+            Player.OnChangingRole(changingRoleEventArgs);
+
+            lite = changingRoleEventArgs.ShouldPreservePosition;
+            escape = changingRoleEventArgs.IsEscaped;
+
+            if (classid != RoleType.Spectator && changingRoleEventArgs.NewRole == RoleType.Spectator)
+            {
+                var diedEventArgs = new DiedEventArgs(API.Features.Server.Host, changingRoleEventArgs.Player, new PlayerStats.HitInfo(-1, "Dedicated Server", DamageTypes.None, 0));
+                Player.OnDied(diedEventArgs);
+            }
+
+            classid = changingRoleEventArgs.NewRole;
+
+            if (escape)
+            {
+                var escapingEventArgs = new EscapingEventArgs(player, classid);
+
+                Player.OnEscaping(escapingEventArgs);
+
+                if (!escapingEventArgs.IsAllowed)
                     return false;
-                }
 
-                var player = API.Features.Player.Get(ply);
+                classid = escapingEventArgs.NewRole;
+            }
 
-                var startItemsList = ListPool<ItemType>.Shared.Rent(__instance.Classes.SafeGet(classid).startItems);
-                var changingRoleEventArgs = new ChangingRoleEventArgs(player, classid, startItemsList, lite, escape);
+            var changedRoleEventArgs = new ChangedRoleEventArgs(player, player.Role, startItemsList, lite, escape);
 
-                Player.OnChangingRole(changingRoleEventArgs);
+            ply.GetComponent<CharacterClassManager>().SetClassIDAdv(classid, lite, escape);
+            ply.GetComponent<PlayerStats>().SetHPAmount(__instance.Classes.SafeGet(classid).maxHP);
+            ply.GetComponent<FirstPersonController>().ResetStamina();
 
-                lite = changingRoleEventArgs.ShouldPreservePosition;
-                escape = changingRoleEventArgs.IsEscaped;
-
-                if (classid != RoleType.Spectator && changingRoleEventArgs.NewRole == RoleType.Spectator)
-                {
-                    var diedEventArgs = new DiedEventArgs(API.Features.Server.Host, changingRoleEventArgs.Player, new PlayerStats.HitInfo(-1, "Dedicated Server", DamageTypes.None, 0));
-                    Player.OnDied(diedEventArgs);
-                }
-
-                classid = changingRoleEventArgs.NewRole;
-
-                if (escape)
-                {
-                    var escapingEventArgs = new EscapingEventArgs(player, classid);
-
-                    Player.OnEscaping(escapingEventArgs);
-
-                    if (!escapingEventArgs.IsAllowed)
-                        return false;
-
-                    classid = escapingEventArgs.NewRole;
-                }
-
-                var changedRoleEventArgs = new ChangedRoleEventArgs(player, player.Role, startItemsList, lite, escape);
-
-                ply.GetComponent<CharacterClassManager>().SetClassIDAdv(classid, lite, escape);
-                ply.GetComponent<PlayerStats>().SetHPAmount(__instance.Classes.SafeGet(classid).maxHP);
-                ply.GetComponent<FirstPersonController>().ResetStamina();
-
-                if (lite)
-                {
-                    Player.OnChangedRole(changedRoleEventArgs);
-
-                    ListPool<ItemType>.Shared.Return(startItemsList);
-                    return false;
-                }
-
-                Inventory component = ply.GetComponent<Inventory>();
-                List<Inventory.SyncItemInfo> list = ListPool<Inventory.SyncItemInfo>.Shared.Rent();
-                if (escape && CharacterClassManager.KeepItemsAfterEscaping)
-                {
-                    foreach (Inventory.SyncItemInfo item in component.items)
-                        list.Add(item);
-                }
-
-                component.items.Clear();
-                foreach (ItemType id in changingRoleEventArgs.Items)
-                {
-                    component.AddNewItem(id, -4.65664672E+11f, 0, 0, 0);
-                }
-
-                if (escape && CharacterClassManager.KeepItemsAfterEscaping)
-                {
-                    foreach (Inventory.SyncItemInfo syncItemInfo in list)
-                    {
-                        if (CharacterClassManager.PutItemsInInvAfterEscaping)
-                        {
-                            var itemByID = component.GetItemByID(syncItemInfo.id);
-                            bool flag = false;
-                            InventoryCategory[] categories = __instance._search.categories;
-                            int i = 0;
-                            while (i < categories.Length)
-                            {
-                                InventoryCategory inventoryCategory = categories[i];
-                                if (inventoryCategory.itemType == itemByID.itemCategory &&
-                                    (itemByID.itemCategory != ItemCategory.None ||
-                                     itemByID.itemCategory != ItemCategory.None))
-                                {
-                                    int num = 0;
-                                    foreach (Inventory.SyncItemInfo syncItemInfo2 in component.items)
-                                    {
-                                        if (component.GetItemByID(syncItemInfo2.id).itemCategory ==
-                                            itemByID.itemCategory)
-                                        {
-                                            num++;
-                                        }
-                                    }
-
-                                    if (num >= inventoryCategory.maxItems)
-                                    {
-                                        flag = true;
-                                        break;
-                                    }
-
-                                    break;
-                                }
-                                else
-                                {
-                                    i++;
-                                }
-                            }
-
-                            if (component.items.Count >= 8 || flag)
-                            {
-                                component.SetPickup(syncItemInfo.id, syncItemInfo.durability, __instance._pms.RealModelPosition, Quaternion.Euler(__instance._pms.Rotations.x, __instance._pms.Rotations.y, 0f), syncItemInfo.modSight, syncItemInfo.modBarrel, syncItemInfo.modOther);
-                            }
-                            else
-                            {
-                                component.AddNewItem(syncItemInfo.id, syncItemInfo.durability, syncItemInfo.modSight, syncItemInfo.modBarrel, syncItemInfo.modOther);
-                            }
-                        }
-                        else
-                        {
-                            component.SetPickup(syncItemInfo.id, syncItemInfo.durability, __instance._pms.RealModelPosition, Quaternion.Euler(__instance._pms.Rotations.x, __instance._pms.Rotations.y, 0f), syncItemInfo.modSight, syncItemInfo.modBarrel, syncItemInfo.modOther);
-                        }
-                    }
-                }
-
-                ListPool<Inventory.SyncItemInfo>.Shared.Return(list);
-
+            if (lite)
+            {
                 Player.OnChangedRole(changedRoleEventArgs);
 
                 ListPool<ItemType>.Shared.Return(startItemsList);
                 return false;
             }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ChangingRole: {e}\n{e.StackTrace}");
 
-                return true;
+            Inventory component = ply.GetComponent<Inventory>();
+            List<Inventory.SyncItemInfo> list = ListPool<Inventory.SyncItemInfo>.Shared.Rent();
+            if (escape && CharacterClassManager.KeepItemsAfterEscaping)
+            {
+                foreach (Inventory.SyncItemInfo item in component.items)
+                    list.Add(item);
             }
+
+            component.items.Clear();
+            foreach (ItemType id in changingRoleEventArgs.Items)
+            {
+                component.AddNewItem(id, -4.65664672E+11f, 0, 0, 0);
+            }
+
+            if (escape && CharacterClassManager.KeepItemsAfterEscaping)
+            {
+                foreach (Inventory.SyncItemInfo syncItemInfo in list)
+                {
+                    if (CharacterClassManager.PutItemsInInvAfterEscaping)
+                    {
+                        var itemByID = component.GetItemByID(syncItemInfo.id);
+                        bool flag = false;
+                        InventoryCategory[] categories = __instance._search.categories;
+                        int i = 0;
+                        while (i < categories.Length)
+                        {
+                            InventoryCategory inventoryCategory = categories[i];
+                            if (inventoryCategory.itemType == itemByID.itemCategory &&
+                                (itemByID.itemCategory != ItemCategory.None ||
+                                 itemByID.itemCategory != ItemCategory.None))
+                            {
+                                int num = 0;
+                                foreach (Inventory.SyncItemInfo syncItemInfo2 in component.items)
+                                {
+                                    if (component.GetItemByID(syncItemInfo2.id).itemCategory ==
+                                        itemByID.itemCategory)
+                                    {
+                                        num++;
+                                    }
+                                }
+
+                                if (num >= inventoryCategory.maxItems)
+                                {
+                                    flag = true;
+                                    break;
+                                }
+
+                                break;
+                            }
+                            else
+                            {
+                                i++;
+                            }
+                        }
+
+                        if (component.items.Count >= 8 || flag)
+                        {
+                            component.SetPickup(syncItemInfo.id, syncItemInfo.durability, __instance._pms.RealModelPosition, Quaternion.Euler(__instance._pms.Rotations.x, __instance._pms.Rotations.y, 0f), syncItemInfo.modSight, syncItemInfo.modBarrel, syncItemInfo.modOther);
+                        }
+                        else
+                        {
+                            component.AddNewItem(syncItemInfo.id, syncItemInfo.durability, syncItemInfo.modSight, syncItemInfo.modBarrel, syncItemInfo.modOther);
+                        }
+                    }
+                    else
+                    {
+                        component.SetPickup(syncItemInfo.id, syncItemInfo.durability, __instance._pms.RealModelPosition, Quaternion.Euler(__instance._pms.Rotations.x, __instance._pms.Rotations.y, 0f), syncItemInfo.modSight, syncItemInfo.modBarrel, syncItemInfo.modOther);
+                    }
+                }
+            }
+
+            ListPool<Inventory.SyncItemInfo>.Shared.Return(list);
+
+            Player.OnChangedRole(changedRoleEventArgs);
+
+            ListPool<ItemType>.Shared.Return(startItemsList);
+            return false;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/DequippedMedicalItem.cs
+++ b/Exiled.Events/Patches/Events/Player/DequippedMedicalItem.cs
@@ -24,18 +24,11 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static void Prefix(ConsumableAndWearableItems __instance, ConsumableAndWearableItems.HealAnimation healAnimation, int mid)
         {
-            try
+            if (healAnimation == ConsumableAndWearableItems.HealAnimation.DequipMedicalItem)
             {
-                if (healAnimation == ConsumableAndWearableItems.HealAnimation.DequipMedicalItem)
-                {
-                    var ev = new DequippedMedicalItemEventArgs(API.Features.Player.Get(__instance.gameObject), __instance.usableItems[mid].inventoryID);
+                var ev = new DequippedMedicalItemEventArgs(API.Features.Player.Get(__instance.gameObject), __instance.usableItems[mid].inventoryID);
 
-                    Player.OnMedicalItemDequipped(ev);
-                }
-            }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"{typeof(DequippedMedicalItem).FullName}:\n{e}");
+                Player.OnMedicalItemDequipped(ev);
             }
         }
     }

--- a/Exiled.Events/Patches/Events/Player/Destroying.cs
+++ b/Exiled.Events/Patches/Events/Player/Destroying.cs
@@ -22,25 +22,18 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static void Prefix(ReferenceHub __instance)
         {
-            try
-            {
-                // Means it's the server
-                if (!(Player.Get(__instance) is Player player))
-                    return;
+            // Means it's the server
+            if (!(Player.Get(__instance) is Player player))
+                return;
 
-                Handlers.Player.OnDestroying(new DestroyingEventArgs(player));
+            Handlers.Player.OnDestroying(new DestroyingEventArgs(player));
 
-                Player.Dictionary.Remove(player.GameObject);
-                Player.UnverifiedPlayers.Remove(__instance);
-                Player.IdsCache.Remove(player.Id);
+            Player.Dictionary.Remove(player.GameObject);
+            Player.UnverifiedPlayers.Remove(__instance);
+            Player.IdsCache.Remove(player.Id);
 
-                if (player.UserId != null)
-                    Player.UserIdsCache.Remove(player.UserId);
-            }
-            catch (Exception exception)
-            {
-                Log.Error($"{typeof(Destroying).FullName}.{nameof(Prefix)}:\n{exception}");
-            }
+            if (player.UserId != null)
+                Player.UserIdsCache.Remove(player.UserId);
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/EnteringFemurBreaker.cs
+++ b/Exiled.Events/Patches/Events/Player/EnteringFemurBreaker.cs
@@ -28,43 +28,34 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(CharacterClassManager __instance)
         {
-            try
+            if (!NetworkServer.active || !NonFacilityCompatibility.currentSceneSettings.enableStandardGamplayItems)
+                return false;
+
+            foreach (GameObject player in PlayerManager.players)
             {
-                if (!NetworkServer.active || !NonFacilityCompatibility.currentSceneSettings.enableStandardGamplayItems)
-                    return false;
-
-                foreach (GameObject player in PlayerManager.players)
+                if (Vector3.Distance(player.transform.position, __instance._lureSpj.transform.position) <
+                    1.97000002861023)
                 {
-                    if (Vector3.Distance(player.transform.position, __instance._lureSpj.transform.position) <
-                        1.97000002861023)
+                    CharacterClassManager component1 = player.GetComponent<CharacterClassManager>();
+                    PlayerStats component2 = player.GetComponent<PlayerStats>();
+
+                    if (component1.Classes.SafeGet(component1.CurClass).team != Team.SCP &&
+                        component1.CurClass != RoleType.Spectator && !component1.GodMode)
                     {
-                        CharacterClassManager component1 = player.GetComponent<CharacterClassManager>();
-                        PlayerStats component2 = player.GetComponent<PlayerStats>();
+                        var ev = new EnteringFemurBreakerEventArgs(API.Features.Player.Get(component2.gameObject));
 
-                        if (component1.Classes.SafeGet(component1.CurClass).team != Team.SCP &&
-                            component1.CurClass != RoleType.Spectator && !component1.GodMode)
+                        Player.OnEnteringFemurBreaker(ev);
+
+                        if (ev.IsAllowed)
                         {
-                            var ev = new EnteringFemurBreakerEventArgs(API.Features.Player.Get(component2.gameObject));
-
-                            Player.OnEnteringFemurBreaker(ev);
-
-                            if (ev.IsAllowed)
-                            {
-                                component2.HurtPlayer(new PlayerStats.HitInfo(10000f, "WORLD", DamageTypes.Lure, 0), player);
-                                __instance._lureSpj.SetState(true);
-                            }
+                            component2.HurtPlayer(new PlayerStats.HitInfo(10000f, "WORLD", DamageTypes.Lure, 0), player);
+                            __instance._lureSpj.SetState(true);
                         }
                     }
                 }
-
-                return false;
             }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.EnteringFemurBreaker: {e}\n{e.StackTrace}");
 
-                return true;
-            }
+            return false;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/Hurting.cs
+++ b/Exiled.Events/Patches/Events/Player/Hurting.cs
@@ -26,56 +26,48 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(PlayerStats __instance, ref PlayerStats.HitInfo info, GameObject go)
         {
-            try
+            if (go == null)
+                return true;
+
+            API.Features.Player attacker = API.Features.Player.Get(info.IsPlayer ? info.RHub.gameObject : __instance.gameObject);
+            API.Features.Player target = API.Features.Player.Get(go);
+
+            if (target == null || target.IsHost)
+                return true;
+
+            if (info.GetDamageType() == DamageTypes.Recontainment && target.Role == RoleType.Scp079)
             {
-                if (go == null)
-                    return true;
+                Scp079.OnRecontained(new RecontainedEventArgs(target));
+                var eventArgs = new DiedEventArgs(null, target, info);
+                Player.OnDied(eventArgs);
+            }
 
-                API.Features.Player attacker = API.Features.Player.Get(info.IsPlayer ? info.RHub.gameObject : __instance.gameObject);
-                API.Features.Player target = API.Features.Player.Get(go);
+            if (attacker == null || attacker.IsHost)
+                return true;
 
-                if (target == null || target.IsHost)
-                    return true;
+            var ev = new HurtingEventArgs(attacker, target, info);
 
-                if (info.GetDamageType() == DamageTypes.Recontainment && target.Role == RoleType.Scp079)
-                {
-                    Scp079.OnRecontained(new RecontainedEventArgs(target));
-                    var eventArgs = new DiedEventArgs(null, target, info);
-                    Player.OnDied(eventArgs);
-                }
+            if (ev.Target.IsHost)
+                return true;
 
-                if (attacker == null || attacker.IsHost)
-                    return true;
+            Player.OnHurting(ev);
 
-                var ev = new HurtingEventArgs(attacker, target, info);
+            info = ev.HitInformations;
 
-                if (ev.Target.IsHost)
-                    return true;
+            if (!ev.IsAllowed)
+                return false;
 
-                Player.OnHurting(ev);
+            if (!ev.Target.IsGodModeEnabled && (ev.Amount == -1 || ev.Amount >= ev.Target.Health + ev.Target.ArtificialHealth))
+            {
+                var dyingEventArgs = new DyingEventArgs(ev.Attacker, ev.Target, ev.HitInformations);
 
-                info = ev.HitInformations;
+                Player.OnDying(dyingEventArgs);
 
-                if (!ev.IsAllowed)
+                if (!dyingEventArgs.IsAllowed)
                     return false;
-
-                if (!ev.Target.IsGodModeEnabled && (ev.Amount == -1 || ev.Amount >= ev.Target.Health + ev.Target.ArtificialHealth))
-                {
-                    var dyingEventArgs = new DyingEventArgs(ev.Attacker, ev.Target, ev.HitInformations);
-
-                    Player.OnDying(dyingEventArgs);
-
-                    if (!dyingEventArgs.IsAllowed)
-                        return false;
-                }
-
-                return true;
             }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.Hurting: {e}\n{e.StackTrace}");
-                return true;
-            }
+
+            return true;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/InsertingGeneratorTablet.cs
+++ b/Exiled.Events/Patches/Events/Player/InsertingGeneratorTablet.cs
@@ -28,86 +28,77 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(Generator079 __instance, GameObject person, PlayerInteract.Generator079Operations command)
         {
-            try
+            API.Features.Player player = API.Features.Player.Get(person);
+
+            switch (command)
             {
-                API.Features.Player player = API.Features.Player.Get(person);
+                case PlayerInteract.Generator079Operations.Door:
+                    bool isAllowed = true;
 
-                switch (command)
-                {
-                    case PlayerInteract.Generator079Operations.Door:
-                        bool isAllowed = true;
+                    switch (__instance.isDoorOpen)
+                    {
+                        case false:
+                            var openingEventArgs = new OpeningGeneratorEventArgs(player, __instance, isAllowed);
 
-                        switch (__instance.isDoorOpen)
-                        {
-                            case false:
-                                var openingEventArgs = new OpeningGeneratorEventArgs(player, __instance, isAllowed);
+                            Player.OnOpeningGenerator(openingEventArgs);
 
-                                Player.OnOpeningGenerator(openingEventArgs);
-
-                                isAllowed = openingEventArgs.IsAllowed;
-                                break;
-                            case true:
-                                var closingEventArgs = new ClosingGeneratorEventArgs(player, __instance, isAllowed);
-
-                                Player.OnClosingGenerator(closingEventArgs);
-
-                                isAllowed = closingEventArgs.IsAllowed;
-                                break;
-                        }
-
-                        if (isAllowed)
-                            __instance.OpenClose(person);
-                        else
-                            __instance.RpcDenied();
-                        break;
-
-                    case PlayerInteract.Generator079Operations.Tablet:
-                        if (__instance.isTabletConnected || !__instance.isDoorOpen || (__instance._localTime <= 0.0 || Generator079.mainGenerator.forcedOvercharge))
+                            isAllowed = openingEventArgs.IsAllowed;
                             break;
-                        Inventory component = person.GetComponent<Inventory>();
-                        using (SyncList<Inventory.SyncItemInfo>.SyncListEnumerator enumerator = component.items.GetEnumerator())
+                        case true:
+                            var closingEventArgs = new ClosingGeneratorEventArgs(player, __instance, isAllowed);
+
+                            Player.OnClosingGenerator(closingEventArgs);
+
+                            isAllowed = closingEventArgs.IsAllowed;
+                            break;
+                    }
+
+                    if (isAllowed)
+                        __instance.OpenClose(person);
+                    else
+                        __instance.RpcDenied();
+                    break;
+
+                case PlayerInteract.Generator079Operations.Tablet:
+                    if (__instance.isTabletConnected || !__instance.isDoorOpen || (__instance._localTime <= 0.0 || Generator079.mainGenerator.forcedOvercharge))
+                        break;
+                    Inventory component = person.GetComponent<Inventory>();
+                    using (SyncList<Inventory.SyncItemInfo>.SyncListEnumerator enumerator = component.items.GetEnumerator())
+                    {
+                        while (enumerator.MoveNext())
                         {
-                            while (enumerator.MoveNext())
+                            Inventory.SyncItemInfo current = enumerator.Current;
+                            if (current.id == ItemType.WeaponManagerTablet)
                             {
-                                Inventory.SyncItemInfo current = enumerator.Current;
-                                if (current.id == ItemType.WeaponManagerTablet)
+                                var insertingEventArgs = new InsertingGeneratorTabletEventArgs(player, __instance);
+
+                                Player.OnInsertingGeneratorTablet(insertingEventArgs);
+
+                                if (insertingEventArgs.IsAllowed)
                                 {
-                                    var insertingEventArgs = new InsertingGeneratorTabletEventArgs(player, __instance);
-
-                                    Player.OnInsertingGeneratorTablet(insertingEventArgs);
-
-                                    if (insertingEventArgs.IsAllowed)
-                                    {
-                                        component.items.Remove(current);
-                                        __instance.NetworkisTabletConnected = true;
-                                    }
-
-                                    break;
+                                    component.items.Remove(current);
+                                    __instance.NetworkisTabletConnected = true;
                                 }
-                            }
 
-                            break;
+                                break;
+                            }
                         }
 
-                    case PlayerInteract.Generator079Operations.Cancel:
-                        var ejectingEventArgs = new EjectingGeneratorTabletEventArgs(player, __instance);
-
-                        Player.OnEjectingGeneratorTablet(ejectingEventArgs);
-
-                        if (ejectingEventArgs.IsAllowed)
-                            __instance.EjectTablet();
-
                         break;
-                }
+                    }
 
-                return false;
-            }
-            catch (Exception exception)
-            {
-                API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.InsertingGeneratorTablet: {exception}\n{exception.StackTrace}");
+                case PlayerInteract.Generator079Operations.Cancel:
+                    var ejectingEventArgs = new EjectingGeneratorTabletEventArgs(player, __instance);
 
-                return true;
+                    Player.OnEjectingGeneratorTablet(ejectingEventArgs);
+
+                    if (ejectingEventArgs.IsAllowed)
+                        __instance.EjectTablet();
+
+                    break;
             }
+
+            return false;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/InteractingElevator.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingElevator.cs
@@ -25,41 +25,32 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(PlayerInteract __instance, GameObject elevator)
         {
-            try
-            {
-                if (!__instance._playerInteractRateLimit.CanExecute(true) ||
-                    ((__instance._hc.CufferId > 0 || __instance._hc.ForceCuff) && !PlayerInteract.CanDisarmedInteract) || elevator == null)
-                    return false;
-
-                Lift component = elevator.GetComponent<Lift>();
-                if (component == null)
-                    return false;
-
-                foreach (Lift.Elevator elevator2 in component.elevators)
-                {
-                    if (__instance.ChckDis(elevator2.door.transform.position))
-                    {
-                        var ev = new InteractingElevatorEventArgs(API.Features.Player.Get(__instance.gameObject), elevator2, component);
-
-                        Handlers.Player.OnInteractingElevator(ev);
-
-                        if (!ev.IsAllowed)
-                            return false;
-
-                        component.UseLift();
-                        __instance.OnInteract();
-                        return false;
-                    }
-                }
-
+            if (!__instance._playerInteractRateLimit.CanExecute(true) ||
+                ((__instance._hc.CufferId > 0 || __instance._hc.ForceCuff) && !PlayerInteract.CanDisarmedInteract) || elevator == null)
                 return false;
-            }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.InteractingElevator:\n{e}");
 
-                return true;
+            Lift component = elevator.GetComponent<Lift>();
+            if (component == null)
+                return false;
+
+            foreach (Lift.Elevator elevator2 in component.elevators)
+            {
+                if (__instance.ChckDis(elevator2.door.transform.position))
+                {
+                    var ev = new InteractingElevatorEventArgs(API.Features.Player.Get(__instance.gameObject), elevator2, component);
+
+                    Handlers.Player.OnInteractingElevator(ev);
+
+                    if (!ev.IsAllowed)
+                        return false;
+
+                    component.UseLift();
+                    __instance.OnInteract();
+                    return false;
+                }
             }
+
+            return false;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/InteractingLocker.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingLocker.cs
@@ -24,81 +24,72 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(PlayerInteract __instance, byte lockerId, byte chamberNumber)
         {
-            try
-            {
-                if (!__instance._playerInteractRateLimit.CanExecute(true) ||
-                    (__instance._hc.CufferId > 0 && !PlayerInteract.CanDisarmedInteract))
-                    return false;
-
-                LockerManager singleton = LockerManager.singleton;
-
-                if (lockerId >= singleton.lockers.Length)
-                    return false;
-
-                if (!__instance.ChckDis(singleton.lockers[lockerId].gameObject.position) ||
-                    !singleton.lockers[lockerId].supportsStandarizedAnimation)
-                    return false;
-
-                if (chamberNumber >= singleton.lockers[lockerId].chambers.Length)
-                    return false;
-
-                if (singleton.lockers[lockerId].chambers[chamberNumber].doorAnimator == null)
-                    return false;
-
-                if (!singleton.lockers[lockerId].chambers[chamberNumber].CooldownAtZero())
-                    return false;
-
-                singleton.lockers[lockerId].chambers[chamberNumber].SetCooldown();
-
-                string accessToken = singleton.lockers[lockerId].chambers[chamberNumber].accessToken;
-                var itemById = __instance._inv.GetItemByID(__instance._inv.curItem);
-
-                var ev = new InteractingLockerEventArgs(
-                    API.Features.Player.Get(__instance.gameObject),
-                    singleton.lockers[lockerId],
-                    singleton.lockers[lockerId].chambers[chamberNumber],
-                    lockerId,
-                    chamberNumber,
-                    string.IsNullOrEmpty(accessToken) || (itemById != null && itemById.permissions.Contains(accessToken)) || __instance._sr.BypassMode);
-
-                Player.OnInteractingLocker(ev);
-
-                if (ev.IsAllowed)
-                {
-                    bool flag = (singleton.openLockers[lockerId] & 1 << chamberNumber) != 1 << chamberNumber;
-                    singleton.ModifyOpen(lockerId, chamberNumber, flag);
-                    singleton.RpcDoSound(lockerId, chamberNumber, flag);
-                    bool anyOpen = true;
-                    for (int i = 0; i < singleton.lockers[lockerId].chambers.Length; i++)
-                    {
-                        if ((singleton.openLockers[lockerId] & 1 << i) == 1 << i)
-                        {
-                            anyOpen = false;
-                            break;
-                        }
-                    }
-
-                    singleton.lockers[lockerId].LockPickups(!flag, chamberNumber, anyOpen);
-                    if (!string.IsNullOrEmpty(accessToken))
-                    {
-                        singleton.RpcChangeMaterial(lockerId, chamberNumber, false);
-                    }
-                }
-                else
-                {
-                    singleton.RpcChangeMaterial(lockerId, chamberNumber, true);
-                }
-
-                __instance.OnInteract();
-
+            if (!__instance._playerInteractRateLimit.CanExecute(true) ||
+                (__instance._hc.CufferId > 0 && !PlayerInteract.CanDisarmedInteract))
                 return false;
-            }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.InteractingLocker:\n{e}");
 
-                return true;
+            LockerManager singleton = LockerManager.singleton;
+
+            if (lockerId >= singleton.lockers.Length)
+                return false;
+
+            if (!__instance.ChckDis(singleton.lockers[lockerId].gameObject.position) ||
+                !singleton.lockers[lockerId].supportsStandarizedAnimation)
+                return false;
+
+            if (chamberNumber >= singleton.lockers[lockerId].chambers.Length)
+                return false;
+
+            if (singleton.lockers[lockerId].chambers[chamberNumber].doorAnimator == null)
+                return false;
+
+            if (!singleton.lockers[lockerId].chambers[chamberNumber].CooldownAtZero())
+                return false;
+
+            singleton.lockers[lockerId].chambers[chamberNumber].SetCooldown();
+
+            string accessToken = singleton.lockers[lockerId].chambers[chamberNumber].accessToken;
+            var itemById = __instance._inv.GetItemByID(__instance._inv.curItem);
+
+            var ev = new InteractingLockerEventArgs(
+                API.Features.Player.Get(__instance.gameObject),
+                singleton.lockers[lockerId],
+                singleton.lockers[lockerId].chambers[chamberNumber],
+                lockerId,
+                chamberNumber,
+                string.IsNullOrEmpty(accessToken) || (itemById != null && itemById.permissions.Contains(accessToken)) || __instance._sr.BypassMode);
+
+            Player.OnInteractingLocker(ev);
+
+            if (ev.IsAllowed)
+            {
+                bool flag = (singleton.openLockers[lockerId] & 1 << chamberNumber) != 1 << chamberNumber;
+                singleton.ModifyOpen(lockerId, chamberNumber, flag);
+                singleton.RpcDoSound(lockerId, chamberNumber, flag);
+                bool anyOpen = true;
+                for (int i = 0; i < singleton.lockers[lockerId].chambers.Length; i++)
+                {
+                    if ((singleton.openLockers[lockerId] & 1 << i) == 1 << i)
+                    {
+                        anyOpen = false;
+                        break;
+                    }
+                }
+
+                singleton.lockers[lockerId].LockPickups(!flag, chamberNumber, anyOpen);
+                if (!string.IsNullOrEmpty(accessToken))
+                {
+                    singleton.RpcChangeMaterial(lockerId, chamberNumber, false);
+                }
             }
+            else
+            {
+                singleton.RpcChangeMaterial(lockerId, chamberNumber, true);
+            }
+
+            __instance.OnInteract();
+
+            return false;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/ItemDrop.cs
+++ b/Exiled.Events/Patches/Events/Player/ItemDrop.cs
@@ -24,43 +24,34 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(Inventory __instance, int itemInventoryIndex)
         {
-            try
-            {
-                if (!__instance._iawRateLimit.CanExecute(true) || itemInventoryIndex < 0 ||
-                    itemInventoryIndex >= __instance.items.Count)
-                    return false;
-
-                Inventory.SyncItemInfo syncItemInfo = __instance.items[itemInventoryIndex];
-
-                if (__instance.items[itemInventoryIndex].id != syncItemInfo.id)
-                    return false;
-
-                var droppingItemEventArgs =
-                    new DroppingItemEventArgs(API.Features.Player.Get(__instance.gameObject), syncItemInfo);
-
-                Player.OnDroppingItem(droppingItemEventArgs);
-
-                syncItemInfo = droppingItemEventArgs.Item;
-
-                if (!droppingItemEventArgs.IsAllowed)
-                    return false;
-
-                Pickup droppedPickup = __instance.SetPickup(syncItemInfo.id, syncItemInfo.durability, __instance.transform.position, __instance.camera.transform.rotation, syncItemInfo.modSight, syncItemInfo.modBarrel, syncItemInfo.modOther);
-
-                __instance.items.RemoveAt(itemInventoryIndex);
-
-                var itemDroppedEventArgs = new ItemDroppedEventArgs(API.Features.Player.Get(__instance.gameObject), droppedPickup);
-
-                Player.OnItemDropped(itemDroppedEventArgs);
-
+            if (!__instance._iawRateLimit.CanExecute(true) || itemInventoryIndex < 0 ||
+                itemInventoryIndex >= __instance.items.Count)
                 return false;
-            }
-            catch (Exception e)
-            {
-                API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ItemDrop: {e}\n{e.StackTrace}");
 
-                return true;
-            }
+            Inventory.SyncItemInfo syncItemInfo = __instance.items[itemInventoryIndex];
+
+            if (__instance.items[itemInventoryIndex].id != syncItemInfo.id)
+                return false;
+
+            var droppingItemEventArgs =
+                new DroppingItemEventArgs(API.Features.Player.Get(__instance.gameObject), syncItemInfo);
+
+            Player.OnDroppingItem(droppingItemEventArgs);
+
+            syncItemInfo = droppingItemEventArgs.Item;
+
+            if (!droppingItemEventArgs.IsAllowed)
+                return false;
+
+            Pickup droppedPickup = __instance.SetPickup(syncItemInfo.id, syncItemInfo.durability, __instance.transform.position, __instance.camera.transform.rotation, syncItemInfo.modSight, syncItemInfo.modBarrel, syncItemInfo.modOther);
+
+            __instance.items.RemoveAt(itemInventoryIndex);
+
+            var itemDroppedEventArgs = new ItemDroppedEventArgs(API.Features.Player.Get(__instance.gameObject), droppedPickup);
+
+            Player.OnItemDropped(itemDroppedEventArgs);
+
+            return false;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/Joined.cs
+++ b/Exiled.Events/Patches/Events/Player/Joined.cs
@@ -46,21 +46,14 @@ namespace Exiled.Events.Patches.Events.Player
 
         private static void Postfix(ReferenceHub __instance)
         {
-            try
-            {
-                // ReferenceHub is a component that is loaded first
-                if (__instance.isDedicatedServer || ReferenceHub.HostHub == null || PlayerManager.localPlayer == null)
-                    return;
+            // ReferenceHub is a component that is loaded first
+            if (__instance.isDedicatedServer || ReferenceHub.HostHub == null || PlayerManager.localPlayer == null)
+                return;
 
-                if (PlayerManager.players.Count >= CustomNetworkManager.slots)
-                    MultiAdminFeatures.CallEvent(MultiAdminFeatures.EventType.SERVER_FULL);
+            if (PlayerManager.players.Count >= CustomNetworkManager.slots)
+                MultiAdminFeatures.CallEvent(MultiAdminFeatures.EventType.SERVER_FULL);
 
-                CallEvent(__instance, out _);
-            }
-            catch (Exception exception)
-            {
-                Log.Error($"{typeof(Joined).FullName}:\n{exception}");
-            }
+            CallEvent(__instance, out _);
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/Kicked.cs
+++ b/Exiled.Events/Patches/Events/Player/Kicked.cs
@@ -25,25 +25,16 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(GameObject player, ref string message)
         {
-            try
-            {
-                if (player == null)
-                    return false;
+            if (player == null)
+                return false;
 
-                var ev = new KickedEventArgs(API.Features.Player.Get(player), message);
+            var ev = new KickedEventArgs(API.Features.Player.Get(player), message);
 
-                Player.OnKicked(ev);
+            Player.OnKicked(ev);
 
-                message = ev.Reason;
+            message = ev.Reason;
 
-                return ev.IsAllowed;
-            }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.Kicked: {e}\n{e.StackTrace}");
-
-                return true;
-            }
+            return ev.IsAllowed;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/Left.cs
+++ b/Exiled.Events/Patches/Events/Player/Left.cs
@@ -26,24 +26,17 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static void Prefix(NetworkConnection conn)
         {
-            try
-            {
-                // The game checks for null NetworkIdentity, do the same
-                // GameObjects don't support the null-conditional operator (?) and the null-coalescing operator (??)
-                if (conn.identity == null || conn.identity.gameObject == null)
-                    return;
+            // The game checks for null NetworkIdentity, do the same
+            // GameObjects don't support the null-conditional operator (?) and the null-coalescing operator (??)
+            if (conn.identity == null || conn.identity.gameObject == null)
+                return;
 
-                Player player = Player.Get(conn.identity.gameObject);
-                if (player == null || player.IsHost)
-                    return;
+            Player player = Player.Get(conn.identity.gameObject);
+            if (player == null || player.IsHost)
+                return;
 
-                Log.SendRaw($"Player {player.Nickname} ({player.UserId}) ({player.Id}) disconnected", ConsoleColor.Green);
-                Handlers.Player.OnLeft(new LeftEventArgs(player));
-            }
-            catch (Exception exception)
-            {
-                Log.Error($"{typeof(Left).FullName}.{nameof(Prefix)}:\n{exception}");
-            }
+            Log.SendRaw($"Player {player.Nickname} ({player.UserId}) ({player.Id}) disconnected", ConsoleColor.Green);
+            Handlers.Player.OnLeft(new LeftEventArgs(player));
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/PickingUpAmmo.cs
+++ b/Exiled.Events/Patches/Events/Player/PickingUpAmmo.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="PickingUpAmmo.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
@@ -26,24 +26,15 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(AmmoSearchCompletor __instance)
         {
-            try
-            {
-                var ev = new PickingUpAmmoEventArgs(Player.Get(__instance.Hub), __instance.TargetPickup);
+            var ev = new PickingUpAmmoEventArgs(Player.Get(__instance.Hub), __instance.TargetPickup);
 
-                Handlers.Player.OnPickingUpAmmo(ev);
+            Handlers.Player.OnPickingUpAmmo(ev);
 
-                // Allow future pick up of this ammo
-                if (!ev.IsAllowed)
-                    __instance.TargetPickup.InUse = false;
+            // Allow future pick up of this ammo
+            if (!ev.IsAllowed)
+                __instance.TargetPickup.InUse = false;
 
-                return ev.IsAllowed;
-            }
-            catch (Exception exception)
-            {
-                Log.Error($"{typeof(PickingUpAmmo).FullName}\n{exception}");
-
-                return true;
-            }
+            return ev.IsAllowed;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/PickingUpItem.cs
+++ b/Exiled.Events/Patches/Events/Player/PickingUpItem.cs
@@ -26,24 +26,15 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(ItemSearchCompletor __instance)
         {
-            try
-            {
-                var ev = new PickingUpItemEventArgs(Player.Get(__instance.Hub), __instance.TargetPickup);
+            var ev = new PickingUpItemEventArgs(Player.Get(__instance.Hub), __instance.TargetPickup);
 
-                Handlers.Player.OnPickingUpItem(ev);
+            Handlers.Player.OnPickingUpItem(ev);
 
-                // Allow future pick up of this item
-                if (!ev.IsAllowed)
-                    __instance.TargetPickup.InUse = false;
+            // Allow future pick up of this item
+            if (!ev.IsAllowed)
+                __instance.TargetPickup.InUse = false;
 
-                return ev.IsAllowed;
-            }
-            catch (Exception exception)
-            {
-                Log.Error($"{typeof(PickingUpItem).FullName}\n{exception}");
-
-                return true;
-            }
+            return ev.IsAllowed;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/ReceivingStatusEffect.cs
+++ b/Exiled.Events/Patches/Events/Player/ReceivingStatusEffect.cs
@@ -31,31 +31,23 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(PlayerEffect __instance, byte newState)
         {
-            try
-            {
-                if (__instance.Intensity == newState)
-                    return false;
-
-                var ev = new ReceivingEffectEventArgs(API.Features.Player.Get(__instance.Hub.gameObject), __instance, newState, __instance.Intensity);
-                Exiled.Events.Handlers.Player.OnReceivingEffect(ev);
-
-                if (!ev.IsAllowed)
-                    return false;
-
-                byte intensity = ev.CurrentState;
-                __instance.Intensity = ev.State;
-                if (NetworkServer.active)
-                    __instance.Hub.playerEffectsController.Resync();
-                __instance.ServerOnIntensityChange(intensity, ev.State);
-                if (ev.Duration > 0.0f)
-                    Timing.CallDelayed(0.5f, () => __instance.Duration = ev.Duration);
+            if (__instance.Intensity == newState)
                 return false;
-            }
-            catch (Exception e)
-            {
-                Log.Error($"RecievingEffect: {e}");
-                return true;
-            }
+
+            var ev = new ReceivingEffectEventArgs(API.Features.Player.Get(__instance.Hub.gameObject), __instance, newState, __instance.Intensity);
+            Exiled.Events.Handlers.Player.OnReceivingEffect(ev);
+
+            if (!ev.IsAllowed)
+                return false;
+
+            byte intensity = ev.CurrentState;
+            __instance.Intensity = ev.State;
+            if (NetworkServer.active)
+                __instance.Hub.playerEffectsController.Resync();
+            __instance.ServerOnIntensityChange(intensity, ev.State);
+            if (ev.Duration > 0.0f)
+                Timing.CallDelayed(0.5f, () => __instance.Duration = ev.Duration);
+            return false;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/ReloadingWeapon.cs
+++ b/Exiled.Events/Patches/Events/Player/ReloadingWeapon.cs
@@ -24,32 +24,23 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(WeaponManager __instance, bool animationOnly)
         {
-            try
-            {
-                if (!__instance._iawRateLimit.CanExecute(false))
-                    return false;
+            if (!__instance._iawRateLimit.CanExecute(false))
+                return false;
 
-                int itemIndex = __instance._hub.inventory.GetItemIndex();
+            int itemIndex = __instance._hub.inventory.GetItemIndex();
 
-                if (itemIndex < 0 || itemIndex >= __instance._hub.inventory.items.Count ||
-                    (__instance.curWeapon < 0 || __instance._hub.inventory.curItem !=
-                        __instance.weapons[__instance.curWeapon].inventoryID) ||
-                    __instance._hub.inventory.items[itemIndex].durability >=
-                    (double)__instance.weapons[__instance.curWeapon].maxAmmo)
-                    return false;
+            if (itemIndex < 0 || itemIndex >= __instance._hub.inventory.items.Count ||
+                (__instance.curWeapon < 0 || __instance._hub.inventory.curItem !=
+                    __instance.weapons[__instance.curWeapon].inventoryID) ||
+                __instance._hub.inventory.items[itemIndex].durability >=
+                (double)__instance.weapons[__instance.curWeapon].maxAmmo)
+                return false;
 
-                var ev = new ReloadingWeaponEventArgs(API.Features.Player.Get(__instance.gameObject), animationOnly);
+            var ev = new ReloadingWeaponEventArgs(API.Features.Player.Get(__instance.gameObject), animationOnly);
 
-                Player.OnReloadingWeapon(ev);
+            Player.OnReloadingWeapon(ev);
 
-                return ev.IsAllowed;
-            }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ReloadingWeapon: {e}\n{e.StackTrace}");
-
-                return true;
-            }
+            return ev.IsAllowed;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/RemovingHandcuffs.cs
+++ b/Exiled.Events/Patches/Events/Player/RemovingHandcuffs.cs
@@ -24,34 +24,25 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(Handcuffs __instance)
         {
-            try
+            foreach (API.Features.Player target in API.Features.Player.List)
             {
-                foreach (API.Features.Player target in API.Features.Player.List)
+                if (target == null)
+                    continue;
+
+                if (target.CufferId == __instance.MyReferenceHub.queryProcessor.PlayerId)
                 {
-                    if (target == null)
-                        continue;
+                    var ev = new RemovingHandcuffsEventArgs(API.Features.Player.Get(__instance.gameObject), target);
 
-                    if (target.CufferId == __instance.MyReferenceHub.queryProcessor.PlayerId)
-                    {
-                        var ev = new RemovingHandcuffsEventArgs(API.Features.Player.Get(__instance.gameObject), target);
+                    Player.OnRemovingHandcuffs(ev);
 
-                        Player.OnRemovingHandcuffs(ev);
+                    if (ev.IsAllowed)
+                        target.CufferId = -1;
 
-                        if (ev.IsAllowed)
-                            target.CufferId = -1;
-
-                        break;
-                    }
+                    break;
                 }
-
-                return false;
             }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.RemovingHandcuffs: {e}\n{e.StackTrace}");
 
-                return true;
-            }
+            return false;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/RemovingHandcuffsByTeammate.cs
+++ b/Exiled.Events/Patches/Events/Player/RemovingHandcuffsByTeammate.cs
@@ -26,33 +26,24 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(Handcuffs __instance, GameObject target)
         {
-            try
-            {
-                if (!__instance._interactRateLimit.CanExecute(true) || target == null ||
-                    (Vector3.Distance(target.transform.position, __instance.transform.position) >
-                        __instance.raycastDistance * 1.10000002384186 || __instance.MyReferenceHub.characterClassManager
-                            .Classes.SafeGet(__instance.MyReferenceHub.characterClassManager.CurClass).team ==
-                        Team.SCP))
-                    return false;
-
-                var targetPlayer = API.Features.Player.Get(target);
-                var ev = new RemovingHandcuffsEventArgs(API.Features.Player.Get(__instance.gameObject), targetPlayer);
-
-                Player.OnRemovingHandcuffs(ev);
-
-                if (!ev.IsAllowed)
-                    return false;
-
-                targetPlayer.CufferId = -1;
-
+            if (!__instance._interactRateLimit.CanExecute(true) || target == null ||
+                (Vector3.Distance(target.transform.position, __instance.transform.position) >
+                    __instance.raycastDistance * 1.10000002384186 || __instance.MyReferenceHub.characterClassManager
+                        .Classes.SafeGet(__instance.MyReferenceHub.characterClassManager.CurClass).team ==
+                    Team.SCP))
                 return false;
-            }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.RemovingHandcuffsByTeammate: {e}\n{e.StackTrace}");
 
-                return true;
-            }
+            var targetPlayer = API.Features.Player.Get(target);
+            var ev = new RemovingHandcuffsEventArgs(API.Features.Player.Get(__instance.gameObject), targetPlayer);
+
+            Player.OnRemovingHandcuffs(ev);
+
+            if (!ev.IsAllowed)
+                return false;
+
+            targetPlayer.CufferId = -1;
+
+            return false;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/SpawningRagdoll.cs
+++ b/Exiled.Events/Patches/Events/Player/SpawningRagdoll.cs
@@ -26,31 +26,22 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(RagdollManager __instance, ref Vector3 pos, ref Quaternion rot, ref Vector3 velocity, ref int classId, ref PlayerStats.HitInfo ragdollInfo, ref bool allowRecall, ref string ownerID, ref string ownerNick, ref int playerId)
         {
-            try
-            {
-                var ev = new SpawningRagdollEventArgs(
-                    ragdollInfo.PlayerId == 0 ? null : API.Features.Player.Get(ragdollInfo.PlayerId), API.Features.Player.Get(__instance.gameObject), pos, rot, velocity, (RoleType)classId, ragdollInfo, allowRecall, ownerID, ownerNick, playerId);
+            var ev = new SpawningRagdollEventArgs(
+                ragdollInfo.PlayerId == 0 ? null : API.Features.Player.Get(ragdollInfo.PlayerId), API.Features.Player.Get(__instance.gameObject), pos, rot, velocity, (RoleType)classId, ragdollInfo, allowRecall, ownerID, ownerNick, playerId);
 
-                Player.OnSpawningRagdoll(ev);
+            Player.OnSpawningRagdoll(ev);
 
-                pos = ev.Position;
-                rot = ev.Rotation;
-                velocity = ev.Velocity;
-                classId = (int)ev.RoleType;
-                ragdollInfo = ev.HitInformations;
-                allowRecall = ev.IsRecallAllowed;
-                ownerID = ev.DissonanceId;
-                ownerNick = ev.PlayerNickname;
-                playerId = ev.PlayerId;
+            pos = ev.Position;
+            rot = ev.Rotation;
+            velocity = ev.Velocity;
+            classId = (int)ev.RoleType;
+            ragdollInfo = ev.HitInformations;
+            allowRecall = ev.IsRecallAllowed;
+            ownerID = ev.DissonanceId;
+            ownerNick = ev.PlayerNickname;
+            playerId = ev.PlayerId;
 
-                return ev.IsAllowed;
-            }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.SpawningRagdoll: {e}\n{e.StackTrace}");
-
-                return true;
-            }
+            return ev.IsAllowed;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/StoppingMedicalItem.cs
+++ b/Exiled.Events/Patches/Events/Player/StoppingMedicalItem.cs
@@ -24,31 +24,22 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(ConsumableAndWearableItems __instance)
         {
-            try
-            {
-                if (!__instance._interactRateLimit.CanExecute(true))
-                    return false;
-
-                for (int i = 0; i < __instance.usableItems.Length; ++i)
-                {
-                    if (__instance.usableItems[i].inventoryID == __instance._hub.inventory.curItem && __instance.usableItems[i].cancelableTime > 0f)
-                    {
-                        var ev = new StoppingMedicalItemEventArgs(API.Features.Player.Get(__instance.gameObject), __instance._hub.inventory.curItem, __instance.usableItems[i].animationDuration);
-
-                        Player.OnStoppingMedicalItem(ev);
-
-                        __instance._cancel = ev.IsAllowed;
-                    }
-                }
-
+            if (!__instance._interactRateLimit.CanExecute(true))
                 return false;
-            }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.StoppingMedicalItem: {e}\n{e.StackTrace}");
 
-                return true;
+            for (int i = 0; i < __instance.usableItems.Length; ++i)
+            {
+                if (__instance.usableItems[i].inventoryID == __instance._hub.inventory.curItem && __instance.usableItems[i].cancelableTime > 0f)
+                {
+                    var ev = new StoppingMedicalItemEventArgs(API.Features.Player.Get(__instance.gameObject), __instance._hub.inventory.curItem, __instance.usableItems[i].animationDuration);
+
+                    Player.OnStoppingMedicalItem(ev);
+
+                    __instance._cancel = ev.IsAllowed;
+                }
             }
+
+            return false;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/SyncingData.cs
+++ b/Exiled.Events/Patches/Events/Player/SyncingData.cs
@@ -26,23 +26,14 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(AnimationController __instance, byte state, Vector2 v2)
         {
-            try
-            {
-                if (!__instance._mSyncRateLimit.CanExecute(false))
-                    return false;
+            if (!__instance._mSyncRateLimit.CanExecute(false))
+                return false;
 
-                var ev = new SyncingDataEventArgs(API.Features.Player.Get(__instance.gameObject), v2, state);
+            var ev = new SyncingDataEventArgs(API.Features.Player.Get(__instance.gameObject), v2, state);
 
-                Player.OnSyncingData(ev);
+            Player.OnSyncingData(ev);
 
-                return ev.IsAllowed;
-            }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.SyncingData: {e}\n{e.StackTrace}");
-
-                return true;
-            }
+            return ev.IsAllowed;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/ThrowingGrenade.cs
+++ b/Exiled.Events/Patches/Events/Player/ThrowingGrenade.cs
@@ -27,24 +27,15 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(ref GrenadeManager __instance, ref int id, ref bool slowThrow, ref double time)
         {
-            try
-            {
-                var ev = new ThrowingGrenadeEventArgs(API.Features.Player.Get(__instance.gameObject), __instance, (GrenadeType)id, slowThrow, time);
+            var ev = new ThrowingGrenadeEventArgs(API.Features.Player.Get(__instance.gameObject), __instance, (GrenadeType)id, slowThrow, time);
 
-                Player.OnThrowingGrenade(ev);
+            Player.OnThrowingGrenade(ev);
 
-                id = (int)ev.Type;
-                slowThrow = ev.IsSlow;
-                time = ev.FuseTime;
+            id = (int)ev.Type;
+            slowThrow = ev.IsSlow;
+            time = ev.FuseTime;
 
-                return ev.IsAllowed;
-            }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.ThrowingGrenade: {e}\n{e.StackTrace}");
-
-                return true;
-            }
+            return ev.IsAllowed;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/TriggeringTesla.cs
+++ b/Exiled.Events/Patches/Events/Player/TriggeringTesla.cs
@@ -27,33 +27,24 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(TeslaGateController __instance)
         {
-            try
+            foreach (KeyValuePair<GameObject, ReferenceHub> allHub in ReferenceHub.GetAllHubs())
             {
-                foreach (KeyValuePair<GameObject, ReferenceHub> allHub in ReferenceHub.GetAllHubs())
+                if (allHub.Value.characterClassManager.CurClass == RoleType.Spectator)
+                    continue;
+                foreach (TeslaGate teslaGate in __instance.TeslaGates)
                 {
-                    if (allHub.Value.characterClassManager.CurClass == RoleType.Spectator)
+                    if (!teslaGate.PlayerInRange(allHub.Value) || teslaGate.InProgress)
                         continue;
-                    foreach (TeslaGate teslaGate in __instance.TeslaGates)
-                    {
-                        if (!teslaGate.PlayerInRange(allHub.Value) || teslaGate.InProgress)
-                            continue;
 
-                        var ev = new TriggeringTeslaEventArgs(API.Features.Player.Get(allHub.Key), teslaGate.PlayerInHurtRange(allHub.Key));
-                        Player.OnTriggeringTesla(ev);
+                    var ev = new TriggeringTeslaEventArgs(API.Features.Player.Get(allHub.Key), teslaGate.PlayerInHurtRange(allHub.Key));
+                    Player.OnTriggeringTesla(ev);
 
-                        if (ev.IsTriggerable)
-                            teslaGate.ServerSideCode();
-                    }
+                    if (ev.IsTriggerable)
+                        teslaGate.ServerSideCode();
                 }
-
-                return false;
             }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.TriggeringTesla: {e}\n{e.StackTrace}");
 
-                return true;
-            }
+            return false;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/UsingMedicalItem.cs
+++ b/Exiled.Events/Patches/Events/Player/UsingMedicalItem.cs
@@ -26,39 +26,30 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static bool Prefix(ConsumableAndWearableItems __instance)
         {
-            try
-            {
-                if (!__instance._medicalItemRateLimit.CanExecute(true))
-                    return false;
-
-                __instance._cancel = false;
-                if (__instance.cooldown > 0f)
-                    return false;
-
-                for (int i = 0; i < __instance.usableItems.Length; ++i)
-                {
-                    if (__instance.usableItems[i].inventoryID == __instance._hub.inventory.curItem &&
-                        __instance.usableCooldowns[i] <= 0.0)
-                    {
-                        var ev = new UsingMedicalItemEventArgs(Player.Get(__instance.gameObject), __instance._hub.inventory.curItem, __instance.usableItems[i].animationDuration);
-
-                        Handlers.Player.OnUsingMedicalItem(ev);
-
-                        __instance.cooldown = ev.Cooldown;
-
-                        if (ev.IsAllowed)
-                            Timing.RunCoroutine(__instance.UseMedicalItem(i), Segment.FixedUpdate);
-                    }
-                }
-
+            if (!__instance._medicalItemRateLimit.CanExecute(true))
                 return false;
-            }
-            catch (Exception exception)
-            {
-                Log.Error($"Exiled.Events.Patches.Events.Player.UsingMedicalItem: {exception}\n{exception.StackTrace}");
 
-                return true;
+            __instance._cancel = false;
+            if (__instance.cooldown > 0f)
+                return false;
+
+            for (int i = 0; i < __instance.usableItems.Length; ++i)
+            {
+                if (__instance.usableItems[i].inventoryID == __instance._hub.inventory.curItem &&
+                    __instance.usableCooldowns[i] <= 0.0)
+                {
+                    var ev = new UsingMedicalItemEventArgs(Player.Get(__instance.gameObject), __instance._hub.inventory.curItem, __instance.usableItems[i].animationDuration);
+
+                    Handlers.Player.OnUsingMedicalItem(ev);
+
+                    __instance.cooldown = ev.Cooldown;
+
+                    if (ev.IsAllowed)
+                        Timing.RunCoroutine(__instance.UseMedicalItem(i), Segment.FixedUpdate);
+                }
             }
+
+            return false;
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Player/Verified.cs
+++ b/Exiled.Events/Patches/Events/Player/Verified.cs
@@ -56,28 +56,21 @@ namespace Exiled.Events.Patches.Events.Player
 
         private static void CallEvent(ServerRoles instance)
         {
-            try
-            {
-                Player.UnverifiedPlayers.TryGetValue(instance._hub, out Player player);
+            Player.UnverifiedPlayers.TryGetValue(instance._hub, out Player player);
 
-                // Means the player connected before WaitingForPlayers event is fired
-                // Let's call Joined event, since it wasn't called, to avoid breaking the logic of the order of event calls
-                // Blame NorthWood
-                if (player == null)
-                    Joined.CallEvent(instance._hub, out player);
+            // Means the player connected before WaitingForPlayers event is fired
+            // Let's call Joined event, since it wasn't called, to avoid breaking the logic of the order of event calls
+            // Blame NorthWood
+            if (player == null)
+                Joined.CallEvent(instance._hub, out player);
 
-                PlayerAPI.Dictionary.Add(instance._hub.gameObject, player);
-                player.IsVerified = true;
-                player.RawUserId = player.UserId.GetRawUserId();
+            PlayerAPI.Dictionary.Add(instance._hub.gameObject, player);
+            player.IsVerified = true;
+            player.RawUserId = player.UserId.GetRawUserId();
 
-                Log.SendRaw($"Player {player.Nickname} ({player.UserId}) ({player.Id}) connected with the IP: {player.IPAddress}", ConsoleColor.Green);
+            Log.SendRaw($"Player {player.Nickname} ({player.UserId}) ({player.Id}) connected with the IP: {player.IPAddress}", ConsoleColor.Green);
 
-                PlayerEvents.OnVerified(new VerifiedEventArgs(player));
-            }
-            catch (Exception ex)
-            {
-                Log.Error($"{typeof(Verified).FullName}.{nameof(CallEvent)}:\n{ex}");
-            }
+            PlayerEvents.OnVerified(new VerifiedEventArgs(player));
         }
     }
 }

--- a/Exiled.Events/Patches/Events/Server/RespawningTeam.cs
+++ b/Exiled.Events/Patches/Events/Server/RespawningTeam.cs
@@ -32,103 +32,94 @@ namespace Exiled.Events.Patches.Events.Server
     {
         private static bool Prefix(RespawnManager __instance)
         {
-            try
+            if (!RespawnWaveGenerator.SpawnableTeams.TryGetValue(__instance.NextKnownTeam, out SpawnableTeam spawnableTeam) ||
+                __instance.NextKnownTeam == SpawnableTeamType.None)
             {
-                if (!RespawnWaveGenerator.SpawnableTeams.TryGetValue(__instance.NextKnownTeam, out SpawnableTeam spawnableTeam) ||
-                    __instance.NextKnownTeam == SpawnableTeamType.None)
+                ServerConsole.AddLog("Fatal error. Team '" + __instance.NextKnownTeam + "' is undefined.", ConsoleColor.Red);
+            }
+            else
+            {
+                List<API.Features.Player> list = ListPool<API.Features.Player>.Shared.Rent(API.Features.Player.List.Where(player => player.IsDead && !player.IsOverwatchEnabled));
+
+                if (__instance._prioritySpawn)
                 {
-                    ServerConsole.AddLog("Fatal error. Team '" + __instance.NextKnownTeam + "' is undefined.", ConsoleColor.Red);
+                    var tempList = ListPool<API.Features.Player>.Shared.Rent();
+
+                    tempList.AddRange(list.OrderBy(item => item.ReferenceHub.characterClassManager.DeathTime));
+
+                    ListPool<API.Features.Player>.Shared.Return(list);
+
+                    list = tempList;
                 }
                 else
                 {
-                    List<API.Features.Player> list = ListPool<API.Features.Player>.Shared.Rent(API.Features.Player.List.Where(player => player.IsDead && !player.IsOverwatchEnabled));
-
-                    if (__instance._prioritySpawn)
-                    {
-                        var tempList = ListPool<API.Features.Player>.Shared.Rent();
-
-                        tempList.AddRange(list.OrderBy(item => item.ReferenceHub.characterClassManager.DeathTime));
-
-                        ListPool<API.Features.Player>.Shared.Return(list);
-
-                        list = tempList;
-                    }
-                    else
-                    {
-                        list.ShuffleList();
-                    }
-
-                    // Code that should be here is in RespawningTeamEventArgs::ReissueNextKnownTeam
-                    var ev = new RespawningTeamEventArgs(list, __instance.NextKnownTeam);
-
-                    Handlers.Server.OnRespawningTeam(ev);
-
-                    if (ev.IsAllowed && ev.SpawnableTeam != null)
-                    {
-                        while (list.Count > ev.MaximumRespawnAmount)
-                            list.RemoveAt(list.Count - 1);
-
-                        list.ShuffleList();
-
-                        List<ReferenceHub> referenceHubList = ListPool<ReferenceHub>.Shared.Rent();
-
-                        foreach (API.Features.Player me in list)
-                        {
-                            try
-                            {
-                                RoleType classid = ev.SpawnableTeam.Value.ClassQueue[Mathf.Min(referenceHubList.Count, spawnableTeam.ClassQueue.Length - 1)];
-
-                                me.ReferenceHub.characterClassManager.SetPlayersClass(classid, me.ReferenceHub.gameObject);
-
-                                referenceHubList.Add(me.ReferenceHub);
-
-                                ServerLogs.AddLog(ServerLogs.Modules.ClassChange, "Player " + me.ReferenceHub.LoggedNameFromRefHub() + " respawned as " + classid + ".", ServerLogs.ServerLogType.GameEvent);
-                            }
-                            catch (Exception ex)
-                            {
-                                if (me != null)
-                                    ServerLogs.AddLog(ServerLogs.Modules.ClassChange, "Player " + me.ReferenceHub.LoggedNameFromRefHub() + " couldn't be spawned. Err msg: " + ex.Message, ServerLogs.ServerLogType.GameEvent);
-                                else
-                                    ServerLogs.AddLog(ServerLogs.Modules.ClassChange, "Couldn't spawn a player - target's ReferenceHub is null.", ServerLogs.ServerLogType.GameEvent);
-                            }
-                        }
-
-                        if (referenceHubList.Count > 0)
-                        {
-                            ServerLogs.AddLog(ServerLogs.Modules.ClassChange, $"RespawnManager has successfully spawned {referenceHubList.Count} players as {__instance.NextKnownTeam}!", ServerLogs.ServerLogType.GameEvent);
-                            RespawnTickets.Singleton.GrantTickets(__instance.NextKnownTeam, -referenceHubList.Count * spawnableTeam.TicketRespawnCost);
-
-                            if (UnitNamingRules.TryGetNamingRule(__instance.NextKnownTeam, out UnitNamingRule rule))
-                            {
-                                rule.GenerateNew(__instance.NextKnownTeam, out string regular);
-                                foreach (ReferenceHub referenceHub in referenceHubList)
-                                {
-                                    referenceHub.characterClassManager.NetworkCurSpawnableTeamType =
-                                        (byte)__instance.NextKnownTeam;
-                                    referenceHub.characterClassManager.NetworkCurUnitName = regular;
-                                }
-
-                                rule.PlayEntranceAnnouncement(regular);
-                            }
-
-                            RespawnEffectsController.ExecuteAllEffects(RespawnEffectsController.EffectType.UponRespawn, __instance.NextKnownTeam);
-                        }
-
-                        ListPool<ReferenceHub>.Shared.Return(referenceHubList);
-                    }
-
-                    ListPool<API.Features.Player>.Shared.Return(list);
-                    __instance.NextKnownTeam = SpawnableTeamType.None;
+                    list.ShuffleList();
                 }
 
-                return false;
-            }
-            catch (Exception e)
-            {
-                Exiled.API.Features.Log.Error($"Exiled.Events.Patches.Events.Server.RespawningTeam: {e}\n{e.StackTrace}");
+                // Code that should be here is in RespawningTeamEventArgs::ReissueNextKnownTeam
+                var ev = new RespawningTeamEventArgs(list, __instance.NextKnownTeam);
 
-                return true;
+                Handlers.Server.OnRespawningTeam(ev);
+
+                if (ev.IsAllowed && ev.SpawnableTeam != null)
+                {
+                    while (list.Count > ev.MaximumRespawnAmount)
+                        list.RemoveAt(list.Count - 1);
+
+                    list.ShuffleList();
+
+                    List<ReferenceHub> referenceHubList = ListPool<ReferenceHub>.Shared.Rent();
+
+                    foreach (API.Features.Player me in list)
+                    {
+                        try
+                        {
+                            RoleType classid = ev.SpawnableTeam.Value.ClassQueue[Mathf.Min(referenceHubList.Count, spawnableTeam.ClassQueue.Length - 1)];
+
+                            me.ReferenceHub.characterClassManager.SetPlayersClass(classid, me.ReferenceHub.gameObject);
+
+                            referenceHubList.Add(me.ReferenceHub);
+
+                            ServerLogs.AddLog(ServerLogs.Modules.ClassChange, "Player " + me.ReferenceHub.LoggedNameFromRefHub() + " respawned as " + classid + ".", ServerLogs.ServerLogType.GameEvent);
+                        }
+                        catch (Exception ex)
+                        {
+                            if (me != null)
+                                ServerLogs.AddLog(ServerLogs.Modules.ClassChange, "Player " + me.ReferenceHub.LoggedNameFromRefHub() + " couldn't be spawned. Err msg: " + ex.Message, ServerLogs.ServerLogType.GameEvent);
+                            else
+                                ServerLogs.AddLog(ServerLogs.Modules.ClassChange, "Couldn't spawn a player - target's ReferenceHub is null.", ServerLogs.ServerLogType.GameEvent);
+                        }
+                    }
+
+                    if (referenceHubList.Count > 0)
+                    {
+                        ServerLogs.AddLog(ServerLogs.Modules.ClassChange, $"RespawnManager has successfully spawned {referenceHubList.Count} players as {__instance.NextKnownTeam}!", ServerLogs.ServerLogType.GameEvent);
+                        RespawnTickets.Singleton.GrantTickets(__instance.NextKnownTeam, -referenceHubList.Count * spawnableTeam.TicketRespawnCost);
+
+                        if (UnitNamingRules.TryGetNamingRule(__instance.NextKnownTeam, out UnitNamingRule rule))
+                        {
+                            rule.GenerateNew(__instance.NextKnownTeam, out string regular);
+                            foreach (ReferenceHub referenceHub in referenceHubList)
+                            {
+                                referenceHub.characterClassManager.NetworkCurSpawnableTeamType =
+                                    (byte)__instance.NextKnownTeam;
+                                referenceHub.characterClassManager.NetworkCurUnitName = regular;
+                            }
+
+                            rule.PlayEntranceAnnouncement(regular);
+                        }
+
+                        RespawnEffectsController.ExecuteAllEffects(RespawnEffectsController.EffectType.UponRespawn, __instance.NextKnownTeam);
+                    }
+
+                    ListPool<ReferenceHub>.Shared.Return(referenceHubList);
+                }
+
+                ListPool<API.Features.Player>.Shared.Return(list);
+                __instance.NextKnownTeam = SpawnableTeamType.None;
             }
+
+            return false;
         }
     }
 }

--- a/Exiled.Loader/ConfigManager.cs
+++ b/Exiled.Loader/ConfigManager.cs
@@ -82,7 +82,8 @@ namespace Exiled.Loader
                         }
                         catch (YamlException yamlException)
                         {
-                            Log.Error($"{plugin.Name} configs could not be loaded, some of them are in a wrong format, default configs will be loaded instead! {yamlException}");
+                            Log.Error($"{plugin.Name} configs could not be loaded, some of them are in a wrong format, default configs will be loaded instead! {yamlException.Message}");
+                            ExceptionHandler.TrySendingHelpMessage(yamlException);
 
                             deserializedConfigs.Add(plugin.Prefix, plugin.Config);
                         }
@@ -95,7 +96,8 @@ namespace Exiled.Loader
             }
             catch (Exception exception)
             {
-                Log.Error($"An error has occurred while loading configs! {exception}");
+                Log.Error($"An error has occurred while loading configs! {exception.Message}");
+                ExceptionHandler.TrySendingHelpMessage(exception);
 
                 return null;
             }
@@ -123,6 +125,7 @@ namespace Exiled.Loader
             catch (Exception exception)
             {
                 Log.Error($"An error has occurred while saving configs to {Paths.Config} path: {exception}");
+                ExceptionHandler.TrySendingHelpMessage(exception);
 
                 return false;
             }
@@ -148,7 +151,8 @@ namespace Exiled.Loader
             }
             catch (YamlException yamlException)
             {
-                Log.Error($"An error has occurred while serializing configs: {yamlException}");
+                Log.Error($"An error has occurred while serializing configs: {yamlException.Message}");
+                ExceptionHandler.TrySendingHelpMessage(yamlException);
 
                 return false;
             }
@@ -168,6 +172,7 @@ namespace Exiled.Loader
             catch (Exception exception)
             {
                 Log.Error($"An error has occurred while reading configs from {Paths.Config} path: {exception}");
+                ExceptionHandler.TrySendingHelpMessage(exception);
             }
 
             return string.Empty;

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -202,7 +202,6 @@ namespace Exiled.Loader
             catch (Exception exception)
             {
                 Log.Error($"Error while loading an assembly at {path}! {exception}");
-                ExceptionHandler.TrySendingHelpMessage(exception);
             }
 
             return null;
@@ -364,10 +363,10 @@ namespace Exiled.Loader
 
                     return true;
                 }
-                else if (requiredVersion < actualVersion && !Config.ShouldLoadOutdatedPlugins)
+                else if (requiredVersion.Major < actualVersion.Major && !Config.ShouldLoadOutdatedPlugins)
                 {
-                    Log.Error($"You're running an older version of {plugin.Name} ({plugin.Version})! " +
-                              $"Its Required Major version is {requiredVersion}, but excepted {actualVersion}. ");
+                    Log.Error($"{plugin.Name} requires EXILED version {requiredVersion}, however your current version ({actualVersion}) is significantly newer. " +
+                              $"This may cause issues with the plugin, so it will not be loaded. To change this, set should_load_outdated_plugins to true.");
 
                     return true;
                 }
@@ -408,7 +407,6 @@ namespace Exiled.Loader
             catch (Exception exception)
             {
                 Log.Error($"An error has occurred while loading dependencies! {exception}");
-                ExceptionHandler.TrySendingHelpMessage(exception);
             }
         }
     }

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -345,23 +345,22 @@ namespace Exiled.Loader
             var requiredVersion = plugin.RequiredExiledVersion;
             var actualVersion = Version;
 
-            // Check Major version
-            // It's increased when an incompatible API change was made
-            if (requiredVersion.Major != actualVersion.Major)
+            // Check the version
+            if (requiredVersion != actualVersion)
             {
-                // Assume that if the Required Major version is greater than the Actual Major version,
+                // Assume that if the Required version is greater than the Actual version,
                 // Exiled is outdated
-                if (requiredVersion.Major > actualVersion.Major)
+                if (requiredVersion > actualVersion)
                 {
-                    Log.Error($"You're running an older version of Exiled ({Version.ToString(3)})! {plugin.Name} won't be loaded! " +
-                              $"Required version to load it: {plugin.RequiredExiledVersion.ToString(3)}");
+                    Log.Error($"You're running an older version of Exiled ({Version})! {plugin.Name} won't be loaded! " +
+                              $"Required version to load it: {plugin.RequiredExiledVersion}");
 
                     return true;
                 }
-                else if (requiredVersion.Major < actualVersion.Major && !Config.ShouldLoadOutdatedPlugins)
+                else if (requiredVersion < actualVersion && !Config.ShouldLoadOutdatedPlugins)
                 {
-                    Log.Error($"You're running an older version of {plugin.Name} ({plugin.Version.ToString(3)})! " +
-                              $"Its Required Major version is {requiredVersion.Major}, but excepted {actualVersion.Major}. ");
+                    Log.Error($"You're running an older version of {plugin.Name} ({plugin.Version})! " +
+                              $"Its Required Major version is {requiredVersion}, but excepted {actualVersion}. ");
 
                     return true;
                 }

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -195,6 +195,7 @@ namespace Exiled.Loader
             catch (Exception exception)
             {
                 Log.Error($"Error while loading an assembly at {path}! {exception}");
+                ExceptionHandler.TrySendingHelpMessage(exception);
             }
 
             return null;
@@ -256,6 +257,7 @@ namespace Exiled.Loader
             catch (Exception exception)
             {
                 Log.Error($"Error while initializing plugin {assembly.GetName().Name} (at {assembly.Location})! {exception}");
+                ExceptionHandler.TrySendingHelpMessage(exception);
             }
 
             return null;
@@ -279,6 +281,7 @@ namespace Exiled.Loader
                 catch (Exception exception)
                 {
                     Log.Error($"Plugin \"{plugin.Name}\" threw an exception while enabling: {exception}");
+                    ExceptionHandler.TrySendingHelpMessage(exception);
                 }
             }
         }
@@ -303,6 +306,7 @@ namespace Exiled.Loader
                 catch (Exception exception)
                 {
                     Log.Error($"Plugin \"{plugin.Name}\" threw an exception while reloading: {exception}");
+                    ExceptionHandler.TrySendingHelpMessage(exception);
                 }
             }
 
@@ -331,6 +335,7 @@ namespace Exiled.Loader
                 catch (Exception exception)
                 {
                     Log.Error($"Plugin \"{plugin.Name}\" threw an exception while disabling: {exception}");
+                    ExceptionHandler.TrySendingHelpMessage(exception);
                 }
             }
         }
@@ -393,6 +398,7 @@ namespace Exiled.Loader
             catch (Exception exception)
             {
                 Log.Error($"An error has occurred while loading dependencies! {exception}");
+                ExceptionHandler.TrySendingHelpMessage(exception);
             }
         }
     }

--- a/Exiled.Loader/TranslationManager.cs
+++ b/Exiled.Loader/TranslationManager.cs
@@ -71,6 +71,7 @@ namespace Exiled.Loader
             catch (Exception exception)
             {
                 Log.Error($"An error has occurred while loading translations! {exception}");
+                ExceptionHandler.TrySendingHelpMessage(exception);
 
                 return null;
             }
@@ -98,6 +99,7 @@ namespace Exiled.Loader
             catch (Exception exception)
             {
                 Log.Error($"An error has occurred while saving translations to {Paths.Translations} path: {exception}");
+                ExceptionHandler.TrySendingHelpMessage(exception);
 
                 return false;
             }
@@ -119,7 +121,8 @@ namespace Exiled.Loader
             }
             catch (YamlException yamlException)
             {
-                Log.Error($"An error has occurred while serializing translations: {yamlException}");
+                Log.Error($"An error has occurred while serializing translations: {yamlException.Message}");
+                ExceptionHandler.TrySendingHelpMessage(yamlException);
 
                 return false;
             }
@@ -139,6 +142,7 @@ namespace Exiled.Loader
             catch (Exception exception)
             {
                 Log.Error($"An error has occurred while reading translations from {Paths.Translations} path: {exception}");
+                ExceptionHandler.TrySendingHelpMessage(exception);
             }
 
             return string.Empty;

--- a/Exiled.Updater/Updater.cs
+++ b/Exiled.Updater/Updater.cs
@@ -192,6 +192,7 @@ namespace Exiled.Updater
             catch (Exception ex)
             {
                 Log.Error($"{nameof(FindUpdate)} threw an exception:\n{ex}");
+                ExceptionHandler.TrySendingHelpMessage(ex);
             }
 
             newVersion = default;


### PR DESCRIPTION
# Changes:
- Added sending helpful messages to a user, when he gots an exception which can led to solving a problem without needing to ping developers. (right know this PR supports 4 exceptions)
- Removed try-catch from all event patches, because InvokeSafely() has one and it was unnecessary to have them.
- Fixed `Exiled.Loader` bug with checking only the Major version

#513 PR was added, but it will be helpful probably only for developers.

This is still WIP, but I think draft pull request is for that, am I right?