### PR TITLE
Added Map.SpawnGrenade() method

### DIFF
--- a/Exiled.API/Features/Components/CollisionHandler.cs
+++ b/Exiled.API/Features/Components/CollisionHandler.cs
@@ -5,7 +5,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Exiled.CustomItems.API.Components
+namespace Exiled.API.Features.Components
 {
     using System;
 
@@ -18,7 +18,6 @@ namespace Exiled.CustomItems.API.Components
     /// <summary>
     /// Collision Handler for grenades.
     /// </summary>
-    [Obsolete("Use the CollisionHandler from EXILED.API.Features.Components instead.", true)]
     public class CollisionHandler : MonoBehaviour
     {
         /// <summary>

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -511,6 +511,9 @@ namespace Exiled.API.Features
         /// <returns>The <see cref="Grenade"/> being spawned.</returns>
         public static Grenade SpawnGrenade(Vector3 position, GrenadeType grenadeType = GrenadeType.FragGrenade, float fuseTime = 3f, Vector3? velocity = null, bool explodeOnCollision = false, Player player = null)
         {
+            if (!Enum.IsDefined(typeof(GrenadeType), grenadeType))
+                return null;
+
             if (player == null)
                 player = Server.Host;
 

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -508,7 +508,7 @@ namespace Exiled.API.Features
         /// <param name="grenadeType">The <see cref="GrenadeType"/> of the grenade to spawn.</param>
         /// <param name="player">The <see cref="Player"/> to count as the thrower of the grenade.</param>
         /// <returns>The <see cref="Grenade"/> being spawned.</returns>
-        public static Grenade Spawn(Vector3 position, Vector3 velocity, float fuseTime = 3f, GrenadeType grenadeType = GrenadeType.FragGrenade, Player player = null)
+        public static Grenade SpawnGrenade(Vector3 position, Vector3? velocity = null, float fuseTime = 3f, GrenadeType grenadeType = GrenadeType.FragGrenade, Player player = null)
         {
             if (player == null)
                 player = Server.Host;
@@ -518,15 +518,10 @@ namespace Exiled.API.Features
 
             Grenade grenade = Object.Instantiate(settings.grenadeInstance).GetComponent<Grenade>();
 
-            grenade.FullInitData(grenadeManager, position, Quaternion.Euler(grenade.throwStartAngle), velocity, grenade.throwAngularVelocity, player == Server.Host ? Team.RIP : player.Team);
+            grenade.FullInitData(grenadeManager, position, Quaternion.Euler(grenade.throwStartAngle), velocity ?? Vector3.zero, grenade.throwAngularVelocity, player == Server.Host ? Team.RIP : player.Team);
             grenade.NetworkfuseTime = NetworkTime.time + fuseTime;
 
             NetworkServer.Spawn(grenade.gameObject);
-
-            /*
-            if (ExplodeOnCollision)
-                grenade.gameObject.AddComponent<CollisionHandler>().Init(player.GameObject, grenade);
-            */
 
             return grenade;
         }

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -503,12 +503,13 @@ namespace Exiled.API.Features
         /// Spawns a live grenade object on the map.
         /// </summary>
         /// <param name="position">The <see cref="Vector3"/> to spawn the grenade at.</param>
-        /// <param name="velocity">The <see cref="Vector3"/> directional velocity the grenade should move at.</param>
-        /// <param name="fuseTime">The <see cref="float"/> fuse time of the grenade.</param>
         /// <param name="grenadeType">The <see cref="GrenadeType"/> of the grenade to spawn.</param>
+        /// <param name="fuseTime">The <see cref="float"/> fuse time of the grenade.</param>
+        /// <param name="velocity">The <see cref="Vector3"/> directional velocity the grenade should move at.</param>
+        /// <param name="explodeOnCollision">Should the grenade explode on collision with wall/floor.</param>
         /// <param name="player">The <see cref="Player"/> to count as the thrower of the grenade.</param>
         /// <returns>The <see cref="Grenade"/> being spawned.</returns>
-        public static Grenade SpawnGrenade(Vector3 position, Vector3? velocity = null, float fuseTime = 3f, GrenadeType grenadeType = GrenadeType.FragGrenade, Player player = null)
+        public static Grenade SpawnGrenade(Vector3 position, GrenadeType grenadeType = GrenadeType.FragGrenade, float fuseTime = 3f, Vector3? velocity = null, bool explodeOnCollision = false, Player player = null)
         {
             if (player == null)
                 player = Server.Host;
@@ -520,6 +521,9 @@ namespace Exiled.API.Features
 
             grenade.FullInitData(grenadeManager, position, Quaternion.Euler(grenade.throwStartAngle), velocity ?? Vector3.zero, grenade.throwAngularVelocity, player == Server.Host ? Team.RIP : player.Team);
             grenade.NetworkfuseTime = NetworkTime.time + fuseTime;
+
+            if (explodeOnCollision)
+                grenade.gameObject.AddComponent<Components.CollisionHandler>().Init(player.GameObject, grenade);
 
             NetworkServer.Spawn(grenade.gameObject);
 

--- a/Exiled.CustomItems/API/Features/CustomGrenade.cs
+++ b/Exiled.CustomItems/API/Features/CustomGrenade.cs
@@ -14,7 +14,6 @@ namespace Exiled.CustomItems.API.Features
     using Exiled.API.Enums;
     using Exiled.API.Extensions;
     using Exiled.API.Features;
-    using Exiled.CustomItems.API.Components;
     using Exiled.Events.EventArgs;
 
     using Grenades;
@@ -93,7 +92,7 @@ namespace Exiled.CustomItems.API.Features
             NetworkServer.Spawn(grenade.gameObject);
 
             if (ExplodeOnCollision)
-                grenade.gameObject.AddComponent<CollisionHandler>().Init(player.GameObject, grenade);
+                grenade.gameObject.AddComponent<Exiled.API.Features.Components.CollisionHandler>().Init(player.GameObject, grenade);
 
             return grenade;
         }


### PR DESCRIPTION
For some reason, this still wasn't a thing. The same method exists in `Exiled.CustomItems` but it isn't accessible, because you can use it only from a `CustomGrenade` class.

I wanted to add `explodeOnCollision` but because `Exiled.CustomItems` is inaccessible from `Exiled.API` I can't use a collider component from it.