### PR TITLE
Make the Banned event work with unsafe issuer nicknames

### DIFF
--- a/Exiled.Events/EventArgs/ChangedRoleEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangedRoleEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     using Exiled.API.Features;
 
@@ -22,14 +23,14 @@ namespace Exiled.Events.EventArgs
         /// </summary>
         /// <param name="player"><inheritdoc cref="Player"/></param>
         /// <param name="oldRole"><inheritdoc cref="OldRole"/></param>
-        /// <param name="items"><inheritdoc cref="Items"/></param>
+        /// <param name="oldCufferId"><inheritdoc cref="OldCufferId"/></param>
         /// <param name="hasPreservedPosition"><inheritdoc cref="HasPreservedPosition"/></param>
         /// <param name="isEscaped"><inheritdoc cref="IsEscaped"/></param>
-        public ChangedRoleEventArgs(Player player, RoleType oldRole, List<ItemType> items, bool hasPreservedPosition, bool isEscaped)
+        public ChangedRoleEventArgs(Player player, RoleType oldRole, int oldCufferId, bool hasPreservedPosition, bool isEscaped)
         {
             Player = player;
             OldRole = oldRole;
-            Items = items.AsReadOnly();
+            OldCufferId = oldCufferId;
             HasPreservedPosition = hasPreservedPosition;
             IsEscaped = isEscaped;
         }
@@ -45,9 +46,15 @@ namespace Exiled.Events.EventArgs
         public RoleType OldRole { get; }
 
         /// <summary>
-        /// Gets base items that the player has received.
+        /// Gets the id of the player's previous cuffer, or -1 if they were not cuffed.
         /// </summary>
-        public IReadOnlyList<ItemType> Items { get; }
+        public int OldCufferId { get; }
+
+        /// <summary>
+        /// Gets items that the player had before their role was changed.
+        /// </summary>
+        [Obsolete("Use Player.Items instead.", true)]
+        public IReadOnlyList<ItemType> Items => Player.Items.Select(item => item.id).ToList().AsReadOnly();
 
         /// <summary>
         /// Gets a value indicating whether the player escaped or not.

--- a/Exiled.Events/Patches/Events/Player/Banned.cs
+++ b/Exiled.Events/Patches/Events/Player/Banned.cs
@@ -20,9 +20,14 @@ namespace Exiled.Events.Patches.Events.Player
     [HarmonyPatch(typeof(BanHandler), nameof(BanHandler.IssueBan))]
     internal static class Banned
     {
-        private static void Postfix(BanDetails ban, BanHandler.BanType banType)
+        private static void Prefix(BanDetails ban, BanHandler.BanType banType, out string __state)
         {
-            var ev = new BannedEventArgs(string.IsNullOrEmpty(ban.Id) ? null : API.Features.Player.Get(ban.Id), API.Features.Player.Get(ban.Issuer), ban, banType);
+            __state = ban.Issuer;
+        }
+
+        private static void Postfix(BanDetails ban, BanHandler.BanType banType, string __state)
+        {
+            var ev = new BannedEventArgs(string.IsNullOrEmpty(ban.Id) ? null : API.Features.Player.Get(ban.Id), API.Features.Player.Get(__state), ban, banType);
 
             Player.OnBanned(ev);
         }

--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -72,7 +72,7 @@ namespace Exiled.Events.Patches.Events.Player
                     classid = escapingEventArgs.NewRole;
                 }
 
-                var changedRoleEventArgs = new ChangedRoleEventArgs(player, player.Role, startItemsList, lite, escape);
+                var changedRoleEventArgs = new ChangedRoleEventArgs(player, player.Role, player.CufferId, lite, escape);
 
                 ply.GetComponent<CharacterClassManager>().SetClassIDAdv(classid, lite, escape);
                 ply.GetComponent<PlayerStats>().SetHPAmount(__instance.Classes.SafeGet(classid).maxHP);


### PR DESCRIPTION
More info on #547, but essentially the issuer is null if their nickname has unsafe characters.