### PR TITLE
Make the Banned event work with unsafe issuer nicknames

### DIFF
--- a/Exiled.Events/Patches/Events/Player/Banned.cs
+++ b/Exiled.Events/Patches/Events/Player/Banned.cs
@@ -20,9 +20,14 @@ namespace Exiled.Events.Patches.Events.Player
     [HarmonyPatch(typeof(BanHandler), nameof(BanHandler.IssueBan))]
     internal static class Banned
     {
-        private static void Postfix(BanDetails ban, BanHandler.BanType banType)
+        private static void Prefix(BanDetails ban, BanHandler.BanType banType, out string __state)
         {
-            var ev = new BannedEventArgs(string.IsNullOrEmpty(ban.Id) ? null : API.Features.Player.Get(ban.Id), API.Features.Player.Get(ban.Issuer), ban, banType);
+            __state = ban.Issuer;
+        }
+
+        private static void Postfix(BanDetails ban, BanHandler.BanType banType, string __state)
+        {
+            var ev = new BannedEventArgs(string.IsNullOrEmpty(ban.Id) ? null : API.Features.Player.Get(ban.Id), API.Features.Player.Get(__state), ban, banType);
 
             Player.OnBanned(ev);
         }


### PR DESCRIPTION
More info on #547, but essentially the issuer is null if their nickname has unsafe characters.