### PR TITLE
Added shouldClearPrevious to Broadcast methods

### DIFF
--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -390,8 +390,6 @@ namespace Exiled.API.Features
         /// <param name="shouldClearPrevious">Clears all players' broadcasts before sending the new one.</param>
         public static void Broadcast(Broadcast broadcast, bool shouldClearPrevious = false)
         {
-            if (shouldClearPrevious)
-                ClearBroadcasts();
 
             if (broadcast.Show)
                 Server.Broadcast.RpcAddElement(broadcast.Content, broadcast.Duration, broadcast.Type);

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -376,8 +376,23 @@ namespace Exiled.API.Features
         /// Broadcasts a message to all players.
         /// </summary>
         /// <param name="broadcast">The <see cref="Features.Broadcast"/> to be broadcasted.</param>
+        [Obsolete("Use Broadcast(Broadcast, shouldClearPrevious)", true)]
         public static void Broadcast(Broadcast broadcast)
         {
+            if (broadcast.Show)
+                Server.Broadcast.RpcAddElement(broadcast.Content, broadcast.Duration, broadcast.Type);
+        }
+
+        /// <summary>
+        /// Broadcasts a message to all players.
+        /// </summary>
+        /// <param name="broadcast">The <see cref="Features.Broadcast"/> to be broadcasted.</param>
+        /// <param name="shouldClearPrevious">Clears all players' broadcasts before sending the new one.</param>
+        public static void Broadcast(Broadcast broadcast, bool shouldClearPrevious = false)
+        {
+            if (shouldClearPrevious)
+                ClearBroadcasts();
+
             if (broadcast.Show)
                 Server.Broadcast.RpcAddElement(broadcast.Content, broadcast.Duration, broadcast.Type);
         }
@@ -388,8 +403,24 @@ namespace Exiled.API.Features
         /// <param name="duration">The duration in seconds.</param>
         /// <param name="message">The message that will be broadcast (supports Unity Rich Text formatting).</param>
         /// <param name="type">The broadcast type.</param>
+        [Obsolete("Use Broadcast(ushort duration, string message, Broadcast.BroadcastFlags type, bool shouldClearPrevious)", true)]
         public static void Broadcast(ushort duration, string message, global::Broadcast.BroadcastFlags type = global::Broadcast.BroadcastFlags.Normal)
         {
+            Server.Broadcast.RpcAddElement(message, duration, type);
+        }
+
+        /// <summary>
+        /// Broadcasts a message to all players.
+        /// </summary>
+        /// <param name="duration">The duration in seconds.</param>
+        /// <param name="message">The message that will be broadcast (supports Unity Rich Text formatting).</param>
+        /// <param name="type">The broadcast type.</param>
+        /// <param name="shouldClearPrevious">Clears all players' broadcasts before sending the new one.</param>
+        public static void Broadcast(ushort duration, string message, global::Broadcast.BroadcastFlags type = global::Broadcast.BroadcastFlags.Normal, bool shouldClearPrevious = false)
+        {
+            if (shouldClearPrevious)
+                ClearBroadcasts();
+
             Server.Broadcast.RpcAddElement(message, duration, type);
         }
 

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -390,7 +390,6 @@ namespace Exiled.API.Features
         /// <param name="shouldClearPrevious">Clears all players' broadcasts before sending the new one.</param>
         public static void Broadcast(Broadcast broadcast, bool shouldClearPrevious = false)
         {
-
             if (broadcast.Show)
                 Broadcast(broadcast.Duration, broadcast.Content, broadcast.Type, shouldClearPrevious);
         }

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -392,7 +392,7 @@ namespace Exiled.API.Features
         {
 
             if (broadcast.Show)
-                Server.Broadcast.RpcAddElement(broadcast.Content, broadcast.Duration, broadcast.Type);
+                Broadcast(broadcast.Duration, broadcast.Content, broadcast.Type, shouldClearPrevious);
         }
 
         /// <summary>

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1166,7 +1166,7 @@ namespace Exiled.API.Features
         public void Broadcast(Broadcast broadcast, bool shouldClearPrevious = false)
         {
             if (broadcast.Show)
-                Broadcast(broadcast.Duration, broadcast.Content, broadcast.Type);
+                Broadcast(broadcast.Duration, broadcast.Content, broadcast.Type, shouldClearPrevious);
         }
 
         /// <summary>

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1322,7 +1322,7 @@ namespace Exiled.API.Features
         /// <param name="duration">The broadcast duration.</param>
         /// <param name="message">The message to be broadcasted.</param>
         /// <param name="type">The broadcast type.</param>
-        /// <param name="overrideMode">Clears the player's broadcast before sending the new one.</param>
+        /// <param name="shouldClearPrevious">Clears all player's broadcasts before sending the new one.</param>
         public void Broadcast(ushort duration, string message, global::Broadcast.BroadcastFlags type = global::Broadcast.BroadcastFlags.Normal, bool overrideMode = false)
         {
             if (overrideMode) ClearBroadcasts();

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1162,7 +1162,7 @@ namespace Exiled.API.Features
         /// Broadcasts the given <see cref="Features.Broadcast"/> to the player.
         /// </summary>
         /// <param name="broadcast">The <see cref="Features.Broadcast"/> to be broadcasted.</param>
-        /// <param name="overrideMode">Clears the player's broadcast before sending the new one.</param>
+        /// <param name="shouldClearPrevious">Clears all player's broadcasts before sending the new one.</param>
         public void Broadcast(Broadcast broadcast, bool shouldClearPrevious = false)
         {
             if (overrideMode) ClearBroadcasts();

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1151,7 +1151,7 @@ namespace Exiled.API.Features
         /// Broadcasts the given <see cref="Features.Broadcast"/> to the player.
         /// </summary>
         /// <param name="broadcast">The <see cref="Features.Broadcast"/> to be broadcasted.</param>
-        [Obsolete("Use Broadcast(Broadcast broadcast, bool overrideMode) instead.", false)]
+        [Obsolete("Use Broadcast(Broadcast broadcast, bool shouldClearPrevious) instead.", true)]
         public void Broadcast(Broadcast broadcast)
         {
             if (broadcast.Show)

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1324,7 +1324,7 @@ namespace Exiled.API.Features
         /// <param name="shouldClearPrevious">Clears all player's broadcasts before sending the new one.</param>
         public void Broadcast(ushort duration, string message, global::Broadcast.BroadcastFlags type = global::Broadcast.BroadcastFlags.Normal, bool shouldClearPrevious = false)
         {
-            if (shouldClearPrevious) 
+            if (shouldClearPrevious)
                 ClearBroadcasts();
 
             Server.Broadcast.TargetAddElement(Connection, message, duration, type);

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1309,7 +1309,7 @@ namespace Exiled.API.Features
         /// <param name="duration">The broadcast duration.</param>
         /// <param name="message">The message to be broadcasted.</param>
         /// <param name="type">The broadcast type.</param>
-        [Obsolete("Use Broadcast(ushort duration, string message, Broadcast.BroadcastFlags type, bool overrideMode) instead.", false)]
+        [Obsolete("Use Broadcast(ushort duration, string message, Broadcast.BroadcastFlags type, bool shouldClearPrevious) instead.", true)]
         public void Broadcast(ushort duration, string message, global::Broadcast.BroadcastFlags type = global::Broadcast.BroadcastFlags.Normal)
         {
             Server.Broadcast.TargetAddElement(Connection, message, duration, type);

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1151,8 +1151,10 @@ namespace Exiled.API.Features
         /// Broadcasts the given <see cref="Features.Broadcast"/> to the player.
         /// </summary>
         /// <param name="broadcast">The <see cref="Features.Broadcast"/> to be broadcasted.</param>
-        public void Broadcast(Broadcast broadcast)
+        /// <param name="overrideMode">Clears the player's broadcast before send the new one.</param>
+        public void Broadcast(Broadcast broadcast, bool overrideMode = false)
         {
+            if (overrideMode) ClearBroadcasts();
             if (broadcast.Show)
                 Broadcast(broadcast.Duration, broadcast.Content, broadcast.Type);
         }
@@ -1297,8 +1299,10 @@ namespace Exiled.API.Features
         /// <param name="duration">The broadcast duration.</param>
         /// <param name="message">The message to be broadcasted.</param>
         /// <param name="type">The broadcast type.</param>
-        public void Broadcast(ushort duration, string message, global::Broadcast.BroadcastFlags type = global::Broadcast.BroadcastFlags.Normal)
+        /// <param name="overrideMode">Clears the player's broadcast before send the new one.</param>
+        public void Broadcast(ushort duration, string message, global::Broadcast.BroadcastFlags type = global::Broadcast.BroadcastFlags.Normal, bool overrideMode = false)
         {
+            if (overrideMode) ClearBroadcasts();
             Server.Broadcast.TargetAddElement(Connection, message, duration, type);
         }
 

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1165,7 +1165,6 @@ namespace Exiled.API.Features
         /// <param name="shouldClearPrevious">Clears all player's broadcasts before sending the new one.</param>
         public void Broadcast(Broadcast broadcast, bool shouldClearPrevious = false)
         {
-            if (overrideMode) ClearBroadcasts();
             if (broadcast.Show)
                 Broadcast(broadcast.Duration, broadcast.Content, broadcast.Type);
         }

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1163,7 +1163,7 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="broadcast">The <see cref="Features.Broadcast"/> to be broadcasted.</param>
         /// <param name="overrideMode">Clears the player's broadcast before sending the new one.</param>
-        public void Broadcast(Broadcast broadcast, bool overrideMode = false)
+        public void Broadcast(Broadcast broadcast, bool shouldClearPrevious = false)
         {
             if (overrideMode) ClearBroadcasts();
             if (broadcast.Show)

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1151,7 +1151,18 @@ namespace Exiled.API.Features
         /// Broadcasts the given <see cref="Features.Broadcast"/> to the player.
         /// </summary>
         /// <param name="broadcast">The <see cref="Features.Broadcast"/> to be broadcasted.</param>
-        /// <param name="overrideMode">Clears the player's broadcast before send the new one.</param>
+        [Obsolete("Deprecated", false)]
+        public void Broadcast(Broadcast broadcast)
+        {
+            if (broadcast.Show)
+                Broadcast(broadcast.Duration, broadcast.Content, broadcast.Type);
+        }
+
+        /// <summary>
+        /// Broadcasts the given <see cref="Features.Broadcast"/> to the player.
+        /// </summary>
+        /// <param name="broadcast">The <see cref="Features.Broadcast"/> to be broadcasted.</param>
+        /// <param name="overrideMode">Clears the player's broadcast before sending the new one.</param>
         public void Broadcast(Broadcast broadcast, bool overrideMode = false)
         {
             if (overrideMode) ClearBroadcasts();
@@ -1299,7 +1310,19 @@ namespace Exiled.API.Features
         /// <param name="duration">The broadcast duration.</param>
         /// <param name="message">The message to be broadcasted.</param>
         /// <param name="type">The broadcast type.</param>
-        /// <param name="overrideMode">Clears the player's broadcast before send the new one.</param>
+        [Obsolete("Deprecated", false)]
+        public void Broadcast(ushort duration, string message, global::Broadcast.BroadcastFlags type = global::Broadcast.BroadcastFlags.Normal)
+        {
+            Server.Broadcast.TargetAddElement(Connection, message, duration, type);
+        }
+
+        /// <summary>
+        /// A simple broadcast to a <see cref="ReferenceHub"/>. Doesn't get logged to the console and can be monospaced.
+        /// </summary>
+        /// <param name="duration">The broadcast duration.</param>
+        /// <param name="message">The message to be broadcasted.</param>
+        /// <param name="type">The broadcast type.</param>
+        /// <param name="overrideMode">Clears the player's broadcast before sending the new one.</param>
         public void Broadcast(ushort duration, string message, global::Broadcast.BroadcastFlags type = global::Broadcast.BroadcastFlags.Normal, bool overrideMode = false)
         {
             if (overrideMode) ClearBroadcasts();

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1324,7 +1324,9 @@ namespace Exiled.API.Features
         /// <param name="shouldClearPrevious">Clears all player's broadcasts before sending the new one.</param>
         public void Broadcast(ushort duration, string message, global::Broadcast.BroadcastFlags type = global::Broadcast.BroadcastFlags.Normal, bool shouldClearPrevious = false)
         {
-            if (overrideMode) ClearBroadcasts();
+            if (shouldClearPrevious) 
+                ClearBroadcasts();
+
             Server.Broadcast.TargetAddElement(Connection, message, duration, type);
         }
 

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1322,7 +1322,7 @@ namespace Exiled.API.Features
         /// <param name="message">The message to be broadcasted.</param>
         /// <param name="type">The broadcast type.</param>
         /// <param name="shouldClearPrevious">Clears all player's broadcasts before sending the new one.</param>
-        public void Broadcast(ushort duration, string message, global::Broadcast.BroadcastFlags type = global::Broadcast.BroadcastFlags.Normal, bool overrideMode = false)
+        public void Broadcast(ushort duration, string message, global::Broadcast.BroadcastFlags type = global::Broadcast.BroadcastFlags.Normal, bool shouldClearPrevious = false)
         {
             if (overrideMode) ClearBroadcasts();
             Server.Broadcast.TargetAddElement(Connection, message, duration, type);

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1151,7 +1151,7 @@ namespace Exiled.API.Features
         /// Broadcasts the given <see cref="Features.Broadcast"/> to the player.
         /// </summary>
         /// <param name="broadcast">The <see cref="Features.Broadcast"/> to be broadcasted.</param>
-        [Obsolete("Deprecated", false)]
+        [Obsolete("Use Broadcast(Broadcast broadcast, bool overrideMode) instead.", false)]
         public void Broadcast(Broadcast broadcast)
         {
             if (broadcast.Show)
@@ -1310,7 +1310,7 @@ namespace Exiled.API.Features
         /// <param name="duration">The broadcast duration.</param>
         /// <param name="message">The message to be broadcasted.</param>
         /// <param name="type">The broadcast type.</param>
-        [Obsolete("Deprecated", false)]
+        [Obsolete("Use Broadcast(ushort duration, string message, Broadcast.BroadcastFlags type, bool overrideMode) instead.", false)]
         public void Broadcast(ushort duration, string message, global::Broadcast.BroadcastFlags type = global::Broadcast.BroadcastFlags.Normal)
         {
             Server.Broadcast.TargetAddElement(Connection, message, duration, type);

--- a/Exiled.Example/Events/PlayerHandler.cs
+++ b/Exiled.Example/Events/PlayerHandler.cs
@@ -83,7 +83,7 @@ namespace Exiled.Example.Events
             if (!Instance.Config.JoinedBroadcast.Show)
                 return;
 
-            ev.Player.Broadcast(Instance.Config.JoinedBroadcast.Duration, Instance.Config.JoinedBroadcast.Content, Instance.Config.JoinedBroadcast.Type);
+            ev.Player.Broadcast(Instance.Config.JoinedBroadcast.Duration, Instance.Config.JoinedBroadcast.Content, Instance.Config.JoinedBroadcast.Type, false);
         }
 
         /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnUnlockingGenerator(UnlockingGeneratorEventArgs)"/>


### PR DESCRIPTION
It's an optional parameter and it just clears player's broadcasts before sending the new one.
I'm just too lazy to ClearBroadcasts() and then send the new one.