### PR TITLE
Allows Custom Items to be spawned inside lockers.

### DIFF
--- a/Exiled.CustomItems/API/Enums/SpawnLocation.cs
+++ b/Exiled.CustomItems/API/Enums/SpawnLocation.cs
@@ -151,5 +151,10 @@ namespace Exiled.CustomItems.API
         /// Just inside the door at the bottom of the server's room.
         /// </summary>
         InsideServersBottom,
+
+        /// <summary>
+        /// Inside a random locker on the map.
+        /// </summary>
+        InsideLocker,
     }
 }

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -468,9 +468,38 @@ namespace Exiled.CustomItems.API.Features
 
                 spawned++;
 
-                Spawn(spawnPoint.Position.ToVector3, out _);
+                if (spawnPoint is DynamicSpawnPoint dynamicSpawnPoint && dynamicSpawnPoint.Location == SpawnLocation.InsideLocker)
+                {
+                    for (int i = 0; i < 50; i++)
+                    {
+                        Locker locker =
+                            LockerManager.singleton.lockers[
+                                Instance.Rng.Next(LockerManager.singleton.lockers.Length)];
+                        if (locker._itemsToSpawn == null)
+                        {
+                            Log.Debug($"{nameof(Spawn)}: Invalid locker location. Attempting to find a new one..", Instance.Config.Debug);
+                            continue;
+                        }
 
-                Log.Debug($"Spawned {Name} at {spawnPoint.Position} ({spawnPoint.Name})", Instance.Config.Debug);
+                        LockerChamber chamber = locker.chambers[Instance.Rng.Next(Mathf.Max(0, locker.chambers.Length - 1))];
+
+                        foreach (Locker.ItemToSpawn item in locker._itemsToSpawn.ToList())
+                        {
+                            if (item._pos == chamber.spawnpoint.position)
+                                locker._itemsToSpawn.Remove(item);
+                        }
+
+                        Vector3 position = chamber.spawnpoint.transform.position;
+                        Spawn(position, out _);
+                        Log.Debug($"Spawned {Name} at {position} ({spawnPoint.Name})", Instance.Config.Debug);
+                    }
+                }
+                else
+                {
+                    Spawn(spawnPoint.Position.ToVector3, out _);
+
+                    Log.Debug($"Spawned {Name} at {spawnPoint.Position} ({spawnPoint.Name})", Instance.Config.Debug);
+                }
             }
 
             return spawned;
@@ -699,7 +728,7 @@ namespace Exiled.CustomItems.API.Features
 
                 Spawn(ev.Player, item, out _);
 
-                Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
+                MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }
         }
 
@@ -721,7 +750,7 @@ namespace Exiled.CustomItems.API.Features
 
                 Spawn(ev.Target, item, out _);
 
-                Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Target.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
+                MirrorExtensions.ResyncSyncVar(ev.Target.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }
         }
 
@@ -743,7 +772,7 @@ namespace Exiled.CustomItems.API.Features
 
                 Spawn(Role.GetRandomSpawnPoint(ev.NewRole), item, out _);
 
-                Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
+                MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }
         }
 
@@ -809,7 +838,7 @@ namespace Exiled.CustomItems.API.Features
         {
             if (!Check(ev.NewItem))
             {
-                Exiled.API.Extensions.MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_displayName));
+                MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_displayName));
                 return;
             }
 

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -493,6 +493,8 @@ namespace Exiled.CustomItems.API.Features
                         Vector3 position = chamber.spawnpoint.transform.position;
                         Spawn(position, out _);
                         Log.Debug($"Spawned {Name} at {position} ({spawnPoint.Name})", Instance.Config.Debug);
+
+                        break;
                     }
                 }
                 else

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -17,6 +17,7 @@ namespace Exiled.CustomItems.API.Features
     using Exiled.CustomItems.API.EventArgs;
     using Exiled.CustomItems.API.Spawn;
     using Exiled.Events.EventArgs;
+    using Exiled.Loader;
 
     using MEC;
 
@@ -474,14 +475,14 @@ namespace Exiled.CustomItems.API.Features
                     {
                         Locker locker =
                             LockerManager.singleton.lockers[
-                                Instance.Rng.Next(LockerManager.singleton.lockers.Length)];
+                                Loader.Random.Next(LockerManager.singleton.lockers.Length)];
                         if (locker._itemsToSpawn == null)
                         {
                             Log.Debug($"{nameof(Spawn)}: Invalid locker location. Attempting to find a new one..", Instance.Config.Debug);
                             continue;
                         }
 
-                        LockerChamber chamber = locker.chambers[Instance.Rng.Next(Mathf.Max(0, locker.chambers.Length - 1))];
+                        LockerChamber chamber = locker.chambers[Loader.Random.Next(Mathf.Max(0, locker.chambers.Length - 1))];
 
                         foreach (Locker.ItemToSpawn item in locker._itemsToSpawn.ToList())
                         {

--- a/Exiled.CustomItems/CustomItems.cs
+++ b/Exiled.CustomItems/CustomItems.cs
@@ -25,6 +25,7 @@ namespace Exiled.CustomItems
     {
         private static readonly CustomItems Singleton = new CustomItems();
 
+        private Random rng = new Random();
         private RoundHandler roundHandler;
         private ServerHandler serverHandler;
         private PlayerHandler playerHandler;
@@ -38,6 +39,11 @@ namespace Exiled.CustomItems
         /// Gets the static reference to this <see cref="CustomItems"/> class.
         /// </summary>
         public static CustomItems Instance => Singleton;
+
+        /// <summary>
+        /// Gets a random number generator.
+        /// </summary>
+        internal Random Rng => rng;
 
         /// <inheritdoc />
         public override void OnEnabled()

--- a/Exiled.CustomItems/CustomItems.cs
+++ b/Exiled.CustomItems/CustomItems.cs
@@ -25,7 +25,6 @@ namespace Exiled.CustomItems
     {
         private static readonly CustomItems Singleton = new CustomItems();
 
-        private Random rng = new Random();
         private RoundHandler roundHandler;
         private ServerHandler serverHandler;
         private PlayerHandler playerHandler;
@@ -39,11 +38,6 @@ namespace Exiled.CustomItems
         /// Gets the static reference to this <see cref="CustomItems"/> class.
         /// </summary>
         public static CustomItems Instance => Singleton;
-
-        /// <summary>
-        /// Gets a random number generator.
-        /// </summary>
-        internal Random Rng => rng;
 
         /// <inheritdoc />
         public override void OnEnabled()


### PR DESCRIPTION
This PR adds the ability for Custom Items to use a "InsideLocker" dynamic spawn location. This will pick a random locker on the map, and replace the item that would normally spawn inside the locker with the custom item.