### PR TITLE
CustomItems Commands Improvements

### DIFF
--- a/Exiled.CustomItems/Commands/Give.cs
+++ b/Exiled.CustomItems/Commands/Give.cs
@@ -16,6 +16,8 @@ namespace Exiled.CustomItems.Commands
     using Exiled.CustomItems.API.Features;
     using Exiled.Permissions.Extensions;
 
+    using RemoteAdmin;
+
     /// <summary>
     /// The command to give a player an item.
     /// </summary>
@@ -48,15 +50,36 @@ namespace Exiled.CustomItems.Commands
                 return false;
             }
 
-            if (arguments.Count < 2)
+            if (arguments.Count == 0)
             {
-                response = "give [Custom item name/Custom item ID] [Nickname/PlayerID/UserID/all/*]";
+                response = "give <Custom item name/Custom item ID> [Nickname/PlayerID/UserID/all/*]";
                 return false;
             }
 
             if (!CustomItem.TryGet(arguments.At(0), out CustomItem item))
             {
                 response = $"Custom item {arguments.At(0)} not found!";
+                return false;
+            }
+
+            if (arguments.Count == 1)
+            {
+                if (sender is PlayerCommandSender playerCommandSender)
+                {
+                    var player = Player.Get(playerCommandSender.SenderId);
+
+                    if (!CheckEligible(player))
+                    {
+                        response = "You cannot receive custom items!";
+                        return false;
+                    }
+
+                    item.Give(player);
+                    response = $"{item.Name} given to {player.Nickname} ({player.UserId})";
+                    return true;
+                }
+
+                response = "Failed to provide a valid player, please follow the syntax.";
                 return false;
             }
 
@@ -96,7 +119,7 @@ namespace Exiled.CustomItems.Commands
         /// </summary>
         private bool CheckEligible(Player player)
         {
-            return player.IsAlive && !player.IsScp && !player.IsCuffed && player.Inventory.items.Count < 8;
+            return player.IsAlive && !player.IsCuffed && player.Inventory.items.Count < 8;
         }
     }
 }

--- a/Exiled.CustomItems/Commands/Give.cs
+++ b/Exiled.CustomItems/Commands/Give.cs
@@ -119,7 +119,7 @@ namespace Exiled.CustomItems.Commands
         /// </summary>
         private bool CheckEligible(Player player)
         {
-            return player.IsAlive && !player.IsCuffed && player.Inventory.items.Count < 8;
+            return player.IsAlive && !player.IsScp && !player.IsCuffed && player.Inventory.items.Count < 8;
         }
     }
 }

--- a/Exiled.CustomItems/Commands/List/Registered.cs
+++ b/Exiled.CustomItems/Commands/List/Registered.cs
@@ -8,6 +8,7 @@
 namespace Exiled.CustomItems.Commands.List
 {
     using System;
+    using System.Linq;
     using System.Text;
 
     using CommandSystem;
@@ -63,7 +64,7 @@ namespace Exiled.CustomItems.Commands.List
 
             message.Append("[Registered custom items (").Append(CustomItem.Registered.Count).AppendLine(")]");
 
-            foreach (CustomItem customItem in CustomItem.Registered)
+            foreach (CustomItem customItem in CustomItem.Registered.OrderBy(item => item.Id))
                 message.Append('[').Append(customItem.Id).Append(". ").Append(customItem.Name).Append(" (").Append(customItem.Type).Append(')').AppendLine("]");
 
             response = StringBuilderPool.Shared.ToStringReturn(message);


### PR DESCRIPTION
**Couple of small QoL changes:**

- **"ci give" command's player identifier is now optional:**
Using the give command without providing an identifier will choose the sender as the player who will receive the CustomItem, we're all too lazy to write our own name over and over again. (If an identifier was specified but was invalid, it will still throw a syntax error response)

- **~~You can now use the give command on SCPs:~~**  Reverted
~~While SCPs can't normally open their inventory, if you fake-change a syncvar using Mirror so the client thinks they're a human class, they will be considered SCPs, but be able to use their inventory normally, as well as their items. (That and also currently in the beta SCPs are able to access their items through hotkeys, but that might change in the future so I'm not considering it as a real reason)~~

- **Registered list gets now ordered by IDs:**
It just looks a lot less like a mess, currently if you wanna have it ordered, you must register the items in the order you want it to show up, if you ask me to revert this I will fight you.

I dedicate this video to y'all dev bois
https://www.youtube.com/watch?v=5xooMXyleXM