### PR TITLE
Add a property to disable spawn of an CustomItem's pickup when owner escapes

### DIFF
--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -66,6 +66,11 @@ namespace Exiled.CustomItems.API.Features
         public virtual float Durability { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether a pickup will be spawned when player escapes or not.
+        /// </summary>
+        public virtual bool ShouldSpawnPickupOnEscape { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the ItemType to use for this item.
         /// </summary>
         public virtual ItemType Type
@@ -773,7 +778,8 @@ namespace Exiled.CustomItems.API.Features
 
                 InsideInventories.Remove(item.uniq);
 
-                Spawn(Role.GetRandomSpawnPoint(ev.NewRole), item, out _);
+                if (ShouldSpawnPickupOnEscape)
+                    Spawn(Role.GetRandomSpawnPoint(ev.NewRole), item, out _);
 
                 MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }


### PR DESCRIPTION
Currently Exiled spawns a pickup of CustomItem when player escapes with it inside his inventory but sometimes you don't need this  to happen. Now you can set a property **ShouldSpawnPickupOnEscape** to false to disable spawn of pickup on escaping. 