### PR TITLE
Fix IsFriendlyFireEnabled

### DIFF
--- a/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
+++ b/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
@@ -8,6 +8,8 @@
 namespace Exiled.Events.Patches.Generic
 {
 #pragma warning disable SA1118
+#pragma warning disable SA1402
+#pragma warning disable SA1649
 #pragma warning disable SA1313
     using System.Collections.Generic;
     using System.Reflection.Emit;
@@ -16,7 +18,11 @@ namespace Exiled.Events.Patches.Generic
 
     using HarmonyLib;
 
+    using InventorySystem.Items.ThrowableProjectiles;
+
     using NorthwoodLib.Pools;
+
+    using UnityEngine;
 
     using static HarmonyLib.AccessTools;
 
@@ -26,11 +32,165 @@ namespace Exiled.Events.Patches.Generic
     [HarmonyPatch(typeof(HitboxIdentity), nameof(HitboxIdentity.CheckFriendlyFire), new[] { typeof(ReferenceHub), typeof(ReferenceHub), typeof(bool) })]
     internal static class IndividualFriendlyFire
     {
-        private static void Prefix(HitboxIdentity __instance, ReferenceHub attacker, ReferenceHub victim, bool ignoreConfig = false)
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
-            Player player = Player.Get(attacker);
-            if (player != null && player.IsFriendlyFireEnabled)
-                ignoreConfig = true;
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            Label returnLabel = generator.DefineLabel();
+
+            int index = newInstructions.Count - 1;
+
+            newInstructions[index].labels.Add(returnLabel);
+
+            newInstructions.InsertRange(index, new[]
+            {
+                new CodeInstruction(OpCodes.Brtrue_S, returnLabel),
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.IsFriendlyFireEnabled))),
+            });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+
+    /// <summary>
+    /// Patches <see cref="HitboxIdentity.Damage(float, InventorySystem.Items.IDamageDealer, Footprinting.Footprint, UnityEngine.Vector3)"/>.
+    /// </summary>
+    [HarmonyPatch(typeof(HitboxIdentity), nameof(HitboxIdentity.Damage))]
+    internal static class HitboxIdentityDamagePatch
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            const int instructionsToRemove = 6;
+            int index = newInstructions.FindIndex(code => code.opcode == OpCodes.Ldloc_3);
+
+            newInstructions.RemoveRange(index, instructionsToRemove);
+
+            newInstructions.InsertRange(index, new[]
+            {
+                new CodeInstruction(OpCodes.Ldarg_3),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Footprinting.Footprint), nameof(Footprinting.Footprint.Hub))),
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(HitboxIdentity), nameof(HitboxIdentity.TargetHub))),
+                new CodeInstruction(OpCodes.Ldc_I4_0),
+                new CodeInstruction(OpCodes.Call, Method(typeof(HitboxIdentity), nameof(HitboxIdentity.CheckFriendlyFire), new[] { typeof(ReferenceHub), typeof(ReferenceHub), typeof(bool) })),
+            });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+
+    /// <summary>
+    /// Patches <see cref="ExplosionGrenade.ExplodeDestructible(IDestructible)"/>.
+    /// </summary>
+    [HarmonyPatch(typeof(ExplosionGrenade), nameof(ExplosionGrenade.ExplodeDestructible))]
+    internal static class ExplosionGrenadeExplodeDestructiblePatch
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            const int TARGET_IS_OWNER_INDEX = 5;
+            const int offset = 6;
+            const int instructionsToRemove = 8;
+
+            int index = newInstructions.FindIndex(code => code.opcode == OpCodes.Stloc_S &&
+                ((LocalBuilder)code.operand).LocalIndex == TARGET_IS_OWNER_INDEX) + offset;
+
+            newInstructions.RemoveRange(index, instructionsToRemove);
+
+            newInstructions.InsertRange(index, new[]
+            {
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldflda, Field(typeof(ExplosionGrenade), nameof(ExplosionGrenade.PreviousOwner))),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Footprinting.Footprint), nameof(Footprinting.Footprint.Hub))),
+                new CodeInstruction(OpCodes.Ldloc_3),
+                new CodeInstruction(OpCodes.Ldc_I4_0),
+                new CodeInstruction(OpCodes.Call, Method(typeof(HitboxIdentity), nameof(HitboxIdentity.CheckFriendlyFire), new[] { typeof(ReferenceHub), typeof(ReferenceHub), typeof(bool) })),
+            });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+
+    /// <summary>
+    /// Patches <see cref="FlashbangGrenade.PlayExplosionEffects()"/>.
+    /// </summary>
+    [HarmonyPatch(typeof(FlashbangGrenade), nameof(FlashbangGrenade.PlayExplosionEffects))]
+    internal static class FlashbangGrenadePlayExplosionEffectsPatch
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            const int offset = 1;
+            const int instructionsToRemove = 9;
+            int index = newInstructions.FindLastIndex(code => code.opcode == OpCodes.Brtrue_S) + offset;
+
+            newInstructions.RemoveRange(index, instructionsToRemove);
+
+            newInstructions.InsertRange(index, new[]
+            {
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldflda, Field(typeof(FlashbangGrenade), nameof(FlashbangGrenade.PreviousOwner))),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Footprinting.Footprint), nameof(Footprinting.Footprint.Hub))),
+                new CodeInstruction(OpCodes.Ldloca_S, 2),
+                new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(KeyValuePair<GameObject, ReferenceHub>), nameof(KeyValuePair<GameObject, ReferenceHub>.Value))),
+                new CodeInstruction(OpCodes.Ldc_I4_0),
+                new CodeInstruction(OpCodes.Call, Method(typeof(HitboxIdentity), nameof(HitboxIdentity.CheckFriendlyFire), new[] { typeof(ReferenceHub), typeof(ReferenceHub), typeof(bool) })),
+            });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+
+    /// <summary>
+    /// Patches <see cref="Scp018Projectile.DetectPlayers()"/>.
+    /// </summary>
+    [HarmonyPatch(typeof(Scp018Projectile), nameof(Scp018Projectile.DetectPlayers))]
+    internal static class Scp018ProjectileDetectPlayersPatch
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            const int REFERENCE_HUB_INDEX = 1;
+            const int offset = 5;
+            const int instructionsToRemove = 7;
+
+            int index = newInstructions.FindLastIndex(code => code.opcode == OpCodes.Ldloca_S &&
+                ((LocalBuilder)code.operand).LocalIndex == REFERENCE_HUB_INDEX) + offset;
+
+            newInstructions.RemoveRange(index, instructionsToRemove);
+
+            newInstructions.InsertRange(index, new[]
+            {
+                new CodeInstruction(OpCodes.Ldflda, Field(typeof(Scp018Projectile), nameof(Scp018Projectile.PreviousOwner))),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Footprinting.Footprint), nameof(Footprinting.Footprint.Hub))),
+                new CodeInstruction(OpCodes.Ldloc_1),
+                new CodeInstruction(OpCodes.Ldc_I4_0),
+                new CodeInstruction(OpCodes.Call, Method(typeof(HitboxIdentity), nameof(HitboxIdentity.CheckFriendlyFire), new[] { typeof(ReferenceHub), typeof(ReferenceHub), typeof(bool) })),
+            });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
         }
     }
 }

--- a/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
+++ b/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
@@ -42,6 +42,8 @@ namespace Exiled.Events.Patches.Generic
 
             newInstructions[index].labels.Add(returnLabel);
 
+            // if (true) return true;
+            // else return Player.Get(ReferenceHub).IsFriendlyFireEnabled;
             newInstructions.InsertRange(index, new[]
             {
                 new CodeInstruction(OpCodes.Brtrue_S, returnLabel),
@@ -72,12 +74,17 @@ namespace Exiled.Events.Patches.Generic
 
             newInstructions.RemoveRange(index, instructionsToRemove);
 
+            // HitboxIdentity.CheckFriendlyFire(ReferenceHub, ReferenceHub, false)
             newInstructions.InsertRange(index, new[]
             {
+                // AttackerFootprint.Hub
                 new CodeInstruction(OpCodes.Ldarg_3),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(Footprinting.Footprint), nameof(Footprinting.Footprint.Hub))),
+
+                // this.TargetHub
                 new CodeInstruction(OpCodes.Ldarg_0),
                 new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(HitboxIdentity), nameof(HitboxIdentity.TargetHub))),
+
                 new CodeInstruction(OpCodes.Ldc_I4_0),
                 new CodeInstruction(OpCodes.Call, Method(typeof(HitboxIdentity), nameof(HitboxIdentity.CheckFriendlyFire), new[] { typeof(ReferenceHub), typeof(ReferenceHub), typeof(bool) })),
             });
@@ -108,12 +115,17 @@ namespace Exiled.Events.Patches.Generic
 
             newInstructions.RemoveRange(index, instructionsToRemove);
 
+            // HitboxIdentity.CheckFriendlyFire(ReferenceHub, ReferenceHub, false)
             newInstructions.InsertRange(index, new[]
             {
+                // this.PreviousOwner.Hub
                 new CodeInstruction(OpCodes.Ldarg_0),
                 new CodeInstruction(OpCodes.Ldflda, Field(typeof(ExplosionGrenade), nameof(ExplosionGrenade.PreviousOwner))),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(Footprinting.Footprint), nameof(Footprinting.Footprint.Hub))),
+
+                // targetReferenceHub
                 new CodeInstruction(OpCodes.Ldloc_3),
+
                 new CodeInstruction(OpCodes.Ldc_I4_0),
                 new CodeInstruction(OpCodes.Call, Method(typeof(HitboxIdentity), nameof(HitboxIdentity.CheckFriendlyFire), new[] { typeof(ReferenceHub), typeof(ReferenceHub), typeof(bool) })),
             });
@@ -141,13 +153,18 @@ namespace Exiled.Events.Patches.Generic
 
             newInstructions.RemoveRange(index, instructionsToRemove);
 
+            // HitboxIdentity.CheckFriendlyFire(ReferenceHub, ReferenceHub, false)
             newInstructions.InsertRange(index, new[]
             {
+                // this.PreviousOwner.Hub
                 new CodeInstruction(OpCodes.Ldarg_0),
                 new CodeInstruction(OpCodes.Ldflda, Field(typeof(FlashbangGrenade), nameof(FlashbangGrenade.PreviousOwner))),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(Footprinting.Footprint), nameof(Footprinting.Footprint.Hub))),
+
+                // KeyValuePair<GameObject, ReferenceHub>.Value (target ReferenceHub)
                 new CodeInstruction(OpCodes.Ldloca_S, 2),
                 new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(KeyValuePair<GameObject, ReferenceHub>), nameof(KeyValuePair<GameObject, ReferenceHub>.Value))),
+
                 new CodeInstruction(OpCodes.Ldc_I4_0),
                 new CodeInstruction(OpCodes.Call, Method(typeof(HitboxIdentity), nameof(HitboxIdentity.CheckFriendlyFire), new[] { typeof(ReferenceHub), typeof(ReferenceHub), typeof(bool) })),
             });
@@ -178,11 +195,16 @@ namespace Exiled.Events.Patches.Generic
 
             newInstructions.RemoveRange(index, instructionsToRemove);
 
+            // HitboxIdentity.CheckFriendlyFire(ReferenceHub, ReferenceHub, false)
             newInstructions.InsertRange(index, new[]
             {
+                // Scp018Projectile.PreviousOwner.Hub
                 new CodeInstruction(OpCodes.Ldflda, Field(typeof(Scp018Projectile), nameof(Scp018Projectile.PreviousOwner))),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(Footprinting.Footprint), nameof(Footprinting.Footprint.Hub))),
+
+                // targetReferenceHub
                 new CodeInstruction(OpCodes.Ldloc_1),
+
                 new CodeInstruction(OpCodes.Ldc_I4_0),
                 new CodeInstruction(OpCodes.Call, Method(typeof(HitboxIdentity), nameof(HitboxIdentity.CheckFriendlyFire), new[] { typeof(ReferenceHub), typeof(ReferenceHub), typeof(bool) })),
             });


### PR DESCRIPTION
This is a pretty janky solution that makes all calls to `CheckFriendlyFire(RoleType, RoleType, bool)` instead go to `CheckFriendlyFire(ReferenceHub, ReferenceHub, bool)` which allows us to get a player object from it. Unfortunately this means with each game update we'd have to make sure any new calls to `CheckFriendlyFire(RoleType, RoleType, bool)` get added (if you have a better solution please let me know, I couldn't think of any).

I tested with `IsFriendlyFire` both `false` and `true` between chaos and mtf. It all seemed to work as expected.