### PR TITLE
Update Pickup.Scale

### DIFF
--- a/Exiled.API/Features/Items/Pickup.cs
+++ b/Exiled.API/Features/Items/Pickup.cs
@@ -94,7 +94,6 @@ namespace Exiled.API.Features.Items
                 NetworkServer.UnSpawn(gameObject);
                 gameObject.transform.localScale = value;
                 NetworkServer.Spawn(gameObject);
-                gameObject.transform.localScale = Vector3.one;
             }
         }
 


### PR DESCRIPTION
With current version of Exiled if you set Pickup's scale to something and then do anything with it's transform, pickup's scale will be Vector3.one again.
For example, doing something like this
```
pickup.Scale = new Vector3(5, 1,1);
pickup.Position = somethere;
```
will result in pickup scale being Vector3.one again.
With this PR Scale will now properly work even after doing any operations with pickup's transform