### PR TITLE
Fixed KickedEventArgs

### DIFF
--- a/Exiled.Events/EventArgs/KickedEventArgs.cs
+++ b/Exiled.Events/EventArgs/KickedEventArgs.cs
@@ -19,14 +19,12 @@ namespace Exiled.Events.EventArgs
         /// <summary>
         /// Initializes a new instance of the <see cref="KickedEventArgs"/> class.
         /// </summary>
-        /// <param name="target"><inheritdoc cref="Player"/></param>
+        /// <param name="target"><inheritdoc cref="Target"/></param>
         /// <param name="reason"><inheritdoc cref="Reason"/></param>
-        /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
-        public KickedEventArgs(Player target, string reason, bool isAllowed = true)
+        public KickedEventArgs(Player target, string reason)
         {
             Target = target;
             Reason = reason;
-            IsAllowed = isAllowed;
         }
 
         /// <summary>
@@ -35,13 +33,8 @@ namespace Exiled.Events.EventArgs
         public Player Target { get; }
 
         /// <summary>
-        /// Gets or sets the kick reason.
+        /// Gets the kick reason.
         /// </summary>
-        public string Reason { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the event can be executed or not.
-        /// </summary>
-        public bool IsAllowed { get; set; }
+        public string Reason { get; }
     }
 }


### PR DESCRIPTION
Since there's a KickingEventArgs, the old patch was useless and placed in the wrong place.
If you make a Prefix, the code will run BEFORE the player has been kicked.
With this method the code is still running before the player gets kicked, but it uses the base-game code, that handles various things with null checks, and the event code too.
Another problem with KickedEventArgs was their properties, `Reason` was a getter and setter, but it should be a getter since you can modify the `Reason` from KickingEventArgs, and `IsAllowed` is actually useless if KickingEventArgs already implements it.
Therefore I made it so that all properties are now getters, and removed `IsAllowed` cause that wasn't a property made for this event.