### PR TITLE
Added DroppingNullEventArgs + Fixed NRE

### DIFF
--- a/Exiled.Events/EventArgs/DroppingNullEventArgs.cs
+++ b/Exiled.Events/EventArgs/DroppingNullEventArgs.cs
@@ -1,0 +1,33 @@
+// -----------------------------------------------------------------------
+// <copyright file="DroppingNullEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+
+    using Exiled.API.Features;
+    using Exiled.API.Features.Items;
+
+    using InventorySystem.Items;
+
+    /// <summary>
+    /// Contains all information before a player drops a null item.
+    /// </summary>
+    public class DroppingNullEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DroppingNullEventArgs"/> class.
+        /// </summary>
+        /// <param name="player"><inheritdoc cref="Player"/></param>
+        public DroppingNullEventArgs(Player player) => Player = player;
+
+        /// <summary>
+        /// Gets the player who's dropping the null item.
+        /// </summary>
+        public Player Player { get; }
+    }
+}

--- a/Exiled.Events/EventArgs/DroppingNullEventArgs.cs
+++ b/Exiled.Events/EventArgs/DroppingNullEventArgs.cs
@@ -10,9 +10,6 @@ namespace Exiled.Events.EventArgs
     using System;
 
     using Exiled.API.Features;
-    using Exiled.API.Features.Items;
-
-    using InventorySystem.Items;
 
     /// <summary>
     /// Contains all information before a player drops a null item.

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -128,6 +128,11 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<DroppingItemEventArgs> DroppingItem;
 
         /// <summary>
+        /// Invoked before dropping a null item.
+        /// </summary>
+        public static event CustomEventHandler<DroppingNullEventArgs> DroppingNull;
+
+        /// <summary>
         /// Invoked before picking up ammo.
         /// </summary>
         public static event CustomEventHandler<PickingUpAmmoEventArgs> PickingUpAmmo;
@@ -423,6 +428,12 @@ namespace Exiled.Events.Handlers
         /// </summary>
         /// <param name="ev">The <see cref="DroppingItemEventArgs"/> instance.</param>
         public static void OnDroppingItem(DroppingItemEventArgs ev) => DroppingItem.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before dropping a null item.
+        /// </summary>
+        /// <param name="ev">The <see cref="DroppingNullEventArgs"/> instance.</param>
+        public static void OnDroppingNull(DroppingNullEventArgs ev) => DroppingNull.InvokeSafely(ev);
 
         /// <summary>
         /// Called before a player picks up ammo.

--- a/Exiled.Events/Patches/Events/Player/ItemDrop.cs
+++ b/Exiled.Events/Patches/Events/Player/ItemDrop.cs
@@ -24,7 +24,7 @@ namespace Exiled.Events.Patches.Events.Player
 
     /// <summary>
     /// Patches <see cref="InventorySystem.Inventory.UserCode_CmdDropItem"/>.
-    /// Adds the <see cref="Player.DroppingItem"/> events.
+    /// Adds the <see cref="Player.DroppingItem"/> and <see cref="Player.DroppingNull"/> events.
     /// </summary>
     [HarmonyPatch(typeof(InventorySystem.Inventory), nameof(InventorySystem.Inventory.UserCode_CmdDropItem))]
     internal static class ItemDrop

--- a/Exiled.Events/Patches/Events/Player/ItemDrop.cs
+++ b/Exiled.Events/Patches/Events/Player/ItemDrop.cs
@@ -22,11 +22,9 @@ namespace Exiled.Events.Patches.Events.Player
 
     using static HarmonyLib.AccessTools;
 
-    using Player = Exiled.Events.Handlers.Player;
-
     /// <summary>
     /// Patches <see cref="InventorySystem.Inventory.UserCode_CmdDropItem"/>.
-    /// Adds the <see cref="Handlers.Player.DroppingItem"/> events.
+    /// Adds the <see cref="Player.DroppingItem"/> events.
     /// </summary>
     [HarmonyPatch(typeof(InventorySystem.Inventory), nameof(InventorySystem.Inventory.UserCode_CmdDropItem))]
     internal static class ItemDrop
@@ -35,25 +33,39 @@ namespace Exiled.Events.Patches.Events.Player
         {
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
 
-            const int offset = 1;
-            int index = newInstructions.FindIndex(i => i.opcode == OpCodes.Ret) + offset;
             LocalBuilder item = generator.DeclareLocal(typeof(Item));
             Label returnLabel = generator.DefineLabel();
+            Label notNullLabel = generator.DefineLabel();
 
             newInstructions.InsertRange(0, new[]
             {
-                // Player.Get(this._hub)
+                // Item item = GetItem(player, itemSerial)
+                // if (item is null)
+                //    Handlers.Player.OnDroppingNull(new DroppingNullEventArgs(Player));
+                //    return;
+                //
+                // Handlers.Player.OnDroppingNull(new DroppingItemEventArgs(Player, Item, true));
+                // if (!ev.IsAllowed)
+                //     return;
                 new CodeInstruction(OpCodes.Ldarg_0),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(InventorySystem.Inventory), nameof(InventorySystem.Inventory._hub))),
-                new CodeInstruction(OpCodes.Call, Method(typeof(Exiled.API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(ReferenceHub) })),
-
-                // GetItem(player, itemSerial)
+                new CodeInstruction(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(ReferenceHub) })),
                 new CodeInstruction(OpCodes.Ldarg_1),
-
-                // true
+                new CodeInstruction(OpCodes.Call, Method(typeof(ItemDrop), nameof(ItemDrop.GetItem))),
+                new CodeInstruction(OpCodes.Stloc_S, item.LocalIndex),
+                new CodeInstruction(OpCodes.Ldloc_S, item.LocalIndex),
+                new CodeInstruction(OpCodes.Brtrue_S, notNullLabel),
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(InventorySystem.Inventory), nameof(InventorySystem.Inventory._hub))),
+                new CodeInstruction(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(ReferenceHub) })),
+                new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(DroppingNullEventArgs))[0]),
+                new CodeInstruction(OpCodes.Call, Method(typeof(Player), nameof(Player.OnDroppingNull))),
+                new CodeInstruction(OpCodes.Ret),
+                new CodeInstruction(OpCodes.Ldarg_0).WithLabels(notNullLabel),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(InventorySystem.Inventory), nameof(InventorySystem.Inventory._hub))),
+                new CodeInstruction(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(ReferenceHub) })),
+                new CodeInstruction(OpCodes.Ldloc_S, item.LocalIndex),
                 new CodeInstruction(OpCodes.Ldc_I4_1),
-
-                // var ev = new DroppingItemEventArgs(Player, Item, true)
                 new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(DroppingItemEventArgs))[0]),
                 new CodeInstruction(OpCodes.Dup),
                 new CodeInstruction(OpCodes.Call, Method(typeof(Player), nameof(Player.OnDroppingItem))),
@@ -69,6 +81,6 @@ namespace Exiled.Events.Patches.Events.Player
             ListPool<CodeInstruction>.Shared.Return(newInstructions);
         }
 
-        private static ItemBase GetItem(Exiled.API.Features.Player player, ushort serial) => player.TryGetItem(serial, out ItemBase item) ? item : null;
+        private static ItemBase GetItem(API.Features.Player player, ushort serial) => player.TryGetItem(serial, out ItemBase item) ? item : null;
     }
 }


### PR DESCRIPTION
**Fixed NRE**: When a player tries to drop an empty inventory slot, or a null item, a NRE occours.
**DroppingNullEventArgs**: Instead of fixing NRE only, we thought about the opportunity NW gave us to make a useful event for plugins. Indeed, this event is thrown before the actual DroppingItemEventArgs. It doesn't require an `IsAllowed` parameter since it'll always return to avoid NRE.