### PR TITLE
Grenade api fixes

### DIFF
--- a/Exiled.API/Extensions/ItemExtensions.cs
+++ b/Exiled.API/Extensions/ItemExtensions.cs
@@ -152,5 +152,25 @@ namespace Exiled.API.Extensions
                     return ItemType.None;
             }
         }
+
+        /// <summary>
+        /// Convert a <see cref="GrenadeType"/> to a <see cref="ItemType"/>.
+        /// </summary>
+        /// <param name="type"><inheritdoc cref="GrenadeType"/></param>
+        /// <returns><inheritdoc cref="ItemType"/></returns>
+        public static ItemType GetItemType(this GrenadeType type)
+        {
+            switch (type)
+            {
+                case GrenadeType.Flashbang:
+                    return ItemType.GrenadeFlash;
+                case GrenadeType.Scp018:
+                    return ItemType.SCP018;
+                case GrenadeType.FragGrenade:
+                    return ItemType.GrenadeHE;
+                default:
+                    return ItemType.None;
+            }
+        }
     }
 }

--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -107,6 +107,11 @@ namespace Exiled.API.Features.Items
             }
         }
 
+        /// <summary>
+        /// Spawns an active grenade on the map at the specified location.
+        /// </summary>
+        /// <param name="position">The location to spawn the grenade.</param>
+        /// <param name="owner">Optional: The <see cref="Player"/> owner of the grenade.</param>
         public void SpawnActive(Vector3 position, Player owner = null)
         {
             if (owner != null)

--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -99,12 +99,7 @@ namespace Exiled.API.Features.Items
         public float FuseTime
         {
             get => Projectile._fuseTime;
-            set
-            {
-                Log.Debug($"Setting fuse time to {value}");
-                Projectile._fuseTime = value;
-                Log.Debug($"Fuse time now {Projectile._fuseTime}");
-            }
+            set => Projectile._fuseTime = value;
         }
 
         /// <summary>

--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -111,6 +111,7 @@ namespace Exiled.API.Features.Items
         {
             if (owner != null)
                 Projectile.PreviousOwner = new Footprint(owner.ReferenceHub);
+
 #if DEBUG
             Log.Debug($"Spawning active grenade: {FuseTime}");
 #endif

--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -9,7 +9,11 @@ namespace Exiled.API.Features.Items
 {
     using Exiled.API.Enums;
 
+    using Footprinting;
+
     using InventorySystem.Items.ThrowableProjectiles;
+
+    using Mirror;
 
     using UnityEngine;
 
@@ -101,6 +105,18 @@ namespace Exiled.API.Features.Items
                 Projectile._fuseTime = value;
                 Log.Debug($"Fuse time now {Projectile._fuseTime}");
             }
+        }
+
+        public void SpawnActive(Vector3 position, Player owner = null)
+        {
+            if (owner != null)
+                Projectile.PreviousOwner = new Footprint(owner.ReferenceHub);
+#if DEBUG
+            Log.Debug($"Spawning active grenade: {FuseTime}");
+#endif
+            Projectile.transform.position = position;
+            NetworkServer.Spawn(Projectile.gameObject);
+            Projectile.RpcSetTime(FuseTime);
         }
     }
 }

--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -11,6 +11,8 @@ namespace Exiled.API.Features.Items
 
     using InventorySystem.Items.ThrowableProjectiles;
 
+    using UnityEngine;
+
     /// <summary>
     /// A wrapper class for <see cref="ExplosionGrenade"/>.
     /// </summary>
@@ -23,7 +25,7 @@ namespace Exiled.API.Features.Items
         public ExplosiveGrenade(ThrowableItem itemBase)
             : base(itemBase)
         {
-            Base = itemBase;
+            Projectile = (ExplosionGrenade)Object.Instantiate(itemBase.Projectile);
         }
 
         /// <summary>
@@ -40,7 +42,7 @@ namespace Exiled.API.Features.Items
         /// <summary>
         /// Gets the <see cref="ExplosionGrenade"/> for this item.
         /// </summary>
-        public new ExplosionGrenade Projectile => (ExplosionGrenade)Base.Projectile;
+        public new ExplosionGrenade Projectile { get; }
 
         /// <summary>
         /// Gets or sets the maximum radius of the grenade.
@@ -93,7 +95,12 @@ namespace Exiled.API.Features.Items
         public float FuseTime
         {
             get => Projectile._fuseTime;
-            set => Projectile._fuseTime = value;
+            set
+            {
+                Log.Debug($"Setting fuse time to {value}");
+                Projectile._fuseTime = value;
+                Log.Debug($"Fuse time now {Projectile._fuseTime}");
+            }
         }
     }
 }

--- a/Exiled.API/Features/Items/FlashGrenade.cs
+++ b/Exiled.API/Features/Items/FlashGrenade.cs
@@ -94,6 +94,9 @@ namespace Exiled.API.Features.Items
             if (owner != null)
                 Projectile.PreviousOwner = new Footprint(owner.ReferenceHub);
 
+#if DEBUG
+            Log.Debug($"Spawning active grenade: {FuseTime}");
+#endif
             Projectile.transform.position = position;
             NetworkServer.Spawn(Projectile.gameObject);
             Projectile.RpcSetTime(FuseTime);

--- a/Exiled.API/Features/Items/FlashGrenade.cs
+++ b/Exiled.API/Features/Items/FlashGrenade.cs
@@ -9,7 +9,11 @@ namespace Exiled.API.Features.Items
 {
     using Exiled.API.Enums;
 
+    using Footprinting;
+
     using InventorySystem.Items.ThrowableProjectiles;
+
+    using Mirror;
 
     using UnityEngine;
 
@@ -78,6 +82,16 @@ namespace Exiled.API.Features.Items
         {
             get => Projectile._fuseTime;
             set => Projectile._fuseTime = value;
+        }
+
+        public void SpawnActive(Vector3 position, Player owner = null)
+        {
+            if (owner != null)
+                Projectile.PreviousOwner = new Footprint(owner.ReferenceHub);
+
+            Projectile.transform.position = position;
+            NetworkServer.Spawn(Projectile.gameObject);
+            Projectile.RpcSetTime(FuseTime);
         }
     }
 }

--- a/Exiled.API/Features/Items/FlashGrenade.cs
+++ b/Exiled.API/Features/Items/FlashGrenade.cs
@@ -84,6 +84,11 @@ namespace Exiled.API.Features.Items
             set => Projectile._fuseTime = value;
         }
 
+        /// <summary>
+        /// Spawns an active grenade on the map at the specified location.
+        /// </summary>
+        /// <param name="position">The location to spawn the grenade.</param>
+        /// <param name="owner">Optional: The <see cref="Player"/> owner of the grenade.</param>
         public void SpawnActive(Vector3 position, Player owner = null)
         {
             if (owner != null)

--- a/Exiled.API/Features/Items/FlashGrenade.cs
+++ b/Exiled.API/Features/Items/FlashGrenade.cs
@@ -25,7 +25,7 @@ namespace Exiled.API.Features.Items
         public FlashGrenade(ThrowableItem itemBase)
             : base(itemBase)
         {
-            Base = itemBase;
+            Projectile = (FlashbangGrenade)Object.Instantiate(itemBase.Projectile);
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace Exiled.API.Features.Items
         /// <summary>
         /// Gets the <see cref="ExplosionGrenade"/> for this item.
         /// </summary>
-        public new FlashbangGrenade Projectile => (FlashbangGrenade)Base.Projectile;
+        public new FlashbangGrenade Projectile { get; }
 
         /// <summary>
         /// Gets or sets the <see cref="AnimationCurve"/> for determining how long the <see cref="EffectType.Blinded"/> effect will last.

--- a/Exiled.API/Features/Items/Throwable.cs
+++ b/Exiled.API/Features/Items/Throwable.cs
@@ -11,6 +11,8 @@ namespace Exiled.API.Features.Items
 
     using InventorySystem.Items.ThrowableProjectiles;
 
+    using UnityEngine;
+
     /// <summary>
     /// A wrapper class for throwable items.
     /// </summary>
@@ -24,6 +26,7 @@ namespace Exiled.API.Features.Items
             : base(itemBase)
         {
             Base = itemBase;
+            Projectile = Object.Instantiate(Base.Projectile, Base.transform);
         }
 
         /// <summary>
@@ -45,7 +48,7 @@ namespace Exiled.API.Features.Items
         /// <summary>
         /// Gets the <see cref="ThrownProjectile"/> for this item.
         /// </summary>
-        public ThrownProjectile Projectile => Base.Projectile;
+        public ThrownProjectile Projectile { get; }
 
         /// <summary>
         /// Gets or sets the amount of time it takes to pull the pin.

--- a/Exiled.Events/Patches/Fixes/GrenadeFuseTimeFix.cs
+++ b/Exiled.Events/Patches/Fixes/GrenadeFuseTimeFix.cs
@@ -59,7 +59,7 @@ namespace Exiled.Events.Patches.Fixes
                 new CodeInstruction(OpCodes.Ldloc, item.LocalIndex),
                 new CodeInstruction(OpCodes.Brfalse, skipLabel),
 
-                // if (!Item.Get(this) is ExplosiveGrenade explosive)
+                // if (item is ExplosiveGrenade explosive)
                 //    goto NOT_EXPLOSIVE_LABEL
                 new CodeInstruction(OpCodes.Ldloc, item.LocalIndex),
                 new CodeInstruction(OpCodes.Isinst, typeof(ExplosiveGrenade)),
@@ -78,7 +78,7 @@ namespace Exiled.Events.Patches.Fixes
                 new CodeInstruction(OpCodes.Callvirt, Method(typeof(TimeGrenade), nameof(TimeGrenade.ServerActivate))),
                 new CodeInstruction(OpCodes.Ret),
 
-                // if (!Item.Get(this) is FlashGrenade flash)
+                // if (item is FlashGrenade flash)
                 //    goto SKIP_LABEL
                 new CodeInstruction(OpCodes.Ldloc, item.LocalIndex).WithLabels(notExplosiveLabel),
                 new CodeInstruction(OpCodes.Isinst, typeof(FlashGrenade)),

--- a/Exiled.Events/Patches/Fixes/GrenadeFuseTimeFix.cs
+++ b/Exiled.Events/Patches/Fixes/GrenadeFuseTimeFix.cs
@@ -80,8 +80,7 @@ namespace Exiled.Events.Patches.Fixes
 
                 // if (!Item.Get(this) is FlashGrenade flash)
                 //    goto SKIP_LABEL
-                new CodeInstruction(OpCodes.Ldarg_0).WithLabels(notExplosiveLabel),
-                new CodeInstruction(OpCodes.Call, Method(typeof(Item), nameof(Item.Get))),
+                new CodeInstruction(OpCodes.Ldloc, item.LocalIndex),
                 new CodeInstruction(OpCodes.Isinst, typeof(FlashGrenade)),
                 new CodeInstruction(OpCodes.Dup),
                 new CodeInstruction(OpCodes.Stloc, flash.LocalIndex),

--- a/Exiled.Events/Patches/Fixes/GrenadeFuseTimeFix.cs
+++ b/Exiled.Events/Patches/Fixes/GrenadeFuseTimeFix.cs
@@ -1,0 +1,111 @@
+// -----------------------------------------------------------------------
+// <copyright file="GrenadeFuseTimeFix.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Fixes
+{
+#pragma warning disable SA1118
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
+
+    using Exiled.API.Features;
+    using Exiled.API.Features.Items;
+
+    using HarmonyLib;
+
+    using InventorySystem.Items.ThrowableProjectiles;
+
+    using NorthwoodLib.Pools;
+
+    using UnityEngine;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    /// Patches <see cref="InventorySystem.Items.ThrowableProjectiles.ThrowableItem"/> to fix fuse times being unchangeable.
+    /// </summary>
+    [HarmonyPatch(typeof(ThrowableItem), nameof(ThrowableItem.ServerThrow), typeof(float), typeof(float), typeof(Vector3))]
+    internal static class GrenadeFuseTimeFix
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+            const int offset = -1;
+            int index = newInstructions.FindLastIndex(i => i.opcode == OpCodes.Callvirt) + offset;
+            LocalBuilder timeGrenade = generator.DeclareLocal(typeof(TimeGrenade));
+            LocalBuilder explosive = generator.DeclareLocal(typeof(ExplosiveGrenade));
+            LocalBuilder flash = generator.DeclareLocal(typeof(FlashGrenade));
+            LocalBuilder item = generator.DeclareLocal(typeof(Item));
+            Label notExplosiveLabel = generator.DefineLabel();
+            Label skipLabel = generator.DefineLabel();
+
+            newInstructions.InsertRange(index, new[]
+            {
+                // if (!thrownProjectils is TimeGrenade timeGrenade)
+                //    goto SKIP_LABEL
+                new CodeInstruction(OpCodes.Ldloc_0),
+                new CodeInstruction(OpCodes.Isinst, typeof(TimeGrenade)),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Stloc, timeGrenade.LocalIndex),
+                new CodeInstruction(OpCodes.Brfalse, skipLabel),
+
+                // item = Item.Get(this);
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Call, Method(typeof(Item), nameof(Item.Get))),
+                new CodeInstruction(OpCodes.Stloc, item.LocalIndex),
+                new CodeInstruction(OpCodes.Ldloc, item.LocalIndex),
+                new CodeInstruction(OpCodes.Brfalse, skipLabel),
+
+                // if (!Item.Get(this) is ExplosiveGrenade explosive)
+                //    goto NOT_EXPLOSIVE_LABEL
+                new CodeInstruction(OpCodes.Ldloc, item.LocalIndex),
+                new CodeInstruction(OpCodes.Isinst, typeof(ExplosiveGrenade)),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Stloc, explosive.LocalIndex),
+                new CodeInstruction(OpCodes.Brfalse, notExplosiveLabel),
+
+                // timeGrenade._fuseTime = explosive.FuseTime
+                new CodeInstruction(OpCodes.Ldloc, timeGrenade.LocalIndex),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Ldloc, explosive.LocalIndex),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ExplosiveGrenade), nameof(ExplosiveGrenade.FuseTime))),
+                new CodeInstruction(OpCodes.Stfld, Field(typeof(TimeGrenade), nameof(TimeGrenade._fuseTime))),
+
+                // timeGrenade.ServerActivate()
+                new CodeInstruction(OpCodes.Callvirt, Method(typeof(TimeGrenade), nameof(TimeGrenade.ServerActivate))),
+                new CodeInstruction(OpCodes.Ret),
+
+                // if (!Item.Get(this) is FlashGrenade flash)
+                //    goto SKIP_LABEL
+                new CodeInstruction(OpCodes.Ldarg_0).WithLabels(notExplosiveLabel),
+                new CodeInstruction(OpCodes.Call, Method(typeof(Item), nameof(Item.Get))),
+                new CodeInstruction(OpCodes.Isinst, typeof(FlashGrenade)),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Stloc, flash.LocalIndex),
+                new CodeInstruction(OpCodes.Brfalse, skipLabel),
+
+                // timeGrenade._fuseTime = flash.FuseTime
+                new CodeInstruction(OpCodes.Ldloc, flash.LocalIndex),
+                new CodeInstruction(OpCodes.Ldloc, timeGrenade.LocalIndex),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(FlashGrenade), nameof(FlashGrenade.FuseTime))),
+                new CodeInstruction(OpCodes.Stfld, Field(typeof(TimeGrenade), nameof(TimeGrenade._fuseTime))),
+
+                // timeGrenade.ServerActivate();
+                new CodeInstruction(OpCodes.Callvirt, Method(typeof(TimeGrenade), nameof(TimeGrenade.ServerActivate))),
+                new CodeInstruction(OpCodes.Ret),
+
+                // skips all of the above code, and runs base-game serverActivate instead.
+                new CodeInstruction(OpCodes.Nop).WithLabels(skipLabel),
+            });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Fixes/GrenadeFuseTimeFix.cs
+++ b/Exiled.Events/Patches/Fixes/GrenadeFuseTimeFix.cs
@@ -80,16 +80,16 @@ namespace Exiled.Events.Patches.Fixes
 
                 // if (!Item.Get(this) is FlashGrenade flash)
                 //    goto SKIP_LABEL
-                new CodeInstruction(OpCodes.Ldloc, item.LocalIndex),
+                new CodeInstruction(OpCodes.Ldloc, item.LocalIndex).WithLabels(notExplosiveLabel),
                 new CodeInstruction(OpCodes.Isinst, typeof(FlashGrenade)),
                 new CodeInstruction(OpCodes.Dup),
                 new CodeInstruction(OpCodes.Stloc, flash.LocalIndex),
                 new CodeInstruction(OpCodes.Brfalse, skipLabel),
 
                 // timeGrenade._fuseTime = flash.FuseTime
-                new CodeInstruction(OpCodes.Ldloc, flash.LocalIndex),
                 new CodeInstruction(OpCodes.Ldloc, timeGrenade.LocalIndex),
                 new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Ldloc, flash.LocalIndex),
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(FlashGrenade), nameof(FlashGrenade.FuseTime))),
                 new CodeInstruction(OpCodes.Stfld, Field(typeof(TimeGrenade), nameof(TimeGrenade._fuseTime))),
 


### PR DESCRIPTION
This adds FlashGrenade and ExplosiveGrenade.SpawnActive() methods to spawn active grenades on the map.
This also adds a transpiler to fix the fact that there's no base-game way to properly set _fuseTime.