### PR TITLE
Make `RespawningTeamEventArgs.SpawnableTeam` public

### DIFF
--- a/Exiled.Events/EventArgs/RespawningTeamEventArgs.cs
+++ b/Exiled.Events/EventArgs/RespawningTeamEventArgs.cs
@@ -69,7 +69,7 @@ namespace Exiled.Events.EventArgs
         /// <summary>
         /// Gets the current spawnable team.
         /// </summary>
-        internal SpawnableTeamHandlerBase SpawnableTeam => RespawnWaveGenerator.SpawnableTeams.TryGetValue(NextKnownTeam, out SpawnableTeamHandlerBase @base) ? @base : null;
+        public SpawnableTeamHandlerBase SpawnableTeam => RespawnWaveGenerator.SpawnableTeams.TryGetValue(NextKnownTeam, out SpawnableTeamHandlerBase @base) ? @base : null;
 
         private void ReissueNextKnownTeam()
         {


### PR DESCRIPTION
I had an interesting moment today when I needed to change something very much in `RespawningTeam.Transpiler` patch, keeping the event working for the other EXILED plugins.
I just copied this transpiler to myself and realized that there was no way to copy exactly because the property was unavailable:
https://github.com/Exiled-Team/EXILED/blob/85fea72ec874a606d7c3b10f36b900afc1e0aee1/Exiled.Events/Patches/Events/Server/RespawningTeam.cs#L80