### PR TITLE
Let's have normal default permissions

### DIFF
--- a/Exiled.Permissions/permissions.yml
+++ b/Exiled.Permissions/permissions.yml
@@ -4,6 +4,11 @@ user:
   permissions:
     - testplugin.user
 
+owner:
+  inheritance: []
+  permissions:
+    - .*
+
 admin:
   inheritance:
     - moderator
@@ -15,8 +20,3 @@ moderator:
   inheritance: []
   permissions:
     - testplugin.moderator
-
-helper:
-  inheritance: []
-  permissions:
-    - .*


### PR DESCRIPTION
Because helper doesn't normally exist and definitely shouldn't have every permission.