### PR TITLE
Revert "Fixes being unable to forceclass someone to the same role they alread…"

### DIFF
--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -58,6 +58,11 @@ namespace Exiled.Events.Patches.Events.Player
                 new CodeInstruction(OpCodes.Stloc, player.LocalIndex),
                 new CodeInstruction(OpCodes.Brfalse, returnLabel),
                 new CodeInstruction(OpCodes.Ldloc, player.LocalIndex),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(API.Features.Player), nameof(API.Features.Player.Role))),
+                new CodeInstruction(OpCodes.Ldarg_1),
+                new CodeInstruction(OpCodes.Ceq),
+                new CodeInstruction(OpCodes.Brtrue, returnLabel),
+                new CodeInstruction(OpCodes.Ldloc, player.LocalIndex),
 
                 // id
                 new CodeInstruction(OpCodes.Ldarg_1),


### PR DESCRIPTION
Reverts Exiled-Team/EXILED#681

Due to base-game issues, the method patched calls itself, which causes the `lite` bool to be ignored. This in turn breaks the functionality of our API. Until a better solution is found, this base-game functionality of being able to force-class someone as the same class they already are, must be removed, to retain functionality of the API.