### PR TITLE
Interacting shooting target event

### DIFF
--- a/Exiled.Events/EventArgs/InteractingShootingTargetEventArgs.cs
+++ b/Exiled.Events/EventArgs/InteractingShootingTargetEventArgs.cs
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="InteractingShootingTargetEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+
+    using Exiled.API.Features;
+    using Exiled.API.Features.Items;
+
+    using InventorySystem.Items.Firearms.Utilities;
+    using InventorySystem.Items.Pickups;
+
+    /// <summary>
+    /// Contains all information before a player interacts with a shooting target.
+    /// </summary>
+    public class InteractingShootingTargetEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InteractingShootingTargetEventArgs"/> class.
+        /// </summary>
+        /// <param name="player"><inheritdoc cref="Player"/></param>
+        /// /// <param name="shootingTarget"><inheritdoc cref="ShootingTarget"/></param>
+        /// /// <param name="targetButton"><inheritdoc cref="TargetButton"/></param>
+        /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
+        public InteractingShootingTargetEventArgs(Player player, ShootingTarget shootingTarget, ShootingTarget.TargetButton targetButton, bool isAllowed = false)
+        {
+            Player = player;
+            ShootingTarget = shootingTarget;
+            TargetButton = targetButton;
+            IsAllowed = isAllowed;
+        }
+
+        /// <summary>
+        /// Gets the player interacting with the shooting target.
+        /// </summary>
+        public Player Player { get; }
+
+        /// <summary>
+        /// Gets the shooting target being interacted with.
+        /// </summary>
+        public ShootingTarget ShootingTarget { get; }
+
+        /// <summary>
+        /// Gets the button the player interacted with.
+        /// </summary>
+        public ShootingTarget.TargetButton TargetButton { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not the interaction is allowed.
+        /// </summary>
+        public bool IsAllowed { get; set; }
+    }
+}

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -308,6 +308,11 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<ProcessingHotkeyEventArgs> ProcessingHotkey;
 
         /// <summary>
+        /// Invoked before a player interacts with a shooting target.
+        /// </summary>
+        public static event CustomEventHandler<InteractingShootingTargetEventArgs> InteractingShootingTarget;
+
+        /// <summary>
         /// Called before pre-authenticating a player.
         /// </summary>
         /// <param name="ev">The <see cref="PreAuthenticatingEventArgs"/> instance.</param>
@@ -649,5 +654,11 @@ namespace Exiled.Events.Handlers
         /// </summary>
         /// <param name="ev">The <see cref="ProcessingHotkeyEventArgs"/> instance.</param>
         public static void OnProcessingHotkey(ProcessingHotkeyEventArgs ev) => ProcessingHotkey.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a player interacts with a shooting target.
+        /// </summary>
+        /// <param name="ev">The <see cref="InteractingShootingTargetEventArgs"/> instance.</param>
+        public static void OnInteractingShootingTarget(InteractingShootingTargetEventArgs ev) => InteractingShootingTarget.InvokeSafely(ev);
     }
 }

--- a/Exiled.Events/Patches/Events/Player/InteractingShootingTarget.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingShootingTarget.cs
@@ -1,0 +1,72 @@
+// -----------------------------------------------------------------------
+// <copyright file="InteractingShootingTarget.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+#pragma warning disable SA1118
+#pragma warning disable SA1313
+#pragma warning disable SA1402
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Reflection.Emit;
+
+    using Exiled.API.Features;
+    using Exiled.Events.EventArgs;
+
+    using HarmonyLib;
+
+    using InventorySystem.Items.Firearms.Utilities;
+
+    using NorthwoodLib.Pools;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    /// Patches <see cref="ShootingTarget.ServerInteract(ReferenceHub, byte)"/>.
+    /// Adds the <see cref="Handlers.Player.InteractingShootingTarget"/> event.
+    /// </summary>
+    [HarmonyPatch(typeof(ShootingTarget), nameof(ShootingTarget.ServerInteract))]
+    internal static class InteractingShootingTarget
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            int offset = -7;
+            int index = newInstructions.FindLastIndex(i => i.opcode == OpCodes.Ldarg_2) + offset;
+
+            Label returnLabel = generator.DefineLabel();
+
+            newInstructions[newInstructions.Count - 1].labels.Add(returnLabel);
+
+            newInstructions.InsertRange(index, new[]
+            {
+                new CodeInstruction(OpCodes.Ldarg_1),
+                new CodeInstruction(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
+
+                new CodeInstruction(OpCodes.Ldarg_0),
+
+                new CodeInstruction(OpCodes.Ldarg_2),
+
+                new CodeInstruction(OpCodes.Ldc_I4_1),
+
+                new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(InteractingShootingTargetEventArgs))[0]),
+                new CodeInstruction(OpCodes.Dup),
+
+                new CodeInstruction(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnInteractingShootingTarget))),
+
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(InteractingShootingTargetEventArgs), nameof(InteractingShootingTargetEventArgs.IsAllowed))),
+                new CodeInstruction(OpCodes.Brfalse, returnLabel),
+            });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/InteractingShootingTarget.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingShootingTarget.cs
@@ -11,7 +11,6 @@ namespace Exiled.Events.Patches.Events.Player
 #pragma warning disable SA1313
 #pragma warning disable SA1402
     using System.Collections.Generic;
-    using System.Reflection;
     using System.Reflection.Emit;
 
     using Exiled.API.Features;


### PR DESCRIPTION
An event that is fired when a player presses one of the buttons on a shooting target while the target is in sync mode.

Honestly I don't know if this event is worth merging as it only works while the target is in sync mode, but some devs may find it useful. Especially if some extra events are added like `ChangingShootingTargetSyncMode` to force the sync mode to always be on, `DamagingShootingTarget`, or some other events, I just haven't gotten to them yet.