### PR TITLE
ArtificialHealth fix

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -641,13 +641,13 @@ namespace Exiled.API.Features
         /// </summary>
         public ushort ArtificialHealth
         {
-            get => ReferenceHub.playerStats.NetworkArtificialHealth;
+            get => (ushort)ArtificialHealthManager.GetAhpValue(ReferenceHub.playerStats);
             set
             {
-                ReferenceHub.playerStats.NetworkArtificialHealth = value;
-
                 if (value > MaxArtificialHealth)
                     MaxArtificialHealth = value;
+
+                ArtificialHealthManager.ForceAhpValue(ReferenceHub.playerStats, value);
             }
         }
 

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -639,13 +639,13 @@ namespace Exiled.API.Features
         /// Gets or sets the player's artificial health.
         /// If the health is greater than the <see cref="MaxArtificialHealth"/>, it will also be changed to match the artificial health.
         /// </summary>
-        public ushort ArtificialHealth
+        public float ArtificialHealth
         {
-            get => (ushort)ArtificialHealthManager.GetAhpValue(ReferenceHub.playerStats);
+            get => ArtificialHealthManager.GetAhpValue(ReferenceHub.playerStats);
             set
             {
                 if (value > MaxArtificialHealth)
-                    MaxArtificialHealth = value;
+                    MaxArtificialHealth = Mathf.CeilToInt(value);
 
                 ArtificialHealthManager.ForceAhpValue(ReferenceHub.playerStats, value);
             }


### PR DESCRIPTION
Fixes an issue with AHP not working as intended. This just changes it to use the base game's ArtificialHealthManager which seems to be where all AHP values actually come from now.