### PR TITLE
Fix GetDoorType()

### DIFF
--- a/Exiled.API/Features/Door.cs
+++ b/Exiled.API/Features/Door.cs
@@ -295,6 +295,8 @@ namespace Exiled.API.Features
                         return DoorType.HeavyContainmentDoor;
                     case "EZ":
                         return DoorType.EntranceDoor;
+                    case "Prison":
+                        return DoorType.PrisonDoor;
                     default:
                         return DoorType.UnknownDoor;
                 }
@@ -302,9 +304,6 @@ namespace Exiled.API.Features
 
             switch (Nametag.RemoveBracketsOnEndOfName())
             {
-                case "Prison BreakableDoor":
-                    return DoorType.PrisonDoor;
-
                 // Doors contains the DoorNameTagExtension component
                 case "CHECKPOINT_LCZ_A":
                     return DoorType.CheckpointLczA;

--- a/Exiled.API/Features/Door.cs
+++ b/Exiled.API/Features/Door.cs
@@ -285,7 +285,20 @@ namespace Exiled.API.Features
         private DoorType GetDoorType()
         {
             if (Nametag == null)
-                return DoorType.UnknownDoor;
+            {
+                string doorName = Base.gameObject.name.GetBefore(' ');
+                switch (doorName)
+                {
+                    case "LCZ":
+                        return DoorType.LightContainmentDoor;
+                    case "HCZ":
+                        return DoorType.HeavyContainmentDoor;
+                    case "EZ":
+                        return DoorType.EntranceDoor;
+                    default:
+                        return DoorType.UnknownDoor;
+                }
+            }
 
             switch (Nametag.RemoveBracketsOnEndOfName())
             {
@@ -373,19 +386,7 @@ namespace Exiled.API.Features
                 case "EntrDoor":
                     return DoorType.EntranceDoor;
                 default:
-                    // All door gameobject names are separated by a whitespace
-                    string doorName = Nametag.GetBefore(' ');
-                    switch (doorName)
-                    {
-                        case "LCZ":
-                            return DoorType.LightContainmentDoor;
-                        case "HCZ":
-                            return DoorType.HeavyContainmentDoor;
-                        case "EZ":
-                            return DoorType.EntranceDoor;
-                        default:
-                            return DoorType.UnknownDoor;
-                    }
+                    return DoorType.UnknownDoor;
             }
         }
     }


### PR DESCRIPTION
Currently GetDoorType() returns UnknownDoor for all of the entrance, heavy, and light containment doors when it should return the correct enum for it. That is now fixed.