### PR TITLE
Fix setting CurrentItem to null or a None item

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -687,12 +687,19 @@ namespace Exiled.API.Features
 
             set
             {
-                if (!Inventory.UserInventory.Items.TryGetValue(value.Serial, out _))
+                if (value == null || value.Type == ItemType.None)
                 {
-                    AddItem(value.Base);
+                    Timing.CallDelayed(0.5f, () => Inventory.ServerSelectItem(0));
                 }
+                else
+                {
+                    if (!Inventory.UserInventory.Items.TryGetValue(value.Serial, out _))
+                    {
+                        AddItem(value.Base);
+                    }
 
-                Timing.CallDelayed(0.5f, () => Inventory.ServerSelectItem(value.Serial));
+                    Timing.CallDelayed(0.5f, () => Inventory.ServerSelectItem(value.Serial));
+                }
             }
         }
 

--- a/Exiled.API/Features/ShootingTarget.cs
+++ b/Exiled.API/Features/ShootingTarget.cs
@@ -29,7 +29,7 @@ namespace Exiled.API.Features
         {
             { "sportTargetPrefab", ShootingTargetType.Sport },
             { "dboyTargetPrefab", ShootingTargetType.ClassD },
-            { "bianryTargetPrefab", ShootingTargetType.Binary },
+            { "binaryTargetPrefab", ShootingTargetType.Binary },
         };
 
         private static readonly Dictionary<BaseTarget, ShootingTarget> BaseToShootingTarget = new Dictionary<BaseTarget, ShootingTarget>();


### PR DESCRIPTION
Currently you will get this error when setting Player.CurrentItem to null or `new Item(ItemType.None)`:
```
[2021-09-14 16:54:00.049 -04:00] [STDOUT] NullReferenceException: Object reference not set to an instance of an object
[2021-09-14 16:54:00.049 -04:00] [STDOUT]   at Exiled.API.Features.Player.set_CurrentItem (Exiled.API.Features.Items.Item value) [0x0001a] in <9d56c16099cf4088878254ced68c312e>:0
```
This PR fixes that.

