### PR TITLE
Added ICommandSender override

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -990,6 +990,13 @@ namespace Exiled.API.Features
         public static IEnumerable<Player> Get(RoleType role) => List.Where(player => player.Role == role);
 
         /// <summary>
+        /// Gets the <see cref="Player"/> belonging to the ICommandSender, if any.
+        /// </summary>
+        /// <param name="sender">The command sender.</param>
+        /// <returns>Returns a player or null if not found.</returns>
+        public static Player Get(CommandSystem.ICommandSender sender) => Get(sender as CommandSender);
+
+        /// <summary>
         /// Gets the <see cref="Player"/> belonging to the CommandSender, if any.
         /// </summary>
         /// <param name="sender">The command sender.</param>


### PR DESCRIPTION
Basically now you can straight up do this:
```cs
public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
{
     Player player = Player.Get(sender);
}
 ```