### PR TITLE
Config | Config Types

### DIFF
--- a/Exiled.API/Enums/ConfigType.cs
+++ b/Exiled.API/Enums/ConfigType.cs
@@ -1,0 +1,25 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ConfigType.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Enums
+{
+    /// <summary>
+    /// The different types of configuration files distribution.
+    /// </summary>
+    public enum ConfigType
+    {
+        /// <summary>
+        /// Default config type, every plugin will share the same config file.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Separated config type, each plugin will have an individual config file.
+        /// </summary>
+        Separated,
+    }
+}

--- a/Exiled.API/Features/Paths.cs
+++ b/Exiled.API/Features/Paths.cs
@@ -48,9 +48,19 @@ namespace Exiled.API.Features
         public static string Configs { get; set; }
 
         /// <summary>
-        /// Gets or sets configs path.
+        /// Gets or sets config file path.
         /// </summary>
         public static string Config { get; set; }
+
+        /// <summary>
+        /// Gets or sets the loader config file path.
+        /// </summary>
+        public static string LoaderConfig { get; set; }
+
+        /// <summary>
+        /// Gets or sets individual configs directory path.
+        /// </summary>
+        public static string IndividualConfigs { get; set; }
 
         /// <summary>
         /// Gets or sets translations path.
@@ -72,9 +82,26 @@ namespace Exiled.API.Features
             Plugins = Path.Combine(Exiled, "Plugins");
             Dependencies = Path.Combine(Plugins, "dependencies");
             Configs = Path.Combine(Exiled, "Configs");
-            Config = Path.Combine(Configs, $"{Server.Port}-config.yml");
+            Config = Path.Combine(Configs,  $"{Server.Port}-config.yml");
+            LoaderConfig = Path.Combine(Configs, "Loader-Configuration.yml");
+            IndividualConfigs = Path.Combine(Configs, "Plugins");
             Translations = Path.Combine(Configs, $"{Server.Port}-translations.yml");
             Log = Path.Combine(Exiled, $"{Server.Port}-RemoteAdminLog.txt");
+        }
+
+        /// <summary>
+        /// Gets the config path of a plugin.
+        /// </summary>
+        /// <param name="pluginPrefix">The prefix of the plugin.</param>
+        /// <returns>The config path of the plugin.</returns>
+        public static string GetConfigPath(string pluginPrefix = null)
+        {
+            if (pluginPrefix != null)
+            {
+                return Path.Combine(IndividualConfigs, pluginPrefix, $"{Server.Port}.yml");
+            }
+
+            return Config;
         }
     }
 }

--- a/Exiled.API/Features/Paths.cs
+++ b/Exiled.API/Features/Paths.cs
@@ -68,6 +68,11 @@ namespace Exiled.API.Features
         public static string Translations { get; set; }
 
         /// <summary>
+        /// Gets or sets individual translations directory path.
+        /// </summary>
+        public static string IndividualTranslations { get; set; }
+
+        /// <summary>
         /// Gets or sets logs path.
         /// </summary>
         public static string Log { get; set; }
@@ -86,6 +91,7 @@ namespace Exiled.API.Features
             LoaderConfig = Path.Combine(Configs, "Loader-Configuration.yml");
             IndividualConfigs = Path.Combine(Configs, "Plugins");
             Translations = Path.Combine(Configs, $"{Server.Port}-translations.yml");
+            IndividualTranslations = Path.Combine(Configs, "Translations");
             Log = Path.Combine(Exiled, $"{Server.Port}-RemoteAdminLog.txt");
         }
 
@@ -94,9 +100,13 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="pluginPrefix">The prefix of the plugin.</param>
         /// <returns>The config path of the plugin.</returns>
-        public static string GetConfigPath(string pluginPrefix = null)
-        {
-            return pluginPrefix == null ? Config : Path.Combine(IndividualConfigs, pluginPrefix, $"{Server.Port}.yml");
-        }
+        public static string GetConfigPath(string pluginPrefix = null) => pluginPrefix == null ? Config : Path.Combine(IndividualConfigs, pluginPrefix, $"{Server.Port}.yml");
+
+        /// <summary>
+        /// Gets the translation path of a plugin.
+        /// </summary>
+        /// <param name="pluginPrefix">The prefix of the plugin.</param>
+        /// <returns>The translation path of the plugin.</returns>
+        public static string GetTranslationPath(string pluginPrefix = null) => pluginPrefix == null ? Config : Path.Combine(IndividualTranslations, pluginPrefix, $"{Server.Port}.yml");
     }
 }

--- a/Exiled.API/Features/Paths.cs
+++ b/Exiled.API/Features/Paths.cs
@@ -96,12 +96,7 @@ namespace Exiled.API.Features
         /// <returns>The config path of the plugin.</returns>
         public static string GetConfigPath(string pluginPrefix = null)
         {
-            if (pluginPrefix != null)
-            {
-                return Path.Combine(IndividualConfigs, pluginPrefix, $"{Server.Port}.yml");
-            }
-
-            return Config;
+            return pluginPrefix == null ? Config : Path.Combine(IndividualConfigs, pluginPrefix, $"{Server.Port}.yml");
         }
     }
 }

--- a/Exiled.API/Features/Plugin.cs
+++ b/Exiled.API/Features/Plugin.cs
@@ -38,6 +38,7 @@ namespace Exiled.API.Features
             Author = Assembly.GetCustomAttribute<AssemblyCompanyAttribute>()?.Company;
             Version = Assembly.GetName().Version;
             ConfigPath = Paths.GetConfigPath(Prefix);
+            TranslationPath = Paths.GetTranslationPath(Prefix);
         }
 
         /// <inheritdoc/>
@@ -77,6 +78,9 @@ namespace Exiled.API.Features
 
         /// <inheritdoc/>
         public string ConfigPath { get; }
+
+        /// <inheritdoc/>
+        public string TranslationPath { get; }
 
         /// <inheritdoc/>
         public virtual void OnEnabled()

--- a/Exiled.API/Features/Plugin.cs
+++ b/Exiled.API/Features/Plugin.cs
@@ -37,6 +37,7 @@ namespace Exiled.API.Features
             Prefix = Name.ToSnakeCase();
             Author = Assembly.GetCustomAttribute<AssemblyCompanyAttribute>()?.Company;
             Version = Assembly.GetName().Version;
+            ConfigPath = Paths.GetConfigPath(Prefix);
         }
 
         /// <inheritdoc/>
@@ -73,6 +74,9 @@ namespace Exiled.API.Features
 
         /// <inheritdoc/>
         public ITranslation InternalTranslation { get; protected set; }
+
+        /// <inheritdoc/>
+        public string ConfigPath { get; }
 
         /// <inheritdoc/>
         public virtual void OnEnabled()

--- a/Exiled.API/Interfaces/IPlugin.cs
+++ b/Exiled.API/Interfaces/IPlugin.cs
@@ -73,6 +73,11 @@ namespace Exiled.API.Interfaces
         ITranslation InternalTranslation { get; }
 
         /// <summary>
+        /// Gets the plugin config path.
+        /// </summary>
+        string ConfigPath { get; }
+
+        /// <summary>
         /// Fired after enabling the plugin.
         /// </summary>
         void OnEnabled();

--- a/Exiled.API/Interfaces/IPlugin.cs
+++ b/Exiled.API/Interfaces/IPlugin.cs
@@ -78,6 +78,11 @@ namespace Exiled.API.Interfaces
         string ConfigPath { get; }
 
         /// <summary>
+        /// Gets the plugin translation path.
+        /// </summary>
+        string TranslationPath { get; }
+
+        /// <summary>
         /// Fired after enabling the plugin.
         /// </summary>
         void OnEnabled();

--- a/Exiled.Events/Commands/Config/EConfig.cs
+++ b/Exiled.Events/Commands/Config/EConfig.cs
@@ -14,7 +14,6 @@ namespace Exiled.Events.Commands.Config
     /// <summary>
     /// The config command.
     /// </summary>
-    [CommandHandler(typeof(RemoteAdminCommandHandler))]
     [CommandHandler(typeof(GameConsoleCommandHandler))]
     public class EConfig : ParentCommand
     {

--- a/Exiled.Events/Commands/Config/EConfig.cs
+++ b/Exiled.Events/Commands/Config/EConfig.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+// <copyright file="EConfig.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Commands.Config
+{
+    using System;
+
+    using CommandSystem;
+
+    /// <summary>
+    /// The config command.
+    /// </summary>
+    [CommandHandler(typeof(RemoteAdminCommandHandler))]
+    [CommandHandler(typeof(GameConsoleCommandHandler))]
+    public class EConfig : ParentCommand
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EConfig"/> class.
+        /// </summary>
+        public EConfig() => LoadGeneratedCommands();
+
+        /// <inheritdoc/>
+        public override string Command { get; } = "econfig";
+
+        /// <inheritdoc/>
+        public override string[] Aliases { get; } = new string[] { "ecfg" };
+
+        /// <inheritdoc/>
+        public override string Description { get; } = "Changes from one config distribution to another one.";
+
+        /// <inheritdoc/>
+        public override void LoadGeneratedCommands()
+        {
+            RegisterCommand(Merge.Instance);
+            RegisterCommand(Split.Instance);
+        }
+
+        /// <inheritdoc/>
+        protected override bool ExecuteParent(ArraySegment<string> arguments, ICommandSender sender, out string response)
+        {
+            response = "Please, specify a valid subcommand! Available ones: merge, split";
+            return false;
+        }
+    }
+}

--- a/Exiled.Events/Commands/Config/Merge.cs
+++ b/Exiled.Events/Commands/Config/Merge.cs
@@ -37,9 +37,9 @@ namespace Exiled.Events.Commands.Config
         /// <inheritdoc/>
         public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
         {
-            if (!sender.CheckPermission("el.merge"))
+            if (!sender.CheckPermission("ee.merge"))
             {
-                response = "You can't use the command, you don't have the \"el.merge\" permission.";
+                response = "You can't use the command, you don't have the \"ee.merge\" permission.";
                 return false;
             }
 

--- a/Exiled.Events/Commands/Config/Merge.cs
+++ b/Exiled.Events/Commands/Config/Merge.cs
@@ -37,9 +37,9 @@ namespace Exiled.Events.Commands.Config
         /// <inheritdoc/>
         public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
         {
-            if (!sender.CheckPermission("ee.merge"))
+            if (Player.Get(sender) != Server.Host)
             {
-                response = "You can't use the command, you don't have the \"ee.merge\" permission.";
+                response = "This command can't be used inside the game.";
                 return false;
             }
 

--- a/Exiled.Events/Commands/Config/Merge.cs
+++ b/Exiled.Events/Commands/Config/Merge.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------
+// <copyright file="Merge.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Commands.Config
+{
+    using System;
+    using System.IO;
+    using CommandSystem;
+    using Exiled.API.Enums;
+    using Exiled.API.Features;
+    using Exiled.Loader;
+    using Exiled.Permissions.Extensions;
+
+    /// <summary>
+    /// The config merge command.
+    /// </summary>
+    public class Merge : ICommand
+    {
+        /// <summary>
+        /// Gets static instance of the <see cref="Merge"/> command.
+        /// </summary>
+        public static Merge Instance { get; } = new Merge();
+
+        /// <inheritdoc/>
+        public string Command { get; } = "merge";
+
+        /// <inheritdoc/>
+        public string[] Aliases { get; } = Array.Empty<string>();
+
+        /// <inheritdoc/>
+        public string Description { get; } = "Merges your configs into the default config distribution.";
+
+        /// <inheritdoc/>
+        public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
+        {
+            if (!sender.CheckPermission("el.merge"))
+            {
+                response = "You can't use the command, you don't have the \"el.merge\" permission.";
+                return false;
+            }
+
+            if (Loader.Config.ConfigType == ConfigType.Default)
+            {
+                response = "Configs are actually merged.";
+                return false;
+            }
+
+            var configs = ConfigManager.LoadConfigs(ConfigManager.Read());
+            Loader.Config.ConfigType = ConfigType.Default;
+            var haveBeenSaved = ConfigManager.SaveAll(configs);
+            File.WriteAllText(Paths.LoaderConfig, Loader.Serializer.Serialize(Loader.Config));
+
+            response = $"Configs have been merged successfully! Feel free to remove the {Paths.IndividualConfigs} file.";
+            return haveBeenSaved;
+        }
+    }
+}

--- a/Exiled.Events/Commands/Config/Split.cs
+++ b/Exiled.Events/Commands/Config/Split.cs
@@ -37,9 +37,9 @@ namespace Exiled.Events.Commands.Config
         /// <inheritdoc/>
         public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
         {
-            if (!sender.CheckPermission("el.split"))
+            if (!sender.CheckPermission("ee.split"))
             {
-                response = "You can't use the command, you don't have the \"el.split\" permission.";
+                response = "You can't use the command, you don't have the \"ee.split\" permission.";
                 return false;
             }
 

--- a/Exiled.Events/Commands/Config/Split.cs
+++ b/Exiled.Events/Commands/Config/Split.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------
+// <copyright file="Split.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Commands.Config
+{
+    using System;
+    using System.IO;
+    using CommandSystem;
+    using Exiled.API.Enums;
+    using Exiled.API.Features;
+    using Exiled.Loader;
+    using Exiled.Permissions.Extensions;
+
+    /// <summary>
+    /// The config split command.
+    /// </summary>
+    public class Split : ICommand
+    {
+        /// <summary>
+        /// Gets static instance of the <see cref="Split"/> command.
+        /// </summary>
+        public static Split Instance { get; } = new Split();
+
+        /// <inheritdoc/>
+        public string Command { get; } = "split";
+
+        /// <inheritdoc/>
+        public string[] Aliases { get; } = Array.Empty<string>();
+
+        /// <inheritdoc/>
+        public string Description { get; } = "Splits your configs into the separated config distribution.";
+
+        /// <inheritdoc/>
+        public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
+        {
+            if (!sender.CheckPermission("el.split"))
+            {
+                response = "You can't use the command, you don't have the \"el.split\" permission.";
+                return false;
+            }
+
+            if (Loader.Config.ConfigType == ConfigType.Separated)
+            {
+                response = "Configs are actually separated.";
+                return false;
+            }
+
+            var configs = ConfigManager.LoadConfigs(ConfigManager.Read());
+            Loader.Config.ConfigType = ConfigType.Separated;
+            var haveBeenSaved = ConfigManager.SaveAll(configs);
+            File.WriteAllText(Paths.LoaderConfig, Loader.Serializer.Serialize(Loader.Config));
+
+            response = $"Configs have been split successfully! Feel free to remove the {Paths.Config} file.";
+            return haveBeenSaved;
+        }
+    }
+}

--- a/Exiled.Events/Commands/Config/Split.cs
+++ b/Exiled.Events/Commands/Config/Split.cs
@@ -37,9 +37,9 @@ namespace Exiled.Events.Commands.Config
         /// <inheritdoc/>
         public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
         {
-            if (!sender.CheckPermission("ee.split"))
+            if (Player.Get(sender) != Server.Host)
             {
-                response = "You can't use the command, you don't have the \"ee.split\" permission.";
+                response = "This command can't be used inside the game.";
                 return false;
             }
 

--- a/Exiled.Loader/Config.cs
+++ b/Exiled.Loader/Config.cs
@@ -32,5 +32,11 @@ namespace Exiled.Loader
         /// </summary>
         [Description("The working environment type (Development, Testing, Production, Ptb)")]
         public EnvironmentType Environment { get; set; } = EnvironmentType.Production;
+
+        /// <summary>
+        /// Gets or sets the config files distribution type.
+        /// </summary>
+        [Description("The config files distribution type (Default, Separated)")]
+        public ConfigType ConfigType { get; set; } = ConfigType.Default;
     }
 }

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -12,9 +12,6 @@ namespace Exiled.Loader
     using System.IO;
     using System.Linq;
     using System.Reflection;
-    using System.Runtime.InteropServices;
-    using System.Security.Principal;
-    using System.Threading;
 
     using CommandSystem.Commands.Shared;
 
@@ -138,12 +135,6 @@ namespace Exiled.Loader
         /// <param name="dependencies">The dependencies that could have been loaded by Exiled.Bootstrap.</param>
         public static void Run(Assembly[] dependencies = null)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator) : geteuid() == 0)
-            {
-                ServerConsole.AddLog("YOU ARE RUNNING THE SERVER AS ROOT / ADMINISTRATOR. THIS IS HIGHLY UNRECOMMENDED. PLEASE INSTALL YOUR SERVER AS A NON-ROOT/ADMIN USER.", ConsoleColor.Red);
-                Thread.Sleep(5000);
-            }
-
             if (dependencies?.Length > 0)
                 Dependencies.AddRange(dependencies);
 
@@ -376,11 +367,10 @@ namespace Exiled.Loader
 
                     return true;
                 }
-                else if (requiredVersion.Major < actualVersion.Major)
+                else if (requiredVersion.Major < actualVersion.Major && !Config.ShouldLoadOutdatedPlugins)
                 {
-                    // TODO: Re-add outdated plugin loading.
                     Log.Error($"You're running an older version of {plugin.Name} ({plugin.Version.ToString(3)})! " +
-                              $"Its Required Major version is {requiredVersion.Major}, but the actual version is: {actualVersion.Major}. This plugin will not be loaded!");
+                              $"Its Required Major version is {requiredVersion.Major}, but excepted {actualVersion.Major}. ");
 
                     return true;
                 }
@@ -389,10 +379,6 @@ namespace Exiled.Loader
             return false;
         }
 
-#pragma warning disable SA1300
-        [DllImport("libc")]
-        private static extern uint geteuid();
-#pragma warning restore
         /// <summary>
         /// Loads all dependencies.
         /// </summary>

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -55,7 +55,8 @@ namespace Exiled.Loader
 
             CustomNetworkManager.Modded = true;
 
-            // "Useless" check for now, since configs will be loaded after loading all plugins.
+            ConfigManager.LoadLoaderConfigs();
+
             if (Config.Environment != EnvironmentType.Production)
                 Paths.Reload($"EXILED-{Config.Environment.ToString().ToUpper()}");
             if (Environment.CurrentDirectory.Contains("testing", StringComparison.OrdinalIgnoreCase))
@@ -63,6 +64,9 @@ namespace Exiled.Loader
 
             if (!Directory.Exists(Paths.Configs))
                 Directory.CreateDirectory(Paths.Configs);
+
+            if (Config.ConfigType == ConfigType.Separated && !Directory.Exists(Paths.IndividualConfigs))
+                Directory.CreateDirectory(Paths.IndividualConfigs);
 
             if (!Directory.Exists(Paths.Plugins))
                 Directory.CreateDirectory(Paths.Plugins);

--- a/Exiled.Loader/TranslationManager.cs
+++ b/Exiled.Loader/TranslationManager.cs
@@ -125,8 +125,14 @@ namespace Exiled.Loader
         {
             try
             {
-                if (pluginPrefix != null && Loader.Config.ConfigType == ConfigType.Separated && !Directory.Exists(Path.Combine(Paths.IndividualConfigs, pluginPrefix)))
-                    Directory.CreateDirectory(Path.Combine(Paths.IndividualConfigs, pluginPrefix));
+                if (pluginPrefix != null && Loader.Config.ConfigType == ConfigType.Separated)
+                {
+                    if (!Directory.Exists(Paths.IndividualTranslations))
+                        Directory.CreateDirectory(Paths.IndividualTranslations);
+
+                    if (!Directory.Exists(Path.Combine(Paths.IndividualTranslations, pluginPrefix)))
+                        Directory.CreateDirectory(Path.Combine(Paths.IndividualTranslations, pluginPrefix));
+                }
 
                 File.WriteAllText(Paths.GetTranslationPath(pluginPrefix), translations ?? string.Empty);
 


### PR DESCRIPTION
This allows people to have their configs into separated folders or use the default one.

 - This creates a file inside the Config folder to configure the Loader so it doesnt have to read a config to check if it is using separated or default type.
 
https://cdn.discordapp.com/attachments/867421794545565699/891640423783743528/configTypesTest.mp4


 