### PR TITLE
Fix Server.Restart not reconnecting players.

### DIFF
--- a/Exiled.API/Features/Server.cs
+++ b/Exiled.API/Features/Server.cs
@@ -137,8 +137,7 @@ namespace Exiled.API.Features
         /// </summary>
         public static void Restart()
         {
-            // Used here fastRestart: true, don't know if it makes sense other than no delays in the call to change the scene
-            Round.Restart(true, true, ServerStatic.NextRoundAction.Restart);
+            Round.Restart(false, true, ServerStatic.NextRoundAction.Restart);
         }
 
         /// <summary>


### PR DESCRIPTION
Idk why fastrestart was passed as true here, it makes clients not expect to get disconnected, then they immediately do so they do not reconnect.