### PR TITLE
Re-implement ChangingIntoGrenade event

### DIFF
--- a/Exiled.Events/EventArgs/ChangingIntoGrenadeEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingIntoGrenadeEventArgs.cs
@@ -23,14 +23,10 @@ namespace Exiled.Events.EventArgs
         /// Initializes a new instance of the <see cref="ChangingIntoGrenadeEventArgs"/> class.
         /// </summary>
         /// <param name="pickup">The <see cref="Pickup"/> being changed.</param>
-        /// <param name="fuseTime">The duration, in seconds, of the fuse time to be used when the grenade goes live.</param>
-        /// <param name="isAllowed">Whether or not the event is allowed to continue.</param>
-        public ChangingIntoGrenadeEventArgs(ItemPickupBase pickup, float fuseTime = 3f, bool isAllowed = true)
+        public ChangingIntoGrenadeEventArgs(ItemPickupBase pickup)
         {
             Pickup = Pickup.Get(pickup);
             Type = pickup.NetworkInfo.ItemId;
-            FuseTime = fuseTime;
-            IsAllowed = isAllowed;
         }
 
         /// <summary>

--- a/Exiled.Events/EventArgs/ChangingIntoGrenadeEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingIntoGrenadeEventArgs.cs
@@ -10,9 +10,11 @@ namespace Exiled.Events.EventArgs
     using System;
 
     using Exiled.API.Enums;
+    using Exiled.API.Features;
     using Exiled.API.Features.Items;
 
     using InventorySystem.Items.Pickups;
+    using InventorySystem.Items.ThrowableProjectiles;
 
     /// <summary>
     /// Contains all information for when the server is turning a pickup into a live grenade.
@@ -23,10 +25,13 @@ namespace Exiled.Events.EventArgs
         /// Initializes a new instance of the <see cref="ChangingIntoGrenadeEventArgs"/> class.
         /// </summary>
         /// <param name="pickup">The <see cref="Pickup"/> being changed.</param>
-        public ChangingIntoGrenadeEventArgs(ItemPickupBase pickup)
+        public ChangingIntoGrenadeEventArgs(TimedGrenadePickup pickup)
         {
+            if (pickup == null)
+                Log.Error($"{nameof(ChangingIntoGrenadeEventArgs)}: Pickup is null!");
             Pickup = Pickup.Get(pickup);
-            Type = Pickup.Type;
+            Type = pickup.Info.ItemId;
+            FuseTime = Pickup.Base is TimeGrenade timeGrenade ? timeGrenade._fuseTime : 3f;
         }
 
         /// <summary>
@@ -42,7 +47,7 @@ namespace Exiled.Events.EventArgs
         /// <summary>
         /// Gets or sets a value indicating whether the pickup will be changed.
         /// </summary>
-        public bool IsAllowed { get; set; }
+        public bool IsAllowed { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating how long the fuse of the changed grenade will be.

--- a/Exiled.Events/EventArgs/ChangingIntoGrenadeEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingIntoGrenadeEventArgs.cs
@@ -26,7 +26,7 @@ namespace Exiled.Events.EventArgs
         public ChangingIntoGrenadeEventArgs(ItemPickupBase pickup)
         {
             Pickup = Pickup.Get(pickup);
-            Type = pickup.NetworkInfo.ItemId;
+            Type = Pickup.Type;
         }
 
         /// <summary>

--- a/Exiled.Events/Patches/Events/Map/ChangingIntoGrenade.cs
+++ b/Exiled.Events/Patches/Events/Map/ChangingIntoGrenade.cs
@@ -8,27 +8,35 @@
 namespace Exiled.Events.Patches.Events.Map
 {
 #pragma warning disable SA1118
-    /*using System.Collections.Generic;
+    using System.Collections.Generic;
     using System.Reflection;
     using System.Reflection.Emit;
 
+    using Exiled.API.Features.Items;
     using Exiled.Events.EventArgs;
-
-    using Grenades;
+    using Exiled.Events.Handlers;
 
     using HarmonyLib;
+
+    using InventorySystem;
+    using InventorySystem.Items;
+    using InventorySystem.Items.ThrowableProjectiles;
 
     using Mirror;
 
     using NorthwoodLib.Pools;
 
+    using UnityEngine;
+
     using static HarmonyLib.AccessTools;
 
+    using Item = Exiled.API.Features.Items.Item;
+
     /// <summary>
-    /// Patches <see cref="FragGrenade.ChangeIntoGrenade"/>.
+    /// Patches <see cref="InventorySystem.Items.ThrowableProjectiles.TimedGrenadePickup.Update"/>.
     /// Adds the <see cref="Handlers.Map.ChangingIntoGrenade"/> event.
     /// </summary>
-    [HarmonyPatch(typeof(FragGrenade), nameof(FragGrenade.ChangeIntoGrenade))]
+    [HarmonyPatch(typeof(InventorySystem.Items.ThrowableProjectiles.TimedGrenadePickup), nameof(InventorySystem.Items.ThrowableProjectiles.TimedGrenadePickup.Update))]
     internal static class ChangingIntoGrenade
     {
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
@@ -36,69 +44,97 @@ namespace Exiled.Events.Patches.Events.Map
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
 
             // The index offset
-            int offset = 2;
+            int offset = 1;
 
             // Find the last return false call.
-            int index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Ldc_I4_0) + offset;
+            int index = newInstructions.FindIndex(i => i.opcode == OpCodes.Ret) + offset;
 
-            // Generate a continue lable.
-            Label continueLabel = generator.DefineLabel();
+            // Extract the existing label we will be removing.
+            Label enterLabel = newInstructions[index].labels[0];
+
+            // Generate a return label.
+            Label returnLabel = generator.DefineLabel();
+
+            // Generate a label for when we cannot set the fuse time.
+            Label skipFuse = generator.DefineLabel();
 
             // Declare ChangingIntoGrenadeEventArgs, to be able to store it's instance with "stloc.s".
             LocalBuilder ev = generator.DeclareLocal(typeof(ChangingIntoGrenadeEventArgs));
-            LocalBuilder grenade = generator.DeclareLocal(typeof(Grenade));
 
+            // Declare TimeGrenade, so we are able to set it's fusetime.
+            LocalBuilder timeGrenade = generator.DeclareLocal(typeof(TimeGrenade));
+
+            // Declare ThrownProjectile because the base method doesn't use it as a local.
+            LocalBuilder thrownProjectile = generator.DeclareLocal(typeof(ThrownProjectile));
+
+            // Remove the existing instructions that get the itemBase to spawn, we will be doing this ourselves.
+            int instructionsToRemove = 14;
+
+            newInstructions.RemoveRange(index, instructionsToRemove);
+
+            // Setup EventArgs, call event, check ev.IsAllowed and implement ev.Type changing
             newInstructions.InsertRange(index, new[]
             {
-                // (Pickup item, float fuseTime, bool isAllowed)
-                new CodeInstruction(OpCodes.Ldarg_1).MoveLabelsFrom(newInstructions[index]),
-                new CodeInstruction(OpCodes.Ldc_R4, 3f),
-                new CodeInstruction(OpCodes.Ldc_I4_1),
+                // itemPickupBase
+                new CodeInstruction(OpCodes.Ldloc_0).WithLabels(enterLabel),
 
-                // var ev = new ServerChangingGrenadeEventArgs(pickup)
+                // var ev = new ChangingIntoGrenadeEventArgs(ItemPickupBase);
                 new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(ChangingIntoGrenadeEventArgs))[0]),
                 new CodeInstruction(OpCodes.Dup),
                 new CodeInstruction(OpCodes.Dup),
-                new CodeInstruction(OpCodes.Stloc_S, ev.LocalIndex),
+                new CodeInstruction(OpCodes.Stloc, ev.LocalIndex),
 
-                // Handlers.Map.OnServerChangingGrenade(ev)
-                new CodeInstruction(OpCodes.Call, Method(typeof(Handlers.Map), nameof(Handlers.Map.OnChangingIntoGrenade))),
+                // Map.OnChangingIntoGrenade(ev);
+                new CodeInstruction(OpCodes.Call, Method(typeof(Map), nameof(Map.OnChangingIntoGrenade))),
 
                 // if (!ev.IsAllowed)
-                //     return;
+                //    return;
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingIntoGrenadeEventArgs), nameof(ChangingIntoGrenadeEventArgs.IsAllowed))),
-                new CodeInstruction(OpCodes.Brtrue_S, continueLabel),
-                new CodeInstruction(OpCodes.Ldc_I4_0),
-                new CodeInstruction(OpCodes.Ret),
+                new CodeInstruction(OpCodes.Brfalse, returnLabel),
 
-                // item.ItemId = ev.Type
-                new CodeInstruction(OpCodes.Ldarg_1).WithLabels(continueLabel),
-                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
-                new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(ChangingIntoGrenadeEventArgs), nameof(ChangingIntoGrenadeEventArgs.Type))),
-                new CodeInstruction(OpCodes.Call, PropertySetter(typeof(Pickup), nameof(Pickup.ItemId))),
+                // if (!InventoryItemLoader.AvailableItems.TryGetValue(ev.Type, out itemBase) || !(itemBase is ThrowableItem throwableItem))
+                //    return;
+                new CodeInstruction(OpCodes.Ldloc, ev.LocalIndex),
+                new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(InventoryItemLoader), nameof(InventoryItemLoader.AvailableItems))),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingIntoGrenadeEventArgs), nameof(ChangingIntoGrenadeEventArgs.Type))),
+                new CodeInstruction(OpCodes.Ldloca_S, 0),
+                new CodeInstruction(OpCodes.Callvirt, Method(typeof(Dictionary<ItemType, ItemBase>), nameof(Dictionary<ItemType, ItemBase>.TryGetValue))),
+                new CodeInstruction(OpCodes.Brfalse, returnLabel),
+                new CodeInstruction(OpCodes.Ldloc_0),
+                new CodeInstruction(OpCodes.Isinst, typeof(ThrowableItem)),
+                new CodeInstruction(OpCodes.Dup),
+                new CodeInstruction(OpCodes.Stloc_1),
+                new CodeInstruction(OpCodes.Brfalse, returnLabel),
             });
 
-            // Find the last method call
-            offset = -2;
-            index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Callvirt && (MethodInfo)instruction.operand == Method(typeof(Grenade), nameof(Grenade.InitData), new[] { typeof(FragGrenade), typeof(Pickup) })) + offset;
+            offset = 4;
+            index = newInstructions.FindIndex(i => i.opcode == OpCodes.Ldloc_1) + offset;
 
             newInstructions.InsertRange(index, new[]
             {
-                // grenade.NetworkFuseTime = NetworkTime.Time + ev.FuseTime
-                new CodeInstruction(OpCodes.Dup),
-                new CodeInstruction(OpCodes.Stloc_S, grenade.LocalIndex),
-                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
+                // if (thrownProjectile is TimeGrenade timeGrenade)
+                //    timeGrenade._fuseTime = ev.FuseTime;
+                new CodeInstruction(OpCodes.Stloc, thrownProjectile.LocalIndex),
+                new CodeInstruction(OpCodes.Ldloc, thrownProjectile.LocalIndex),
+                new CodeInstruction(OpCodes.Isinst, typeof(TimeGrenade)),
+                new CodeInstruction(OpCodes.Stloc, timeGrenade.LocalIndex),
+                new CodeInstruction(OpCodes.Brfalse, skipFuse),
+
+                new CodeInstruction(OpCodes.Ldloc, timeGrenade.LocalIndex),
+                new CodeInstruction(OpCodes.Ldloc, ev.LocalIndex),
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingIntoGrenadeEventArgs), nameof(ChangingIntoGrenadeEventArgs.FuseTime))),
-                new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(NetworkTime), nameof(NetworkTime.time))),
-                new CodeInstruction(OpCodes.Add),
-                new CodeInstruction(OpCodes.Callvirt, PropertySetter(typeof(Grenades.Grenade), nameof(Grenades.Grenade.NetworkfuseTime))),
-                new CodeInstruction(OpCodes.Ldloc_S, grenade.LocalIndex),
+                new CodeInstruction(OpCodes.Stfld, Field(typeof(TimeGrenade), nameof(TimeGrenade._fuseTime))),
+                new CodeInstruction(OpCodes.Nop).WithLabels(skipFuse),
+                new CodeInstruction(OpCodes.Ldloc, thrownProjectile.LocalIndex),
+                new CodeInstruction(OpCodes.Dup),
             });
+
+            newInstructions[newInstructions.Count - 1].WithLabels(returnLabel);
 
             for (int z = 0; z < newInstructions.Count; z++)
                 yield return newInstructions[z];
 
             ListPool<CodeInstruction>.Shared.Return(newInstructions);
         }
-    }*/
+    }
 }

--- a/Exiled.Events/Patches/Events/Map/ChangingIntoGrenade.cs
+++ b/Exiled.Events/Patches/Events/Map/ChangingIntoGrenade.cs
@@ -76,7 +76,7 @@ namespace Exiled.Events.Patches.Events.Map
             newInstructions.InsertRange(index, new[]
             {
                 // itemPickupBase
-                new CodeInstruction(OpCodes.Ldloc_0).WithLabels(enterLabel),
+                new CodeInstruction(OpCodes.Ldarg_0).WithLabels(enterLabel),
 
                 // var ev = new ChangingIntoGrenadeEventArgs(ItemPickupBase);
                 new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(ChangingIntoGrenadeEventArgs))[0]),
@@ -94,8 +94,8 @@ namespace Exiled.Events.Patches.Events.Map
 
                 // if (!InventoryItemLoader.AvailableItems.TryGetValue(ev.Type, out itemBase) || !(itemBase is ThrowableItem throwableItem))
                 //    return;
-                new CodeInstruction(OpCodes.Ldloc, ev.LocalIndex),
                 new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(InventoryItemLoader), nameof(InventoryItemLoader.AvailableItems))),
+                new CodeInstruction(OpCodes.Ldloc, ev.LocalIndex),
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingIntoGrenadeEventArgs), nameof(ChangingIntoGrenadeEventArgs.Type))),
                 new CodeInstruction(OpCodes.Ldloca_S, 0),
                 new CodeInstruction(OpCodes.Callvirt, Method(typeof(Dictionary<ItemType, ItemBase>), nameof(Dictionary<ItemType, ItemBase>.TryGetValue))),


### PR DESCRIPTION
This patch re-implements the Map.ChangingIntoGrenade event, which will fire when an explodable pickup (IE HE grenade or 018) is turned into an active grenade when hit with an explosion.

The patch has been tested to not cause patching errors, but I have not yet verified the event works as expected and that base-game behavior isn't borked.