### PR TITLE
Potential softlock fix

### DIFF
--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -156,13 +156,37 @@ namespace Exiled.Events.Patches.Events.Player
                     if (inventory.TryGetBodyArmor(out BodyArmor bodyArmor))
                         bodyArmor.DontRemoveExcessOnDrop = true;
                     while (inventory.UserInventory.Items.Count > 0)
-                        list.Add(inventory.ServerDropItem(inventory.UserInventory.Items.ElementAt(0).Key));
+                    {
+                        var startCount = inventory.UserInventory.Items.Count;
+                        var item = inventory.ServerDropItem(inventory.UserInventory.Items.ElementAt(0).Key);
+
+                        // If the list wasn't changed, we need to manually remove the item to avoid a softlock.
+                        if (startCount == inventory.UserInventory.Items.Count)
+                        {
+                            inventory.UserInventory.Items.Remove(0);
+                        }
+                        else
+                        {
+                            list.Add(item);
+                        }
+                    }
+
                     InventoryItemProvider.PreviousInventoryPickups[player.ReferenceHub] = list;
                 }
                 else
                 {
                     while (inventory.UserInventory.Items.Count > 0)
+                    {
+                        var startCount = inventory.UserInventory.Items.Count;
                         inventory.ServerRemoveItem(inventory.UserInventory.Items.ElementAt(0).Key, null);
+
+                        // If the list wasn't changed, we need to manually remove the item to avoid a softlock.
+                        if (startCount == inventory.UserInventory.Items.Count)
+                        {
+                            inventory.UserInventory.Items.Remove(0);
+                        }
+                    }
+
                     inventory.UserInventory.ReserveAmmo.Clear();
                     inventory.SendAmmoNextFrame = true;
                 }

--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -158,12 +158,13 @@ namespace Exiled.Events.Patches.Events.Player
                     while (inventory.UserInventory.Items.Count > 0)
                     {
                         var startCount = inventory.UserInventory.Items.Count;
-                        var item = inventory.ServerDropItem(inventory.UserInventory.Items.ElementAt(0).Key);
+                        var key = inventory.UserInventory.Items.ElementAt(0).Key;
+                        var item = inventory.ServerDropItem(key);
 
                         // If the list wasn't changed, we need to manually remove the item to avoid a softlock.
                         if (startCount == inventory.UserInventory.Items.Count)
                         {
-                            inventory.UserInventory.Items.Remove(0);
+                            inventory.UserInventory.Items.Remove(key);
                         }
                         else
                         {
@@ -178,12 +179,13 @@ namespace Exiled.Events.Patches.Events.Player
                     while (inventory.UserInventory.Items.Count > 0)
                     {
                         var startCount = inventory.UserInventory.Items.Count;
-                        inventory.ServerRemoveItem(inventory.UserInventory.Items.ElementAt(0).Key, null);
+                        var key = inventory.UserInventory.Items.ElementAt(0).Key;
+                        inventory.ServerRemoveItem(key, null);
 
                         // If the list wasn't changed, we need to manually remove the item to avoid a softlock.
                         if (startCount == inventory.UserInventory.Items.Count)
                         {
-                            inventory.UserInventory.Items.Remove(0);
+                            inventory.UserInventory.Items.Remove(key);
                         }
                     }
 


### PR DESCRIPTION
The softlocks occur during death and escape, and are exasperated by EXILED. This method is ran on death and escape and has a while loop in it that calls a method that potentially wont remove the value from the while loop, creating a while-true.

This pretty much just forces the item to be removed from the inventory if it wasn't, so the while loop can't go on forever.