### PR TITLE
Fix FindParentRoom not returning Outside

### DIFF
--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -242,9 +242,9 @@ namespace Exiled.API.Features
             }
 
             // Always default to surface transform, since it's static.
-            // The current index of the 'Outsise' room is the last one
+            // The current index of the 'Outsise' room is the first one
             if (room == null && rooms.Count != 0)
-                room = rooms[rooms.Count - 1];
+                room = rooms[0];
 
             return room;
         }


### PR DESCRIPTION
Since #827 made the default room(first room) in rooms to be Outside. FindParentRoom needs to be updated in order to return Outside.

PS: #826 is the issue I am encountering which uses FindParentRoom