### PR TITLE
Adjusted comment in JumpingEventArgs

### DIFF
--- a/Exiled.Events/EventArgs/JumpingEventArgs.cs
+++ b/Exiled.Events/EventArgs/JumpingEventArgs.cs
@@ -44,7 +44,7 @@ namespace Exiled.Events.EventArgs
         public Vector3 Position { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the player can jump.
+        /// Gets or sets a value indicating whether the client data can be synchronized with the server.
         /// </summary>
         public bool IsAllowed { get; set; }
     }


### PR DESCRIPTION
Setting `ev.IsAllowed = false` won't prevent player from jumping, but it also won't send information about jump to the server. (for the server it will look like the player didn't jump at all)

Current comment states otherwise, so I adjusted it to say a correct behaviour.