### PR TITLE
Server Freeze Problem

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1343,7 +1343,16 @@ namespace Exiled.API.Features
         public bool RemoveItem(Item item, bool destroy = true)
         {
             if (!ItemsValue.Contains(item))
+            {
                 return false;
+            }
+            
+            if (!Inventory.UserInventory.Items.ContainsKey(item.Serial))
+            {
+                ItemsValue.Remove(item);
+                return false;       
+            }
+
             if (destroy)
             {
                 Inventory.ServerRemoveItem(item.Serial, null);

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1346,11 +1346,11 @@ namespace Exiled.API.Features
             {
                 return false;
             }
-            
+
             if (!Inventory.UserInventory.Items.ContainsKey(item.Serial))
             {
                 ItemsValue.Remove(item);
-                return false;       
+                return false;
             }
 
             if (destroy)


### PR DESCRIPTION
The server freezes when the main game and the exiled item list do not match. Rarely will 2 items with the same serial number appear on the list. The reason is not yet clear