### PR TITLE
Player Ammo methods

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1498,6 +1498,29 @@ namespace Exiled.API.Features
         public void ClearBroadcasts() => Server.Broadcast.TargetClearElements(Connection);
 
         /// <summary>
+        /// Adds the amount of a specified <see cref="AmmoType">ammo type</see> to the player's inventory.
+        /// </summary>
+        /// <param name="ammoType">The <see cref="AmmoType"/> to be set.</param>
+        /// <param name="amount">The amount of ammo to be set.</param>
+        public void AddAmmo(AmmoType ammoType, ushort amount) => Inventory.ServerAddAmmo(ammoType.GetItemType(), amount);
+
+        /// <summary>
+        /// Sets the amount of a specified <see cref="AmmoType">ammo type</see> to the player's inventory.
+        /// </summary>
+        /// <param name="ammoType">The <see cref="AmmoType"/> to be set.</param>
+        /// <param name="amount">The amount of ammo to be set.</param>
+        public void SetAmmo(AmmoType ammoType, ushort amount) => Inventory.ServerSetAmmo(ammoType.GetItemType(), amount);
+
+        /// <summary>
+        /// Drops a specific <see cref="AmmoType"/> out of the player's inventory.
+        /// </summary>
+        /// <param name="ammoType">The <see cref="AmmoType"/> that will be dropped.</param>
+        /// <param name="amount">The amount of ammo that will be dropped.</param>
+        /// <param name="checkMinimals">Whether ammo limits will be taken into consideration.</param>
+        /// <returns>Whether ammo was dropped.</returns>
+        public bool DropAmmo(AmmoType ammoType, ushort amount, bool checkMinimals = false) => Inventory.ServerDropAmmo(ammoType.GetItemType(), amount, checkMinimals);
+
+        /// <summary>
         /// Add an item of the specified type with default durability(ammo/charge) and no mods to the player's inventory.
         /// </summary>
         /// <param name="itemType">The item to be added.</param>

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1500,8 +1500,8 @@ namespace Exiled.API.Features
         /// <summary>
         /// Adds the amount of a specified <see cref="AmmoType">ammo type</see> to the player's inventory.
         /// </summary>
-        /// <param name="ammoType">The <see cref="AmmoType"/> to be set.</param>
-        /// <param name="amount">The amount of ammo to be set.</param>
+        /// <param name="ammoType">The <see cref="AmmoType"/> to be added.</param>
+        /// <param name="amount">The amount of ammo to be added.</param>
         public void AddAmmo(AmmoType ammoType, ushort amount) => Inventory.ServerAddAmmo(ammoType.GetItemType(), amount);
 
         /// <summary>
@@ -1510,6 +1510,13 @@ namespace Exiled.API.Features
         /// <param name="ammoType">The <see cref="AmmoType"/> to be set.</param>
         /// <param name="amount">The amount of ammo to be set.</param>
         public void SetAmmo(AmmoType ammoType, ushort amount) => Inventory.ServerSetAmmo(ammoType.GetItemType(), amount);
+
+        /// <summary>
+        /// Gets the ammo count of a specified <see cref="AmmoType">ammo type</see> in a player's inventory.
+        /// </summary>
+        /// <param name="ammoType">The <see cref="AmmoType"/> to be searched for in the player's inventory.</param>
+        /// <returns>The specified <see cref="AmmoType">ammo</see> count.</returns>
+        public ushort GetAmmo(AmmoType ammoType) => Inventory.GetCurAmmo(ammoType.GetItemType());
 
         /// <summary>
         /// Drops a specific <see cref="AmmoType"/> out of the player's inventory.


### PR DESCRIPTION
Initially I wanted to make a separate Ammo class that could be used as a Dictionary, which would also contain some cool methods and all that... Obviously that would've been the fancy way of doing this, so me being very lazy I instead opted for a few cool methods.

Either way, added the following methods to the `Player` class:
- `Player.AddAmmo(AmmoType, ushort)` to easily add ammo to the player's inventory.
- `Player.SetAmmo(AmmoType, ushort)` to set a specific ammo type to the specified amount.
- `Player.DropAmmo(AmmoType, ushort, bool)` to drop a specific amount of ammo. (I honestly don't have a clue as to what `checkMinimals` does)
- `Player.GetAmmo(AmmoType, ushort)` to get how much ammo the player has of a specific ammo type, not entirely necessary given `Player.Ammo` exists, but for the sake of consistency I added it.