### PR TITLE
Fix mistakenly reverted docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run DocFX
         env:
           EXILED_REFERENCES: ${{ env.EXILED_REFERENCES_PATH }}
-        run: docfx docfx.json
+        run: docfx docfx.json; docfx docfx.json
         
       - name: Deploy to GitHub Pages
         if: github.event_name == 'push' && success() #Only publishes on push to master to avoid docs mishaps


### PR DESCRIPTION
A change i made in PR #749 `docs.yml` was mistakenly reverted in commit [73adac92b9d072a13d699d213c90036abbf767b3](https://github.com/Exiled-Team/EXILED/pull/872/commits/73adac92b9d072a13d699d213c90036abbf767b3), this PR fixes that so CI will not  error when trying to build docs(somehow it didn't make its way back to dev???? ¯\_(ツ)_/¯)