### PR TITLE
Make MaxHealth great again

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1286,7 +1286,6 @@ namespace Exiled.API.Features
         public void SetRole(RoleType newRole, SpawnReason reason = SpawnReason.ForceClass, bool lite = false)
         {
             ReferenceHub.characterClassManager.SetPlayersClass(newRole, GameObject, (CharacterClassManager.SpawnReason)reason, lite);
-            MaxHealth = ReferenceHub.characterClassManager.Classes.SafeGet(newRole).maxHP;
         }
 
         /// <summary>

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -663,11 +663,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets or sets the player's maximum health.
         /// </summary>
-        public int MaxHealth
-        {
-            get => ReferenceHub.characterClassManager.CurRole.maxHP;
-            set => ReferenceHub.characterClassManager.CurRole.maxHP = value;
-        }
+        public int MaxHealth { get; set; }
 
         /// <summary>
         /// Gets or sets the player's artificial health.
@@ -1290,6 +1286,7 @@ namespace Exiled.API.Features
         public void SetRole(RoleType newRole, SpawnReason reason = SpawnReason.ForceClass, bool lite = false)
         {
             ReferenceHub.characterClassManager.SetPlayersClass(newRole, GameObject, (CharacterClassManager.SpawnReason)reason, lite);
+            MaxHealth = ReferenceHub.characterClassManager.Classes.SafeGet(newRole).maxHP;
         }
 
         /// <summary>

--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -100,6 +100,15 @@ namespace Exiled.Events.Patches.Events.Player
                 // escape = ev.IsEscaped
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingRoleEventArgs), nameof(ChangingRoleEventArgs.Reason))),
                 new CodeInstruction(OpCodes.Starg, 3),
+
+                // ev.Player.MaxHealth = this.Classes.SafeGet(ev.NewRole)
+                new CodeInstruction(OpCodes.Ldloc, player.LocalIndex),
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(CharacterClassManager), nameof(CharacterClassManager.Classes))),
+                new CodeInstruction(OpCodes.Ldarg_1),
+                new CodeInstruction(OpCodes.Call, Method(typeof(RoleExtensionMethods), nameof(RoleExtensionMethods.SafeGet), new[] { typeof(Role[]), typeof(RoleType) })),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Role), nameof(Role.maxHP))),
+                new CodeInstruction(OpCodes.Call, PropertySetter(typeof(API.Features.Player), nameof(API.Features.Player.MaxHealth))),
             });
 
             offset = 0;


### PR DESCRIPTION
Having MaxHealth tie directly to the Role.maxHP field makes it affect all players of that role. 
playerStats.StatModules[0].MaxValue is unsettable, thus we have no way to change a specific player's max-health within base-game code.

To allow us to still have and use the MaxHealth value for plugins, we need to detach it from base-game values. Plugins can still get/change the value as normal, and EXILED will change the value back to default for their new role when they change roles.