### PR TITLE
Fix NW moment

### DIFF
--- a/Exiled.Events/Patches/Events/Server/RoundEnd.cs
+++ b/Exiled.Events/Patches/Events/Server/RoundEnd.cs
@@ -43,7 +43,7 @@ namespace Exiled.Events.Patches.Events.Server
             {
                 yield return Timing.WaitForSeconds(2.5f);
 
-                while (RoundSummary.RoundLock || !RoundSummary.RoundInProgress() || Time.unscaledTime - time < 15f || (roundSummary._keepRoundOnOne && PlayerManager.players.Count < 2))
+                while (RoundSummary.RoundLock || (ReferenceHub.LocalHub != null && ReferenceHub.LocalHub.characterClassManager != null && !RoundSummary.RoundInProgress()) || Time.unscaledTime - time < 15f || (roundSummary._keepRoundOnOne && PlayerManager.players.Count < 2))
                     yield return Timing.WaitForOneFrame;
 
                 RoundSummary.SumInfo_ClassList newList = default;


### PR DESCRIPTION
Sometimes the host ReferenceHub gets destroyed when a round is ending, this causes the RoundSummary.RoundInProgress() call to hit a nullref which kills the coroutine responsible for ending the round and triggering a round restart.

This fix checks that the host ReferenceHub and it's associated CCM component are not null before running the above method, if one of them is null, the round will immediately end and a new round will be triggered as normal.