### PR TITLE
Use the unused index on Hurting transpiler

### DIFF
--- a/Exiled.Events/Patches/Events/Player/Hurting.cs
+++ b/Exiled.Events/Patches/Events/Player/Hurting.cs
@@ -42,15 +42,16 @@ namespace Exiled.Events.Patches.Events.Player
         {
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
 
-            int offset = 1;
+            const int offset = 1;
             int index = newInstructions.FindIndex(i => i.opcode == OpCodes.Ret) + offset;
+
             LocalBuilder player = generator.DeclareLocal(typeof(Player));
             LocalBuilder hurtingEv = generator.DeclareLocal(typeof(HurtingEventArgs));
 
             Label notRecontainment = generator.DefineLabel();
             Label ret = generator.DefineLabel();
 
-            newInstructions.InsertRange(0, new[]
+            newInstructions.InsertRange(index, new[]
             {
                 // Player = Player.Get(this._hub)
                 new CodeInstruction(OpCodes.Ldarg_0),


### PR DESCRIPTION
This will prevent the event from being called when the target is dead/has godmode.