### PR TITLE
Fix for InvalidCastException in custom items.

### DIFF
--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -664,64 +664,8 @@ namespace Exiled.CustomItems.API.Features
         protected Item CreateCorrectItem(ItemBase itemBase = null)
         {
             if (itemBase != null)
-                return Item.Get(itemBase);
-
-            Item item = null;
-            if (Type.IsMedical())
-            {
-                item = new Usable(Type);
-            }
-            else if (Type.IsAmmo())
-            {
-                item = new Ammo(Type);
-            }
-            else if (Type.IsArmor())
-            {
-                item = new Armor(Type);
-            }
-            else if (Type.IsKeycard())
-            {
-                item = new Keycard(Type);
-            }
-            else if (Type.IsThrowable())
-            {
-                switch (Type)
-                {
-                    case ItemType.GrenadeFlash:
-                        item = new FlashGrenade(Type);
-                        break;
-                    case ItemType.GrenadeHE:
-                    case ItemType.SCP018:
-                        item = new ExplosiveGrenade(Type);
-                        break;
-                }
-            }
-            else if (Type.IsWeapon())
-            {
-                switch (Type)
-                {
-                    case ItemType.MicroHID:
-                        item = new MicroHid(Type);
-                        break;
-                    default:
-                        item = new Firearm(Type);
-                        break;
-                }
-            }
-            else if (Type.IsUtility())
-            {
-                switch (Type)
-                {
-                    case ItemType.Radio:
-                        item = new Radio(Type);
-                        break;
-                    case ItemType.Flashlight:
-                        item = new Flashlight(Type);
-                        break;
-                }
-            }
-
-            return item ?? new Item(Type);
+                itemBase = Server.Host.Inventory.CreateItemInstance(Type, false);
+            return Item.Get(itemBase);
         }
 
         private void OnInternalOwnerChangingRole(ChangingRoleEventArgs ev)

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -363,7 +363,67 @@ namespace Exiled.CustomItems.API.Features
         /// <returns>The <see cref="Pickup"/> wrapper of the spawned <see cref="CustomItem"/>.</returns>
         public virtual Pickup Spawn(Vector3 position)
         {
-            var pickup = new Item(Type).Spawn(position);
+            Pickup pickup = null;
+            Item item = null;
+            if (Type.IsMedical())
+            {
+                item = new Usable(Type);
+            }
+            else if (Type.IsAmmo())
+            {
+                item = new Ammo(Type);
+            }
+            else if (Type.IsArmor())
+            {
+                item = new Armor(Type);
+            }
+            else if (Type.IsKeycard())
+            {
+                item = new Keycard(Type);
+            }
+            else if (Type.IsThrowable())
+            {
+                switch (Type)
+                {
+                    case ItemType.GrenadeFlash:
+                        item = new FlashGrenade(Type);
+                        break;
+                    case ItemType.GrenadeHE:
+                    case ItemType.SCP018:
+                        item = new ExplosiveGrenade(Type);
+                        break;
+                }
+            }
+            else if (Type.IsWeapon())
+            {
+                switch (Type)
+                {
+                    case ItemType.MicroHID:
+                        item = new MicroHid(Type);
+                        break;
+                    default:
+                        item = new Firearm(Type);
+                        break;
+                }
+            }
+            else if (Type.IsUtility())
+            {
+                switch (Type)
+                {
+                    case ItemType.Radio:
+                        item = new Radio(Type);
+                        break;
+                    case ItemType.Flashlight:
+                        item = new Flashlight(Type);
+                        break;
+                }
+            }
+            else
+            {
+                item = new Item(Type);
+            }
+
+            pickup = item.Spawn(position);
             pickup.Weight = Weight;
             TrackedSerials.Add(pickup.Serial);
 

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -663,7 +663,7 @@ namespace Exiled.CustomItems.API.Features
         /// <returns>The <see cref="Item"/> created.</returns>
         protected Item CreateCorrectItem(ItemBase itemBase = null)
         {
-            if (itemBase != null)
+            if (itemBase == null)
                 itemBase = Server.Host.Inventory.CreateItemInstance(Type, false);
             return Item.Get(itemBase);
         }


### PR DESCRIPTION
Currently, this results in the custom item being created as a generic API.Features.Items.Item type, always no matter what.
It prevents things like
`if (ev.Item is Firearm firearm)` from working properly in event handlers, and also causes InvalidCastExceptions to occur in events where ev.Item is a specific sub-type, like MicroHid and UsableItem events.

This implementation will ensure that the ItemBase created by the server is properly converted into the correct Features.Items sub-type, to prevent such issues.