### PR TITLE
Add Flags attribute to KeycardPermissions

### DIFF
--- a/Exiled.API/Enums/KeycardPermissions.cs
+++ b/Exiled.API/Enums/KeycardPermissions.cs
@@ -7,9 +7,12 @@
 
 namespace Exiled.API.Enums
 {
+    using System;
+
     /// <summary>
     /// The types of permissions assigned to keycards.
     /// </summary>
+    [Flags]
     public enum KeycardPermissions
     {
         /// <summary>


### PR DESCRIPTION
KeycardPermissions has this attribute in base game. It's needed for bitwise operations (to check if player has permission to open a door)