### PR TITLE
Added option to disable EXILED from loading

### DIFF
--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -149,6 +149,12 @@ namespace Exiled.Loader
             ConfigManager.Reload();
             TranslationManager.Reload();
 
+            if (!Config.IsEnabled)
+            {
+                Log.Warn("Loading EXILED has been disabled in a config. No plugins will be enabled.");
+                return;
+            }
+
             EnablePlugins();
 
             BuildInfoCommand.ModDescription = string.Join(


### PR DESCRIPTION
In `exiled_loader` there is `is_enabled` property that does nothing. I've made so when set to `false` no plugins will be enabled (only loaded without any changes to the server).
This may be useful for testing, when you want to check some behaviour in vanilla without a need to yeet the Assembly-CSharp.