### PR TITLE
Updated damage types to 11.1.1

### DIFF
--- a/Exiled.API/Enums/DamageType.cs
+++ b/Exiled.API/Enums/DamageType.cs
@@ -48,11 +48,6 @@ namespace Exiled.API.Enums
         Bleeding,
 
         /// <summary>
-        /// <see cref="EffectType.Hypothermia"/>
-        /// </summary>
-        Hypothermia,
-
-        /// <summary>
         /// Damage dealt by a <see cref="API.Features.Items.Firearm"/> when the <see cref="ItemType"/> used is not available.
         /// </summary>
         Firearm,
@@ -201,5 +196,10 @@ namespace Exiled.API.Enums
         /// Damage caused by <see cref="ItemType.MolecularDisruptor"/>.
         /// </summary>
         MolecularDisruptor,
+
+        /// <summary>
+        /// <see cref="EffectType.Hypothermia"/>
+        /// </summary>
+        Hypothermia,
     }
 }

--- a/Exiled.API/Enums/DamageType.cs
+++ b/Exiled.API/Enums/DamageType.cs
@@ -48,6 +48,11 @@ namespace Exiled.API.Enums
         Bleeding,
 
         /// <summary>
+        /// <see cref="EffectType.Hypothermia"/>
+        /// </summary>
+        Hypothermia,
+
+        /// <summary>
         /// Damage dealt by a <see cref="API.Features.Items.Firearm"/> when the <see cref="ItemType"/> used is not available.
         /// </summary>
         Firearm,
@@ -191,5 +196,10 @@ namespace Exiled.API.Enums
         /// Damage caused by <see cref="ItemType.GunE11SR"/>.
         /// </summary>
         E11Sr,
+
+        /// <summary>
+        /// Damage caused by <see cref="ItemType.MolecularDisruptor"/>.
+        /// </summary>
+        MolecularDisruptor,
     }
 }

--- a/Exiled.API/Enums/EffectType.cs
+++ b/Exiled.API/Enums/EffectType.cs
@@ -151,5 +151,10 @@ namespace Exiled.API.Enums
         /// Causes the player to slowly regenerate health.
         /// </summary>
         Vitality,
+
+        /// <summary>
+        /// Amougs.
+        /// </summary>
+        Hypothermia,
     }
 }

--- a/Exiled.API/Enums/EffectType.cs
+++ b/Exiled.API/Enums/EffectType.cs
@@ -153,7 +153,7 @@ namespace Exiled.API.Enums
         Vitality,
 
         /// <summary>
-        /// Amougs.
+        /// Causes the player to slowly freeze.
         /// </summary>
         Hypothermia,
     }

--- a/Exiled.API/Features/DamageHandler.cs
+++ b/Exiled.API/Features/DamageHandler.cs
@@ -9,8 +9,6 @@ namespace Exiled.API.Features
 {
     using System.Collections.Generic;
 
-    using Dissonance;
-
     using Exiled.API.Enums;
     using Exiled.API.Features.Items;
 
@@ -22,31 +20,32 @@ namespace Exiled.API.Features
     public class DamageHandler
     {
         private readonly Dictionary<DeathTranslation, DamageType> translationConversion = new Dictionary<DeathTranslation, DamageType>
-            {
-                { DeathTranslations.Asphyxiated, DamageType.Asphyxiation },
-                { DeathTranslations.Bleeding, DamageType.Bleeding },
-                { DeathTranslations.Crushed, DamageType.Crushed },
-                { DeathTranslations.Decontamination, DamageType.Decontamination },
-                { DeathTranslations.Explosion, DamageType.Explosion },
-                { DeathTranslations.Falldown, DamageType.Falldown },
-                { DeathTranslations.Poisoned, DamageType.Poison },
-                { DeathTranslations.Recontained, DamageType.Recontainment },
-                { DeathTranslations.Scp049, DamageType.Scp049 },
-                { DeathTranslations.Scp096, DamageType.Scp096 },
-                { DeathTranslations.Scp173, DamageType.Scp173 },
-                { DeathTranslations.Scp207, DamageType.Scp207 },
-                { DeathTranslations.Scp939, DamageType.Scp939 },
-                { DeathTranslations.Tesla, DamageType.Tesla },
-                { DeathTranslations.Unknown, DamageType.Unknown },
-                { DeathTranslations.Warhead, DamageType.Warhead },
-                { DeathTranslations.Zombie, DamageType.Scp0492 },
-                { DeathTranslations.BulletWounds, DamageType.Firearm },
-                { DeathTranslations.PocketDecay, DamageType.PocketDimension },
-                { DeathTranslations.SeveredHands, DamageType.SeveredHands },
-                { DeathTranslations.FriendlyFireDetector, DamageType.FriendlyFireDetector },
-                { DeathTranslations.UsedAs106Bait, DamageType.FemurBreaker },
-                { DeathTranslations.MicroHID, DamageType.MicroHid },
-            };
+        {
+            { DeathTranslations.Asphyxiated, DamageType.Asphyxiation },
+            { DeathTranslations.Bleeding, DamageType.Bleeding },
+            { DeathTranslations.Crushed, DamageType.Crushed },
+            { DeathTranslations.Decontamination, DamageType.Decontamination },
+            { DeathTranslations.Explosion, DamageType.Explosion },
+            { DeathTranslations.Falldown, DamageType.Falldown },
+            { DeathTranslations.Poisoned, DamageType.Poison },
+            { DeathTranslations.Recontained, DamageType.Recontainment },
+            { DeathTranslations.Hypothermia, DamageType.Hypothermia },
+            { DeathTranslations.Scp049, DamageType.Scp049 },
+            { DeathTranslations.Scp096, DamageType.Scp096 },
+            { DeathTranslations.Scp173, DamageType.Scp173 },
+            { DeathTranslations.Scp207, DamageType.Scp207 },
+            { DeathTranslations.Scp939, DamageType.Scp939 },
+            { DeathTranslations.Tesla, DamageType.Tesla },
+            { DeathTranslations.Unknown, DamageType.Unknown },
+            { DeathTranslations.Warhead, DamageType.Warhead },
+            { DeathTranslations.Zombie, DamageType.Scp0492 },
+            { DeathTranslations.BulletWounds, DamageType.Firearm },
+            { DeathTranslations.PocketDecay, DamageType.PocketDimension },
+            { DeathTranslations.SeveredHands, DamageType.SeveredHands },
+            { DeathTranslations.FriendlyFireDetector, DamageType.FriendlyFireDetector },
+            { DeathTranslations.UsedAs106Bait, DamageType.FemurBreaker },
+            { DeathTranslations.MicroHID, DamageType.MicroHid },
+        };
 
         private readonly Dictionary<ItemType, DamageType> itemConversion = new Dictionary<ItemType, DamageType>
         {
@@ -140,12 +139,12 @@ namespace Exiled.API.Features
                         case Scp096DamageHandler _:
                             return DamageType.Scp096;
                         case ScpDamageHandler scp:
-                        {
-                            DeathTranslation translation = DeathTranslations.TranslationsById[scp._translationId];
-                            if (translation.Id == DeathTranslations.PocketDecay.Id)
-                                return DamageType.Scp106;
-                            return translationConversion.ContainsKey(translation) ? translationConversion[translation] : DamageType.Scp;
-                        }
+                            {
+                                DeathTranslation translation = DeathTranslations.TranslationsById[scp._translationId];
+                                if (translation.Id == DeathTranslations.PocketDecay.Id)
+                                    return DamageType.Scp106;
+                                return translationConversion.ContainsKey(translation) ? translationConversion[translation] : DamageType.Scp;
+                            }
 
                         case ExplosionDamageHandler _:
                             return DamageType.Explosion;
@@ -153,38 +152,18 @@ namespace Exiled.API.Features
                             return DamageType.Scp018;
                         case RecontainmentDamageHandler _:
                             return DamageType.Recontainment;
+                        case DisruptorDamageHandler _:
+                            return DamageType.MolecularDisruptor;
                         case UniversalDamageHandler universal:
-                        {
-                            DeathTranslation translation = DeathTranslations.TranslationsById[universal.TranslationId];
+                            {
+                                DeathTranslation translation = DeathTranslations.TranslationsById[universal.TranslationId];
 
-                            if (translationConversion.ContainsKey(translation))
-                                return translationConversion[translation];
-                            if (translation.Id == DeathTranslations.Asphyxiated.Id)
-                                return DamageType.Asphyxiation;
-                            if (translation.Id == DeathTranslations.Bleeding.Id)
-                                return DamageType.Bleeding;
-                            if (translation.Id == DeathTranslations.Decontamination.Id)
-                                return DamageType.Decontamination;
-                            if (translation.Id == DeathTranslations.Poisoned.Id)
-                                return DamageType.Poison;
-                            if (translation.Id == DeathTranslations.Falldown.Id)
-                                return DamageType.Falldown;
-                            if (translation.Id == DeathTranslations.Tesla.Id)
-                                return DamageType.Tesla;
-                            if (translation.Id == DeathTranslations.Scp207.Id)
-                                return DamageType.Scp207;
-                            if (translation.Id == DeathTranslations.Crushed.Id)
-                                return DamageType.Crushed;
-                            if (translation.Id == DeathTranslations.UsedAs106Bait.Id)
-                                return DamageType.FemurBreaker;
-                            if (translation.Id == DeathTranslations.FriendlyFireDetector.Id)
-                                return DamageType.FriendlyFireDetector;
-                            if (translation.Id == DeathTranslations.SeveredHands.Id)
-                                return DamageType.SeveredHands;
+                                if (translationConversion.ContainsKey(translation))
+                                    return translationConversion[translation];
 
-                            Log.Warn($"{nameof(DamageHandler)}.{nameof(Type)}: No matching {nameof(DamageType)} for {nameof(UniversalDamageHandler)} with ID {translation.Id}, type will be reported as {DamageType.Unknown}. Report this to EXILED Devs.");
-                            break;
-                        }
+                                Log.Warn($"{nameof(DamageHandler)}.{nameof(Type)}: No matching {nameof(DamageType)} for {nameof(UniversalDamageHandler)} with ID {translation.Id}, type will be reported as {DamageType.Unknown}. Report this to EXILED Devs.");
+                                break;
+                            }
                     }
                 }
 


### PR DESCRIPTION
- Added `DamageType.Hypothermia`
- Added `DamageType.MolecularDisruptor`
- Removed giant if-return case which does not serve any purpose (all damage types are already in `translationConversion` dictionary, which means they would never be used)