### PR TITLE
Fixes 096 enrage lasting too long when windup is cancelled due to not…

### DIFF
--- a/Exiled.Events/Patches/Fixes/Scp096FailEnrageFix.cs
+++ b/Exiled.Events/Patches/Fixes/Scp096FailEnrageFix.cs
@@ -88,7 +88,11 @@ namespace Exiled.Events.Patches.Fixes
                 new CodeInstruction(OpCodes.Ldarg_0),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(Scp096), nameof(Scp096._targets))),
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(HashSet<ReferenceHub>), nameof(HashSet<ReferenceHub>.Count))),
-                new CodeInstruction(OpCodes.Brfalse_S, returnLabel),
+                new CodeInstruction(OpCodes.Brtrue, continueLabel),
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldc_R4, 0.0f),
+                new CodeInstruction(OpCodes.Call, PropertySetter(typeof(Scp096), nameof(Scp096.AddedTimeThisRage))),
+                new CodeInstruction(OpCodes.Ret),
             });
 
             newInstructions[newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Ldsfld)].WithLabels(continueLabel);


### PR DESCRIPTION
… having targets.

This causes the Scp096.AddedTimeThisEnrage to reset back to 0 when there was no enrage.