### PR TITLE
Delay API

### DIFF
--- a/Exiled.API/Features/Door.cs
+++ b/Exiled.API/Features/Door.cs
@@ -277,9 +277,22 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Locks the door with the given lock type, after a given delay has passed.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        /// <param name="lockType"><inheritdoc cref="DoorLockType"/></param>
+        public void ChangeLock(float delay, DoorLockType lockType) => MEC.Timing.CallDelayed(delay, () => ChangeLock(lockType));
+
+        /// <summary>
         /// Unlocks and clears all active locks on the door.
         /// </summary>
         public void Unlock() => ChangeLock(DoorLockType.None);
+
+        /// <summary>
+        /// Unlocks and clears all active locks on the door after a given delay has passed.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        public void Unlock(float delay) => MEC.Timing.CallDelayed(delay, () => Unlock());
 
         /// <summary>
         /// Gets all the <see cref="DoorType"/> values for the <see cref="Door"/> instances using <see cref="Door"/> and <see cref="UnityEngine.GameObject"/> name.

--- a/Exiled.API/Features/Door.cs
+++ b/Exiled.API/Features/Door.cs
@@ -292,7 +292,7 @@ namespace Exiled.API.Features
         /// Unlocks and clears all active locks on the door after a given delay has passed.
         /// </summary>
         /// <param name="delay">Delay in seconds.</param>
-        public void Unlock(float delay) => MEC.Timing.CallDelayed(delay, () => Unlock());
+        public void Unlock(float delay) => MEC.Timing.CallDelayed(delay, Unlock);
 
         /// <summary>
         /// Gets all the <see cref="DoorType"/> values for the <see cref="Door"/> instances using <see cref="Door"/> and <see cref="UnityEngine.GameObject"/> name.

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1427,7 +1427,7 @@ namespace Exiled.API.Features
         /// <param name="damageReason"> The reason for the damage being dealt.</param>
         /// <param name="damage">The amount of damage to deal.</param>
         /// <param name="cassieAnnouncement">The cassie announcement to make.</param>
-        public void Hurt(string damageReason, float damage, string cassieAnnouncement = "") => ReferenceHub.playerStats.DealDamage(new CustomReasonDamageHandler(damageReason, damage, cassieAnnouncement));
+        public void Hurt(string damageReason, float damage, string cassieAnnouncement = "") => Hurt(new CustomReasonDamageHandler(damageReason, damage, cassieAnnouncement));
 
         /// <summary>
         /// Heals the player.

--- a/Exiled.API/Features/Ragdoll.cs
+++ b/Exiled.API/Features/Ragdoll.cs
@@ -13,6 +13,8 @@ namespace Exiled.API.Features
 
     using DeathAnimations;
 
+    using MEC;
+
     using Mirror;
 
     using PlayableScps;
@@ -286,13 +288,31 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Deletes the ragdoll after a given delay has passed.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        public void Delete(float delay) => Timing.CallDelayed(delay, Delete);
+
+        /// <summary>
         /// Spawns the ragdoll.
         /// </summary>
         public void Spawn() => NetworkServer.Spawn(GameObject);
 
         /// <summary>
+        /// Spawns the ragdoll after a given delay has passed.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        public void Spawn(float delay) => Timing.CallDelayed(delay, Spawn);
+
+        /// <summary>
         /// Un-spawns the ragdoll.
         /// </summary>
         public void UnSpawn() => NetworkServer.UnSpawn(GameObject);
+
+        /// <summary>
+        /// Un-spawns the ragdoll after a given delay has passed.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        public void UnSpawn(float delay) => Timing.CallDelayed(delay, UnSpawn);
     }
 }

--- a/Exiled.API/Features/Respawn.cs
+++ b/Exiled.API/Features/Respawn.cs
@@ -11,6 +11,8 @@ namespace Exiled.API.Features
 
     using Exiled.API.Enums;
 
+    using MEC;
+
     using Respawning;
 
     using UnityEngine;
@@ -80,6 +82,12 @@ namespace Exiled.API.Features
         public static void SummonNtfChopper() => PlayEffects(new RespawnEffectType[] { RespawnEffectType.SummonNtfChopper });
 
         /// <summary>
+        /// Summons the NTF chopper after a given delay has passed.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        public static void SummonNtfChopper(float delay) => Timing.CallDelayed(delay, SummonNtfChopper);
+
+        /// <summary>
         /// Summons the <see cref="Side.ChaosInsurgency"/> van.
         /// </summary>
         /// <param name="playMusic">Whether or not to play the Chaos Insurgency spawn music.</param>
@@ -96,6 +104,14 @@ namespace Exiled.API.Features
                 RespawnEffectType.SummonChaosInsurgencyVan,
             });
         }
+
+        /// <summary>
+        /// Summons the <see cref="Side.ChaosInsurgency"/> van after a given delay has passed.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        /// <param name="playMusic">Whether or not to play the Chaos Insurgency spawn music.</param>
+        public static void SummonChaosInsurgencyVan(float delay, bool playMusic = true) =>
+            Timing.CallDelayed(delay, () => SummonChaosInsurgencyVan(playMusic));
 
         /// <summary>
         /// Grants tickets to a <see cref="SpawnableTeamType"/>.
@@ -119,5 +135,14 @@ namespace Exiled.API.Features
                 RespawnEffectsController.ExecuteAllEffects(RespawnEffectsController.EffectType.Selection, team);
             }
         }
+
+        /// <summary>
+        /// Forces a spawn wave of the given <see cref="SpawnableTeamType"/> after a given delay has passed.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        /// <param name="team">The <see cref="SpawnableTeamType"/> to spawn.</param>
+        /// <param name="playEffects">Whether or not effects will be played with the spawn.</param>
+        public static void ForceWave(float delay, SpawnableTeamType team, bool playEffects = false) =>
+            Timing.CallDelayed(delay, () => ForceWave(team, playEffects));
     }
 }

--- a/Exiled.API/Features/Room.cs
+++ b/Exiled.API/Features/Room.cs
@@ -126,6 +126,15 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Locks all the doors in the room after a given delay has passed.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        /// <param name="duration">Duration in seconds.</param>
+        /// <param name="lockType">DoorLockType of the lockdown.</param>
+        public void LockDown(float delay, float duration, DoorLockType lockType = DoorLockType.Regular079) =>
+            MEC.Timing.CallDelayed(delay, () => LockDown(duration, lockType));
+
+        /// <summary>
         /// Locks all the doors and turns off all lights in the room.
         /// </summary>
         /// <param name="duration">Duration in seconds.</param>
@@ -137,6 +146,15 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Locks all the doors and turns off all lights in the room after a given delay has passed.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        /// <param name="duration">Duration in seconds.</param>
+        /// <param name="lockType">DoorLockType of the blackout.</param>
+        public void Blackout(float delay, float duration, DoorLockType lockType = DoorLockType.Regular079) =>
+            MEC.Timing.CallDelayed(delay, () => Blackout(duration, lockType));
+
+        /// <summary>
         /// Unlocks all the doors in the room.
         /// </summary>
         public void UnlockAll()
@@ -144,6 +162,12 @@ namespace Exiled.API.Features
             foreach (Door door in Doors)
                 door.Unlock();
         }
+
+        /// <summary>
+        /// Unlocks all the doors in the room after a given delay has passed.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        public void UnlockAll(float delay) => MEC.Timing.CallDelayed(delay, () => UnlockAll());
 
         /// <summary>
         /// Resets the room color to default.

--- a/Exiled.API/Features/Room.cs
+++ b/Exiled.API/Features/Room.cs
@@ -167,7 +167,7 @@ namespace Exiled.API.Features
         /// Unlocks all the doors in the room after a given delay has passed.
         /// </summary>
         /// <param name="delay">Delay in seconds.</param>
-        public void UnlockAll(float delay) => MEC.Timing.CallDelayed(delay, () => UnlockAll());
+        public void UnlockAll(float delay) => MEC.Timing.CallDelayed(delay, UnlockAll);
 
         /// <summary>
         /// Resets the room color to default.

--- a/Exiled.API/Features/Round.cs
+++ b/Exiled.API/Features/Round.cs
@@ -11,6 +11,8 @@ namespace Exiled.API.Features
 
     using GameCore;
 
+    using MEC;
+
     using PlayerStatsSystem;
 
     using RoundRestarting;
@@ -124,6 +126,12 @@ namespace Exiled.API.Features
         public static void RestartSilently() => Restart(true, true, ServerStatic.NextRoundAction.DoNothing);
 
         /// <summary>
+        /// Restarts the round silently after a given delay has passed.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        public static void RestartSilenty(float delay) => Timing.CallDelayed(delay, RestartSilently);
+
+        /// <summary>
         /// Forces the round to end, regardless of which factions are alive.
         /// </summary>
         /// <returns>A <see cref="bool"/> describing whether or not the round was successfully ended.</returns>
@@ -144,8 +152,21 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Forces the round to end after a given delay has passed, regardless of which factions are alive.
+        /// </summary>
+        /// <remarks>This method does not return any value regarding whether or not the request to end the round was successful. If this value is required, please use ForceEnd() with a coroutine instead of this method.</remarks>
+        /// <param name="delay">Delay in seconds.</param>
+        public static void ForceEnd(float delay) => Timing.CallDelayed(delay, () => ForceEnd());
+
+        /// <summary>
         /// Start the round.
         /// </summary>
         public static void Start() => CharacterClassManager.ForceRoundStart();
+
+        /// <summary>
+        /// Start the round after a given delay has passed.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        public static void Start(float delay) => Timing.CallDelayed(delay, Start);
     }
 }

--- a/Exiled.API/Features/Server.cs
+++ b/Exiled.API/Features/Server.cs
@@ -148,12 +148,24 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Restarts the server after a given delay has passed. Reconnects all players.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        public static void Restart(float delay) => Timing.CallDelayed(delay, Restart);
+
+        /// <summary>
         /// Shutdowns the server, disconnects all players.
         /// </summary>
         public static void Shutdown()
         {
             global::Shutdown.Quit();
         }
+
+        /// <summary>
+        /// Shutdowns the server after a given delay has passed. Disconnects all players.
+        /// </summary>
+        /// <param name="delay">Delay in seconds.</param>
+        public static void Shutdown(float delay) => Timing.CallDelayed(delay, Shutdown);
 
         /// <summary>
         /// Redirects players to a server on another port, restarts the current server.


### PR DESCRIPTION
Minor delay methods - methods that already exist, but feature an overload which includes a delay before calling the method. Thoughts on adding methods like this? It's a slight bit redundant, but it may help with new plugin devs, plus it would be more convenient for plugin devs to simply have the method to call, rather than adding MEC and all. The delay methods are overloads, so it won't clutter the list of methods for plugin devs either
I noticed that the Cassie class already has a delay method (which I've used before for my own plugins), so this may be a helpful addition to the rest of the framework
If you all like, I'll add more methods before requesting to merge pr