### PR TITLE
Better item constructors

### DIFF
--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -46,8 +46,20 @@ namespace Exiled.API.Features.Items
         /// <param name="type"><inheritdoc cref="Throwable.Base"/></param>
         /// <param name="player"><inheritdoc cref="Item.Owner"/></param>
         /// <remarks>The player parameter will always need to be defined if this grenade is custom using Exiled.CustomItems.</remarks>
+        [System.Obsolete("Please use new ExplosiveGrenade(GrenadeType, Player) instead. This constructor will be removed soon.")]
         public ExplosiveGrenade(ItemType type, Player player = null)
             : this(player == null ? (ThrowableItem)Server.Host.Inventory.CreateItemInstance(type, false) : (ThrowableItem)player.Inventory.CreateItemInstance(type, true))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExplosiveGrenade"/> class, as well as an explosive grenade item. This class should only be used for explosive grenades (Frag grenade and SCP-018). For the flash grenade, see the <see cref="FlashGrenade"/> class.
+        /// </summary>
+        /// <param name="type"><inheritdoc cref="Throwable.Base"/></param>
+        /// <param name="player"><inheritdoc cref="Item.Owner"/></param>
+        /// <remarks>The player parameter will always need to be defined if this grenade is custom using Exiled.CustomItems.</remarks>
+        public ExplosiveGrenade(GrenadeType type, Player player = null)
+            : this(player == null ? (ThrowableItem)Server.Host.Inventory.CreateItemInstance(type == GrenadeType.Scp018 ? ItemType.SCP018 : ItemType.GrenadeHE, false) : (ThrowableItem)player.Inventory.CreateItemInstance(type == GrenadeType.Scp018 ? ItemType.SCP018 : ItemType.GrenadeHE, true))
         {
         }
 

--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -55,8 +55,8 @@ namespace Exiled.API.Features.Items
         /// <summary>
         /// Initializes a new instance of the <see cref="ExplosiveGrenade"/> class, as well as an explosive grenade item. This class should only be used for explosive grenades (Frag grenade and SCP-018). For the flash grenade, see the <see cref="FlashGrenade"/> class.
         /// </summary>
-        /// <param name="type"><inheritdoc cref="Throwable.Base"/></param>
-        /// <param name="player"><inheritdoc cref="Item.Owner"/></param>
+        /// <param name="type">The type of grenade. Should be either <see cref="GrenadeType.FragGrenade"/> or <see cref="GrenadeType.Scp018"/>; for flash grenades, see the <see cref="FlashGrenade"/> class.</param>
+        /// <param name="player">The owner of the grenade. Leave <see langword="null"/> for no owner.</param>
         /// <remarks>The player parameter will always need to be defined if this grenade is custom using Exiled.CustomItems.</remarks>
         public ExplosiveGrenade(GrenadeType type, Player player = null)
             : this(player == null ? (ThrowableItem)Server.Host.Inventory.CreateItemInstance(type == GrenadeType.Scp018 ? ItemType.SCP018 : ItemType.GrenadeHE, false) : (ThrowableItem)player.Inventory.CreateItemInstance(type == GrenadeType.Scp018 ? ItemType.SCP018 : ItemType.GrenadeHE, true))

--- a/Exiled.API/Features/Items/FlashGrenade.cs
+++ b/Exiled.API/Features/Items/FlashGrenade.cs
@@ -44,8 +44,19 @@ namespace Exiled.API.Features.Items
         /// <param name="type"><inheritdoc cref="Throwable.Base"/></param>
         /// <param name="player"><inheritdoc cref="Item.Owner"/></param>
         /// <remarks>The player parameter will always need to be defined if this grenade is custom using Exiled.CustomItems.</remarks>
+        [System.Obsolete("Please use new FlashGrenade(Player) instead. This constructor will be removed in the future.", true)]
         public FlashGrenade(ItemType type, Player player = null)
             : this(player == null ? (ThrowableItem)Server.Host.Inventory.CreateItemInstance(type, false) : (ThrowableItem)player.Inventory.CreateItemInstance(type, true))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FlashGrenade"/> class, as well as a new flash grenade item.
+        /// </summary>
+        /// <param name="player"><inheritdoc cref="Item.Owner"/></param>
+        /// <remarks>The player parameter will always need to be defined if this grenade is custom using Exiled.CustomItems.</remarks>
+        public FlashGrenade(Player player = null)
+            : this(player == null ? (ThrowableItem)Server.Host.Inventory.CreateItemInstance(ItemType.GrenadeFlash, false) : (ThrowableItem)player.Inventory.CreateItemInstance(ItemType.GrenadeFlash, true))
         {
         }
 

--- a/Exiled.API/Features/Items/FlashGrenade.cs
+++ b/Exiled.API/Features/Items/FlashGrenade.cs
@@ -53,7 +53,7 @@ namespace Exiled.API.Features.Items
         /// <summary>
         /// Initializes a new instance of the <see cref="FlashGrenade"/> class, as well as a new flash grenade item.
         /// </summary>
-        /// <param name="player"><inheritdoc cref="Item.Owner"/></param>
+        /// <param name="player">The owner of the grenade. Leave <see langword="null"/> for no owner.</param>
         /// <remarks>The player parameter will always need to be defined if this grenade is custom using Exiled.CustomItems.</remarks>
         public FlashGrenade(Player player = null)
             : this(player == null ? (ThrowableItem)Server.Host.Inventory.CreateItemInstance(ItemType.GrenadeFlash, false) : (ThrowableItem)player.Inventory.CreateItemInstance(ItemType.GrenadeFlash, true))

--- a/Exiled.API/Features/Items/Flashlight.cs
+++ b/Exiled.API/Features/Items/Flashlight.cs
@@ -32,8 +32,17 @@ namespace Exiled.API.Features.Items
         /// Initializes a new instance of the <see cref="Flashlight"/> class.
         /// </summary>
         /// <param name="type"><inheritdoc cref="Type"/></param>
+        [Obsolete("Please use new Flashlight() instead. This constructor will be removed in the future.", true)]
         public Flashlight(ItemType type)
             : this((FlashlightItem)Server.Host.Inventory.CreateItemInstance(type, false))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Flashlight"/> class, as well as a new Flashlight item.
+        /// </summary>
+        public Flashlight()
+            : this((FlashlightItem)Server.Host.Inventory.CreateItemInstance(ItemType.Flashlight, false))
         {
         }
 

--- a/Exiled.API/Features/Items/MicroHid.cs
+++ b/Exiled.API/Features/Items/MicroHid.cs
@@ -30,8 +30,17 @@ namespace Exiled.API.Features.Items
         /// Initializes a new instance of the <see cref="MicroHid"/> class.
         /// </summary>
         /// <param name="type"><inheritdoc cref="Base"/></param>
+        [System.Obsolete("Please use new MicroHid() instead. This constructor will be removed in the future.", true)]
         public MicroHid(ItemType type)
             : this((MicroHIDItem)Server.Host.Inventory.CreateItemInstance(type, false))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MicroHid"/> class, as well as a new Micro HID item.
+        /// </summary>
+        public MicroHid()
+            : this((MicroHIDItem)Server.Host.Inventory.CreateItemInstance(ItemType.MicroHID, false))
         {
         }
 

--- a/Exiled.API/Features/Items/Radio.cs
+++ b/Exiled.API/Features/Items/Radio.cs
@@ -33,8 +33,17 @@ namespace Exiled.API.Features.Items
         /// Initializes a new instance of the <see cref="Radio"/> class.
         /// </summary>
         /// <param name="type"><inheritdoc cref="Base"/></param>
+        [System.Obsolete("Please use new Radio() instead. This constructor will be removed in the future.", true)]
         public Radio(ItemType type)
             : this((RadioItem)Server.Host.Inventory.CreateItemInstance(type, false))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Radio"/> class, as well as a new Radio item.
+        /// </summary>
+        public Radio()
+            : this((RadioItem)Server.Host.Inventory.CreateItemInstance(ItemType.Radio, false))
         {
         }
 

--- a/Exiled.API/Features/Items/Scp330.cs
+++ b/Exiled.API/Features/Items/Scp330.cs
@@ -34,8 +34,17 @@ namespace Exiled.API.Features.Items
         /// Initializes a new instance of the <see cref="Scp330"/> class.
         /// </summary>
         /// <param name="type"><inheritdoc cref="Base"/></param>
+        [System.Obsolete("Please use new Scp330() instead. This constructor will be removed in the future.", true)]
         public Scp330(ItemType type)
             : this((Scp330Bag)Server.Host.Inventory.CreateItemInstance(type, false))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Scp330"/> class, as well as a new SCP-330 bag item.
+        /// </summary>
+        public Scp330()
+            : this((Scp330Bag)Server.Host.Inventory.CreateItemInstance(ItemType.SCP330, false))
         {
         }
 

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1798,10 +1798,10 @@ namespace Exiled.API.Features
             switch (type)
             {
                 case GrenadeType.Flashbang:
-                    throwable = new FlashGrenade(ItemType.GrenadeFlash);
+                    throwable = new FlashGrenade();
                     break;
                 default:
-                    throwable = new ExplosiveGrenade(type == GrenadeType.Scp018 ? ItemType.SCP018 : ItemType.GrenadeHE);
+                    throwable = new ExplosiveGrenade(type);
                     break;
             }
 


### PR DESCRIPTION
* Remove unnecessary item types in item constructors (eg. `new MicroHid(ItemType.MicroHID)` -> `new MicroHid()`)
  * MicroHID
  * Radio
  * Flashlight
  * Scp330
  * FlashGrenade
* Added new ExplosiveGrenade constructor to take a GrenadeType rather than an ItemType (makes more sense than ItemType logically, the documentation specifies that FlashGrenade class should be used for flash grenades)
* Reworded documentation slightly for all the new methods