### PR TITLE
Added ExiledSerializable attribute for Exiled features

### DIFF
--- a/Exiled.API/Features/ExiledSerializable.cs
+++ b/Exiled.API/Features/ExiledSerializable.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+// <copyright file="ExiledSerializable.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Features
+{
+    using System;
+
+    /// <summary>
+    /// An attribute to easily manage Exiled features' behavior.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public sealed class ExiledSerializable : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExiledSerializable"/> class.
+        /// </summary>
+        public ExiledSerializable()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExiledSerializable"/> class.
+        /// </summary>
+        /// <param name="type"><inheritdoc cref="ItemType"/></param>
+        public ExiledSerializable(ItemType type) => ItemType = type;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExiledSerializable"/> class.
+        /// </summary>
+        /// <param name="role"><inheritdoc cref="RoleType"/></param>
+        public ExiledSerializable(RoleType role) => RoleType = role;
+
+        /// <summary>
+        /// Gets the attribute's <see cref="ItemType"/>.
+        /// </summary>
+        public ItemType ItemType { get; }
+
+        /// <summary>
+        /// Gets the attribute's <see cref="RoleType"/>.
+        /// </summary>
+        public RoleType RoleType { get; }
+    }
+}

--- a/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -10,6 +10,7 @@ namespace Exiled.CustomRoles.API.Features
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
 
     using Dissonance.Integrations.MirrorIgnorance;
 
@@ -139,6 +140,48 @@ namespace Exiled.CustomRoles.API.Features
         }
 
         /// <summary>
+        /// Registers all the <see cref="CustomRole"/>'s present in the current assembly.
+        /// </summary>
+        /// <returns>A <see cref="IEnumerable{T}"/> of <see cref="CustomRole"/> which contains all registered <see cref="CustomRole"/>'s.</returns>
+        public static IEnumerable<CustomRole> RegisterRoles()
+        {
+            List<CustomRole> registeredRoles = new List<CustomRole>();
+
+            foreach (Type type in Assembly.GetExecutingAssembly().GetTypes())
+            {
+                if (type.BaseType != typeof(CustomRole) || type.GetCustomAttribute(typeof(ExiledSerializable)) is null)
+                    continue;
+
+                foreach (Attribute attribute in type.GetCustomAttributes(typeof(ExiledSerializable), true))
+                {
+                    CustomRole customRole = (CustomRole)Activator.CreateInstance(type);
+                    customRole.Role = (attribute as ExiledSerializable).RoleType;
+                    customRole.TryRegister();
+                    registeredRoles.Add(customRole);
+                }
+            }
+
+            return registeredRoles;
+        }
+
+        /// <summary>
+        /// Unregisters all the <see cref="CustomRole"/>'s present in the current assembly.
+        /// </summary>
+        /// <returns>A <see cref="IEnumerable{T}"/> of <see cref="CustomRole"/> which contains all unregistered <see cref="CustomRole"/>'s.</returns>
+        public static IEnumerable<CustomRole> UnregisterRoles()
+        {
+            List<CustomRole> unregisteredRoles = new List<CustomRole>();
+
+            foreach (CustomRole customRole in Registered)
+            {
+                customRole.TryUnregister();
+                unregisteredRoles.Add(customRole);
+            }
+
+            return unregisteredRoles;
+        }
+
+        /// <summary>
         /// Tries to get a <see cref="CustomRole"/> by name.
         /// </summary>
         /// <param name="name">The name of the role to get.</param>
@@ -184,52 +227,6 @@ namespace Exiled.CustomRoles.API.Features
         public virtual bool Check(Player player) => TrackedPlayers.Contains(player);
 
         /// <summary>
-        /// Tries to register this role.
-        /// </summary>
-        /// <returns>True if the role registered properly.</returns>
-        public bool TryRegister()
-        {
-            if (!Registered.Contains(this))
-            {
-                if (Registered.Any(r => r.Id == Id))
-                {
-                    Log.Warn($"{Name} has tried to register with the same Role ID as another role: {Id}. It will not be registered!");
-
-                    return false;
-                }
-
-                Registered.Add(this);
-                Init();
-
-                Log.Debug($"{Name} ({Id}) has been successfully registered.", CustomRoles.Instance.Config.Debug);
-
-                return true;
-            }
-
-            Log.Warn($"Couldn't register {Name} ({Id}) [{Role}] as it already exists.");
-
-            return false;
-        }
-
-        /// <summary>
-        /// Tries to unregister this role.
-        /// </summary>
-        /// <returns>True if the role is unregistered properly.</returns>
-        public bool TryUnregister()
-        {
-            Destroy();
-
-            if (!Registered.Remove(this))
-            {
-                Log.Warn($"Cannot unregister {Name} ({Id}) [{Role}], it hasn't been registered yet.");
-
-                return false;
-            }
-
-            return true;
-        }
-
-        /// <summary>
         /// Initializes this role manager.
         /// </summary>
         public virtual void Init() => SubscribeEvents();
@@ -237,7 +234,7 @@ namespace Exiled.CustomRoles.API.Features
         /// <summary>
         /// Destroys this role manager.
         /// </summary>
-        public virtual void Destroy() => UnSubscribeEvents();
+        public virtual void Destroy() => UnsubscribeEvents();
 
         /// <summary>
         /// Handles setup of the role, including spawn location, inventory and registering event handlers.
@@ -306,6 +303,52 @@ namespace Exiled.CustomRoles.API.Features
             }
 
             RoleRemoved(player);
+        }
+
+        /// <summary>
+        /// Tries to register this role.
+        /// </summary>
+        /// <returns>True if the role registered properly.</returns>
+        internal bool TryRegister()
+        {
+            if (!Registered.Contains(this))
+            {
+                if (Registered.Any(r => r.Id == Id))
+                {
+                    Log.Warn($"{Name} has tried to register with the same Role ID as another role: {Id}. It will not be registered!");
+
+                    return false;
+                }
+
+                Registered.Add(this);
+                Init();
+
+                Log.Debug($"{Name} ({Id}) has been successfully registered.", CustomRoles.Instance.Config.Debug);
+
+                return true;
+            }
+
+            Log.Warn($"Couldn't register {Name} ({Id}) [{Role}] as it already exists.");
+
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to unregister this role.
+        /// </summary>
+        /// <returns>True if the role is unregistered properly.</returns>
+        internal bool TryUnregister()
+        {
+            Destroy();
+
+            if (!Registered.Remove(this))
+            {
+                Log.Warn($"Cannot unregister {Name} ({Id}) [{Role}], it hasn't been registered yet.");
+
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -393,7 +436,7 @@ namespace Exiled.CustomRoles.API.Features
         /// <summary>
         /// Called when the role is destroyed to unsubscribe internal event handlers.
         /// </summary>
-        protected virtual void UnSubscribeEvents()
+        protected virtual void UnsubscribeEvents()
         {
             foreach (Player player in TrackedPlayers)
                 RemoveRole(player);


### PR DESCRIPTION
Basically, this attribute can be used to register CustomItem's, CustomRole's and CustomAbility's without having to make two methods to register/unregister them, and then call them OnEnabled on whatever is it.

The attribute can be used more than once, so that you can define more "types" of CustomItem/CustomRole.
Quick example:

```
[ExiledSerializable(ItemType.GunRevolver)]
[ExiledSerializable(ItemType.GunCrossvec)]
public class MyCustomWeapon : CustomWeapon
{
}
```

This gets translated to:
```
new MyCustomWeapon() { Type = ItemType.GunRevolver }.TryRegister();
new MyCustomWeapon() { Type = ItemType.GunCrossvec }.TryRegister();
```

But it's fully handled by EXILED.

All the `TryRegister` and `TryUnregister` methods are now internal, this prevents people from using them so that they use the **ExiledSerializable** attribute.
It can be applied to classes only as you can see, so something like this:

```
[ExiledSerializable]
public struct MyAwesomeStruct
{
}
```

could not ever happen.

Also, if the attribute is used in a bad way, EXILED will consider its default values without using the defined ones:
```
[ExiledSerializable(ItemType.GunCrossvec)]
public class MyCustomRole: CustomRole
{
}
```
Therefore, EXILED will register the CustomRole as `RoleType::Scp173` because no data valuable as `RoleType` has been provided.

**UnSubscribeEvents** virtual method for CustomRole and CustomAbility has been renamed to **UnsubscribeEvents** 