### PR TITLE
Re-work item API.

### DIFF
--- a/Exiled.API/Features/Items/Ammo.cs
+++ b/Exiled.API/Features/Items/Ammo.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Items
 {
+    using System;
+
     using Exiled.API.Enums;
 
     using InventorySystem.Items.Firearms.Ammo;
@@ -30,6 +32,7 @@ namespace Exiled.API.Features.Items
         /// Initializes a new instance of the <see cref="Ammo"/> class.
         /// </summary>
         /// <param name="type"><inheritdoc cref="Item.Type"/></param>
+        [Obsolete("Use Exiled.API.Features.Item.Create(ItemType) instead.")]
         public Ammo(ItemType type)
             : this((AmmoItem)Server.Host.Inventory.CreateItemInstance(type, false))
         {

--- a/Exiled.API/Features/Items/Armor.cs
+++ b/Exiled.API/Features/Items/Armor.cs
@@ -43,6 +43,7 @@ namespace Exiled.API.Features.Items
         /// Initializes a new instance of the <see cref="Armor"/> class.
         /// </summary>
         /// <param name="type"><inheritdoc cref="Item.Type"/></param>
+        [Obsolete("Use Exiled.API.Features.Item.Create(ItemType) instead.")]
         public Armor(ItemType type)
             : this((BodyArmor)Server.Host.Inventory.CreateItemInstance(type, false))
         {

--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -7,6 +7,7 @@
 
 namespace Exiled.API.Features.Items
 {
+    using System;
     using System.Collections.Generic;
 
     using Exiled.API.Enums;
@@ -18,6 +19,8 @@ namespace Exiled.API.Features.Items
     using Mirror;
 
     using UnityEngine;
+
+    using Object = UnityEngine.Object;
 
     /// <summary>
     /// A wrapper class for <see cref="ExplosionGrenade"/>.
@@ -46,20 +49,9 @@ namespace Exiled.API.Features.Items
         /// <param name="type"><inheritdoc cref="Throwable.Base"/></param>
         /// <param name="player"><inheritdoc cref="Item.Owner"/></param>
         /// <remarks>The player parameter will always need to be defined if this grenade is custom using Exiled.CustomItems.</remarks>
-        [System.Obsolete("Please use new ExplosiveGrenade(GrenadeType, Player) instead. This constructor will be removed soon.")]
+        [Obsolete("Use Exiled.API.Features.Item.Create(ItemType) instead.")]
         public ExplosiveGrenade(ItemType type, Player player = null)
             : this(player == null ? (ThrowableItem)Server.Host.Inventory.CreateItemInstance(type, false) : (ThrowableItem)player.Inventory.CreateItemInstance(type, true))
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ExplosiveGrenade"/> class, as well as an explosive grenade item. This class should only be used for explosive grenades (Frag grenade and SCP-018). For the flash grenade, see the <see cref="FlashGrenade"/> class.
-        /// </summary>
-        /// <param name="type">The type of grenade. Should be either <see cref="GrenadeType.FragGrenade"/> or <see cref="GrenadeType.Scp018"/>; for flash grenades, see the <see cref="FlashGrenade"/> class.</param>
-        /// <param name="player">The owner of the grenade. Leave <see langword="null"/> for no owner.</param>
-        /// <remarks>The player parameter will always need to be defined if this grenade is custom using Exiled.CustomItems.</remarks>
-        public ExplosiveGrenade(GrenadeType type, Player player = null)
-            : this(player == null ? (ThrowableItem)Server.Host.Inventory.CreateItemInstance(type == GrenadeType.Scp018 ? ItemType.SCP018 : ItemType.GrenadeHE, false) : (ThrowableItem)player.Inventory.CreateItemInstance(type == GrenadeType.Scp018 ? ItemType.SCP018 : ItemType.GrenadeHE, true))
         {
         }
 

--- a/Exiled.API/Features/Items/Firearm.cs
+++ b/Exiled.API/Features/Items/Firearm.cs
@@ -73,6 +73,7 @@ namespace Exiled.API.Features.Items
         /// Initializes a new instance of the <see cref="Firearm"/> class.
         /// </summary>
         /// <param name="type"><inheritdoc cref="Item.Type"/></param>
+        [Obsolete("Use Exiled.API.Features.Item.Create(ItemType) instead.")]
         public Firearm(ItemType type)
             : this((InventorySystem.Items.Firearms.Firearm)Server.Host.Inventory.CreateItemInstance(type, false))
         {

--- a/Exiled.API/Features/Items/FlashGrenade.cs
+++ b/Exiled.API/Features/Items/FlashGrenade.cs
@@ -7,6 +7,7 @@
 
 namespace Exiled.API.Features.Items
 {
+    using System;
     using System.Collections.Generic;
 
     using Exiled.API.Enums;
@@ -18,6 +19,8 @@ namespace Exiled.API.Features.Items
     using Mirror;
 
     using UnityEngine;
+
+    using Object = UnityEngine.Object;
 
     /// <summary>
     /// A wrapper class for <see cref="FlashbangGrenade"/>.
@@ -44,7 +47,7 @@ namespace Exiled.API.Features.Items
         /// <param name="type"><inheritdoc cref="Throwable.Base"/></param>
         /// <param name="player"><inheritdoc cref="Item.Owner"/></param>
         /// <remarks>The player parameter will always need to be defined if this grenade is custom using Exiled.CustomItems.</remarks>
-        [System.Obsolete("Please use new FlashGrenade(Player) instead. This constructor will be removed in the future.", true)]
+        [Obsolete("Use Exiled.API.Features.Item.Create(ItemType) instead.", true)]
         public FlashGrenade(ItemType type, Player player = null)
             : this(player == null ? (ThrowableItem)Server.Host.Inventory.CreateItemInstance(type, false) : (ThrowableItem)player.Inventory.CreateItemInstance(type, true))
         {
@@ -55,7 +58,7 @@ namespace Exiled.API.Features.Items
         /// </summary>
         /// <param name="player">The owner of the grenade. Leave <see langword="null"/> for no owner.</param>
         /// <remarks>The player parameter will always need to be defined if this grenade is custom using Exiled.CustomItems.</remarks>
-        public FlashGrenade(Player player = null)
+        internal FlashGrenade(Player player = null)
             : this(player == null ? (ThrowableItem)Server.Host.Inventory.CreateItemInstance(ItemType.GrenadeFlash, false) : (ThrowableItem)player.Inventory.CreateItemInstance(ItemType.GrenadeFlash, true))
         {
         }

--- a/Exiled.API/Features/Items/Flashlight.cs
+++ b/Exiled.API/Features/Items/Flashlight.cs
@@ -32,7 +32,7 @@ namespace Exiled.API.Features.Items
         /// Initializes a new instance of the <see cref="Flashlight"/> class.
         /// </summary>
         /// <param name="type"><inheritdoc cref="Type"/></param>
-        [Obsolete("Please use new Flashlight() instead. This constructor will be removed in the future.", true)]
+        [Obsolete("Use Exiled.API.Features.Item.Create(ItemType) instead.", true)]
         public Flashlight(ItemType type)
             : this((FlashlightItem)Server.Host.Inventory.CreateItemInstance(type, false))
         {
@@ -41,7 +41,7 @@ namespace Exiled.API.Features.Items
         /// <summary>
         /// Initializes a new instance of the <see cref="Flashlight"/> class, as well as a new Flashlight item.
         /// </summary>
-        public Flashlight()
+        internal Flashlight()
             : this((FlashlightItem)Server.Host.Inventory.CreateItemInstance(ItemType.Flashlight, false))
         {
         }

--- a/Exiled.API/Features/Items/Item.cs
+++ b/Exiled.API/Features/Items/Item.cs
@@ -7,10 +7,12 @@
 
 namespace Exiled.API.Features.Items
 {
+#pragma warning disable CS0618
     using System;
     using System.Collections.Generic;
     using System.Linq;
 
+    using Exiled.API.Enums;
     using Exiled.API.Extensions;
     using Exiled.API.Structs;
 
@@ -164,6 +166,76 @@ namespace Exiled.API.Features.Items
 
                 default:
                     return new Item(itemBase);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Item"/> with the proper inherited subclass.
+        /// </summary>
+        /// <param name="type">The <see cref="ItemType"/> of the item to create.</param>
+        /// <param name="owner">The <see cref="Player"/> who owns the item by default.</param>
+        /// <returns>The <see cref="Item"/> created. This can be cast as a subclass.</returns>
+        public static Item Create(ItemType type, Player owner = null)
+        {
+            switch (type)
+            {
+                case ItemType.Adrenaline:
+                case ItemType.Medkit:
+                case ItemType.Painkillers:
+                case ItemType.SCP500:
+                case ItemType.SCP207:
+                case ItemType.SCP268:
+                    return new Usable(type);
+                case ItemType.Ammo9x19:
+                case ItemType.Ammo12gauge:
+                case ItemType.Ammo44cal:
+                case ItemType.Ammo556x45:
+                case ItemType.Ammo762x39:
+                    return new Ammo(type);
+                case ItemType.Flashlight:
+                    return new Flashlight();
+                case ItemType.Radio:
+                    return new Radio();
+                case ItemType.MicroHID:
+                    return new MicroHid();
+                case ItemType.GrenadeFlash:
+                    return new FlashGrenade(owner);
+                case ItemType.GrenadeHE:
+                case ItemType.SCP018:
+                    return new ExplosiveGrenade(type, owner);
+                case ItemType.GunCrossvec:
+                case ItemType.GunLogicer:
+                case ItemType.GunRevolver:
+                case ItemType.GunShotgun:
+                case ItemType.GunAK:
+                case ItemType.GunCOM15:
+                case ItemType.GunCOM18:
+                case ItemType.GunE11SR:
+                case ItemType.GunFSP9:
+                    return new Firearm(type);
+                case ItemType.KeycardGuard:
+                case ItemType.KeycardJanitor:
+                case ItemType.KeycardO5:
+                case ItemType.KeycardScientist:
+                case ItemType.KeycardChaosInsurgency:
+                case ItemType.KeycardContainmentEngineer:
+                case ItemType.KeycardFacilityManager:
+                case ItemType.KeycardResearchCoordinator:
+                case ItemType.KeycardZoneManager:
+                case ItemType.KeycardNTFCommander:
+                case ItemType.KeycardNTFLieutenant:
+                case ItemType.KeycardNTFOfficer:
+                    return new Keycard(type);
+                case ItemType.ArmorLight:
+                case ItemType.ArmorCombat:
+                case ItemType.ArmorHeavy:
+                    return new Armor(type);
+                case ItemType.SCP330:
+                    return new Scp330();
+                case ItemType.SCP2176:
+                    return new Throwable(type);
+                default:
+                    return new Item(type);
             }
         }
 

--- a/Exiled.API/Features/Items/Keycard.cs
+++ b/Exiled.API/Features/Items/Keycard.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Items
 {
+    using System;
+
     using Exiled.API.Enums;
 
     using Interactables.Interobjects.DoorUtils;
@@ -34,6 +36,7 @@ namespace Exiled.API.Features.Items
         /// Initializes a new instance of the <see cref="Keycard"/> class.
         /// </summary>
         /// <param name="type"><inheritdoc cref="Item.Type"/></param>
+        [Obsolete("Use Exiled.API.Features.Item.Create(ItemType) instead.")]
         public Keycard(ItemType type)
             : this((KeycardItem)Server.Host.Inventory.CreateItemInstance(type, false))
         {

--- a/Exiled.API/Features/Items/MicroHid.cs
+++ b/Exiled.API/Features/Items/MicroHid.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Items
 {
+    using System;
+
     using Exiled.API.Enums;
 
     using InventorySystem.Items.MicroHID;
@@ -30,7 +32,7 @@ namespace Exiled.API.Features.Items
         /// Initializes a new instance of the <see cref="MicroHid"/> class.
         /// </summary>
         /// <param name="type"><inheritdoc cref="Base"/></param>
-        [System.Obsolete("Please use new MicroHid() instead. This constructor will be removed in the future.", true)]
+        [Obsolete("Use Exiled.API.Features.Item.Create(ItemType) instead.", true)]
         public MicroHid(ItemType type)
             : this((MicroHIDItem)Server.Host.Inventory.CreateItemInstance(type, false))
         {
@@ -39,7 +41,7 @@ namespace Exiled.API.Features.Items
         /// <summary>
         /// Initializes a new instance of the <see cref="MicroHid"/> class, as well as a new Micro HID item.
         /// </summary>
-        public MicroHid()
+        internal MicroHid()
             : this((MicroHIDItem)Server.Host.Inventory.CreateItemInstance(ItemType.MicroHID, false))
         {
         }

--- a/Exiled.API/Features/Items/Radio.cs
+++ b/Exiled.API/Features/Items/Radio.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Items
 {
+    using System;
+
     using Exiled.API.Enums;
     using Exiled.API.Structs;
 
@@ -33,7 +35,7 @@ namespace Exiled.API.Features.Items
         /// Initializes a new instance of the <see cref="Radio"/> class.
         /// </summary>
         /// <param name="type"><inheritdoc cref="Base"/></param>
-        [System.Obsolete("Please use new Radio() instead. This constructor will be removed in the future.", true)]
+        [Obsolete("Use Exiled.API.Features.Item.Create(ItemType) instead.", true)]
         public Radio(ItemType type)
             : this((RadioItem)Server.Host.Inventory.CreateItemInstance(type, false))
         {
@@ -42,7 +44,7 @@ namespace Exiled.API.Features.Items
         /// <summary>
         /// Initializes a new instance of the <see cref="Radio"/> class, as well as a new Radio item.
         /// </summary>
-        public Radio()
+        internal Radio()
             : this((RadioItem)Server.Host.Inventory.CreateItemInstance(ItemType.Radio, false))
         {
         }

--- a/Exiled.API/Features/Items/Scp330.cs
+++ b/Exiled.API/Features/Items/Scp330.cs
@@ -7,6 +7,7 @@
 
 namespace Exiled.API.Features.Items
 {
+    using System;
     using System.Collections.Generic;
 
     using InventorySystem.Items.Usables.Scp330;
@@ -14,6 +15,8 @@ namespace Exiled.API.Features.Items
     using Mirror;
 
     using UnityEngine;
+
+    using Object = UnityEngine.Object;
 
     /// <summary>
     /// A wrapper class for SCP-330 bags.
@@ -34,7 +37,7 @@ namespace Exiled.API.Features.Items
         /// Initializes a new instance of the <see cref="Scp330"/> class.
         /// </summary>
         /// <param name="type"><inheritdoc cref="Base"/></param>
-        [System.Obsolete("Please use new Scp330() instead. This constructor will be removed in the future.", true)]
+        [Obsolete("Use Exiled.API.Features.Item.Create(ItemType) instead.", true)]
         public Scp330(ItemType type)
             : this((Scp330Bag)Server.Host.Inventory.CreateItemInstance(type, false))
         {
@@ -43,7 +46,7 @@ namespace Exiled.API.Features.Items
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp330"/> class, as well as a new SCP-330 bag item.
         /// </summary>
-        public Scp330()
+        internal Scp330()
             : this((Scp330Bag)Server.Host.Inventory.CreateItemInstance(ItemType.SCP330, false))
         {
         }

--- a/Exiled.API/Features/Items/Throwable.cs
+++ b/Exiled.API/Features/Items/Throwable.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Items
 {
+    using System;
+
     using Exiled.API.Enums;
 
     using Footprinting;
@@ -38,6 +40,7 @@ namespace Exiled.API.Features.Items
         /// <param name="type"><inheritdoc cref="Base"/></param>
         /// <param name="player"><inheritdoc cref="Item.Owner"/></param>
         /// <remarks>The player parameter will always need to be defined if this throwable is custom using Exiled.CustomItems.</remarks>
+        [Obsolete("Use Exiled.API.Features.Item.Create(ItemType) instead.")]
         public Throwable(ItemType type, Player player = null)
             : this(player == null ? (ThrowableItem)Server.Host.Inventory.CreateItemInstance(type, false) : (ThrowableItem)player.Inventory.CreateItemInstance(type, true))
         {

--- a/Exiled.API/Features/Items/Usable.cs
+++ b/Exiled.API/Features/Items/Usable.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Items
 {
+    using System;
+
     using Exiled.API.Enums;
 
     using InventorySystem.Items.Usables;
@@ -30,6 +32,7 @@ namespace Exiled.API.Features.Items
         /// Initializes a new instance of the <see cref="Usable"/> class.
         /// </summary>
         /// <param name="type"><inheritdoc cref="Item.Type"/></param>
+        [Obsolete("Use Exiled.API.Features.Item.Create(ItemType) instead.")]
         public Usable(ItemType type)
             : this((UsableItem)Server.Host.Inventory.CreateItemInstance(type, false))
         {

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -59,6 +59,7 @@ namespace Exiled.API.Features
     public class Player
     {
 #pragma warning disable SA1401
+#pragma warning disable CS0618
         /// <summary>
         /// A list of the player's items.
         /// </summary>
@@ -1987,7 +1988,7 @@ namespace Exiled.API.Features
                     throwable = new FlashGrenade();
                     break;
                 default:
-                    throwable = new ExplosiveGrenade(type);
+                    throwable = new ExplosiveGrenade(type.GetItemType());
                     break;
             }
 

--- a/Exiled.CustomItems/API/Features/CustomGrenade.cs
+++ b/Exiled.CustomItems/API/Features/CustomGrenade.cs
@@ -86,7 +86,7 @@ namespace Exiled.CustomItems.API.Features
             if (player == null)
                 player = Server.Host;
 
-            Throwable throwable = new Throwable(grenadeType, player);
+            Throwable throwable = (Throwable)Item.Create(grenadeType, player);
 
             ThrownProjectile thrownProjectile = UnityEngine.Object.Instantiate(throwable.Base.Projectile, position, throwable.Owner.CameraTransform.rotation);
             Transform transform = thrownProjectile.transform;

--- a/Exiled.Example/Events/PlayerHandler.cs
+++ b/Exiled.Example/Events/PlayerHandler.cs
@@ -196,7 +196,7 @@ namespace Exiled.Example.Events
             if (ev.RoleType == RoleType.Scientist)
             {
                 ev.Position = new Vector3(53f, 1020f, -44f);
-                Timing.CallDelayed(1f, () => ev.Player.CurrentItem = new Firearm(ItemType.GunCrossvec));
+                Timing.CallDelayed(1f, () => ev.Player.CurrentItem = Item.Create(ItemType.GunCrossvec));
                 Timing.CallDelayed(1f, () => ev.Player.AddItem(ItemType.GunLogicer));
             }
         }


### PR DESCRIPTION
Item.Create() should now be used by all plugins, while constructors will be reserved for EXILED internally.

This allows a single line of code to handle creation of items of any subtype with the correct subclass attached (resolves issues where gun ammo breaks etc if you simple `new Item(ItemType.E11SR)` instead of `new Firearm(ItemType.E11SR)`, amongst others)

Obsolete marked ctors will be made internal only in the future, as to alleviate all plugins breaking instantly when 5.0 releases.