### PR TITLE
Make Player.Heal() respect negative values

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1469,10 +1469,12 @@ namespace Exiled.API.Features
         /// <param name="overrideMaxHealth">Whether healing should exceed their max health.</param>
         public void Heal(float amount, bool overrideMaxHealth = false)
         {
-            if (!overrideMaxHealth)
-                ((HealthStat)ReferenceHub.playerStats.StatModules[0]).ServerHeal(amount);
+            float newHealth = Health + amount;
+            
+            if (!overrideMaxHealth && newHealth > MaxHealth)
+                Health = MaxHealth;
             else
-                Health += amount;
+                Health = newHealth;
         }
 
         /// <summary>


### PR DESCRIPTION
Problem is NW ServerHeal method converts amount to an absolute value.
Player.Health exists of course but doesn't have the option to not override max health in case the value being added is positive

