### PR TITLE
Fixed `Map::Lockers` not returning all the generated lockers.

### DIFF
--- a/Exiled.Events/Handlers/Internal/MapGenerated.cs
+++ b/Exiled.Events/Handlers/Internal/MapGenerated.cs
@@ -61,7 +61,7 @@ namespace Exiled.Events.Handlers.Internal
             GenerateTeslaGates();
             GenerateLifts();
             GeneratePocketTeleports();
-            Timing.CallDelayed(0.15f, GenerateLockers);
+            Timing.CallDelayed(1f, GenerateLockers);
             Map.AmbientSoundPlayer = PlayerManager.localPlayer.GetComponent<AmbientSoundPlayer>();
         }
 


### PR DESCRIPTION
This is the minimum delay we need to use, because I tried by adding 0.1f periodically (starting from 0.15f), and 1f seems the best delay. Also, with less than 1f, it doesn't work.