### PR TITLE
Breaking changes and more fixes to Attachments API

### DIFF
--- a/Exiled.API/Extensions/ItemExtensions.cs
+++ b/Exiled.API/Extensions/ItemExtensions.cs
@@ -194,17 +194,17 @@ namespace Exiled.API.Extensions
                 throw new System.ArgumentException("The attachments code can't be less than the item's base code.");
             }
 
-            IEnumerable<AttachmentIdentifier> attachmentIdentifiers = Firearm.AvailableAttachments[type];
-            IEnumerable<uint> sources = attachmentIdentifiers.Select(attId => attId.Code);
+            AttachmentIdentifier[] attachmentIdentifiers = Firearm.AvailableAttachments[type].ToArray();
+            uint[] sources = attachmentIdentifiers.Select(attId => attId.Code).ToArray();
 
             code -= (uint)type.GetBaseCode();
-            for (int i = 0; i < sources.Count(); i++)
+            for (int i = 0; i < sources.Length; i++)
             {
-                if (code < sources.ElementAt(i))
+                if (code < sources[i])
                     continue;
 
                 yield return attachmentIdentifiers.ElementAt(i);
-                code -= sources.ElementAt(i);
+                code -= sources[i];
             }
         }
 

--- a/Exiled.API/Extensions/ItemExtensions.cs
+++ b/Exiled.API/Extensions/ItemExtensions.cs
@@ -5,10 +5,6 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System;
-
-using Exiled.API.Features;
-
 namespace Exiled.API.Extensions
 {
     using System.Collections.Generic;
@@ -193,19 +189,23 @@ namespace Exiled.API.Extensions
         /// <returns>A <see cref="IEnumerable{T}"/> of <see cref="AttachmentIdentifier"/> value which represents all the attachments present on the specified <see cref="ItemType"/>.</returns>
         public static IEnumerable<AttachmentIdentifier> GetAttachmentIdentifiers(this ItemType type, uint code)
         {
-            Log.Debug($"Getting identifiers at {DateTime.Now.Millisecond}");
             if ((uint)type.GetBaseCode() > code)
             {
                 throw new System.ArgumentException("The attachments code can't be less than the item's base code.");
             }
 
-            AttachmentIdentifier[] attachmentIdentifiers = Firearm.AvailableAttachments[type];
+            IEnumerable<AttachmentIdentifier> attachmentIdentifiers = Firearm.AvailableAttachments[type];
+            IEnumerable<uint> sources = attachmentIdentifiers.Select(attId => attId.Code);
+
             code -= (uint)type.GetBaseCode();
-            IEnumerable<AttachmentIdentifier> identifiers = (GetCombinations(attachmentIdentifiers.Select(identifier =>
-                identifier.Code)).FirstOrDefault(items => items.Sum() == code) ?? Array.Empty<uint>()).Select(target =>
-                attachmentIdentifiers.FirstOrDefault(attId => attId.Code == target));
-            Log.Debug($"Found identifiers at {DateTime.Now}.{DateTime.Now.Millisecond}");
-            return identifiers;
+            for (int i = 0; i < sources.Count(); i++)
+            {
+                if (code < sources.ElementAt(i))
+                    continue;
+
+                yield return attachmentIdentifiers.ElementAt(i);
+                code -= sources.ElementAt(i);
+            }
         }
 
         /// <summary>
@@ -255,27 +255,5 @@ namespace Exiled.API.Extensions
         /// <param name="type">The <see cref="ItemType"/> to check.</param>
         /// <returns>The corresponding <see cref="BaseCode"/>.</returns>
         public static BaseCode GetBaseCode(this ItemType type) => !type.IsWeapon() ? 0 : Firearm.FirearmPairs[type];
-
-        // This is an extension for IEnumerable to sum uint values.
-        // Credit: "TheGeneral" on StackOverflow
-        private static uint Sum(this IEnumerable<uint> source)
-        {
-            uint sum = 0;
-            checked
-            {
-                return source.Aggregate(sum, (current, v) => current + v);
-            }
-        }
-
-        // This determines what attachment codes can be added together
-        // to give us the combined code we have, so that we can determine
-        // which attachments are present for any given value.
-        // Credits: "TheGeneral" on StackOverflow
-        // https://stackoverflow.com/questions/69762657/how-to-find-a-given-number-by-adding-up-numbers-from-list-of-numbers-and-return
-        private static IEnumerable<IEnumerable<T>> GetCombinations<T>(IEnumerable<T> source)
-        {
-            for (int i = 0; i < 1 << source.Count(); i++)
-                yield return source.Where((t, j) => (i & (1 << j)) != 0);
-        }
     }
 }

--- a/Exiled.API/Extensions/ItemExtensions.cs
+++ b/Exiled.API/Extensions/ItemExtensions.cs
@@ -203,7 +203,7 @@ namespace Exiled.API.Extensions
                 if (code < sources[i])
                     continue;
 
-                yield return attachmentIdentifiers.ElementAt(i);
+                yield return attachmentIdentifiers[i];
                 code -= sources[i];
             }
         }

--- a/Exiled.API/Features/Cassie.cs
+++ b/Exiled.API/Features/Cassie.cs
@@ -16,8 +16,6 @@ namespace Exiled.API.Features
 
     using Respawning;
 
-    using static PlayerStatsSystem.PlayerStats;
-
     /// <summary>
     /// A set of tools to use in-game C.A.S.S.I.E.
     /// </summary>

--- a/Exiled.API/Features/DamageHandler.cs
+++ b/Exiled.API/Features/DamageHandler.cs
@@ -9,8 +9,6 @@ namespace Exiled.API.Features
 {
     using System.Collections.Generic;
 
-    using Dissonance;
-
     using Exiled.API.Enums;
     using Exiled.API.Features.Items;
 

--- a/Exiled.API/Features/Items/Ammo.cs
+++ b/Exiled.API/Features/Items/Ammo.cs
@@ -7,10 +7,6 @@
 
 namespace Exiled.API.Features.Items
 {
-    using System;
-
-    using Exiled.API.Enums;
-
     using InventorySystem.Items.Firearms.Ammo;
 
     /// <summary>

--- a/Exiled.API/Features/Items/Armor.cs
+++ b/Exiled.API/Features/Items/Armor.cs
@@ -9,20 +9,13 @@ namespace Exiled.API.Features.Items
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
 
-    using Exiled.API.Enums;
     using Exiled.API.Extensions;
     using Exiled.API.Structs;
 
-    using InventorySystem;
-    using InventorySystem.Items;
     using InventorySystem.Items.Armor;
-    using InventorySystem.Items.Usables;
 
     using NorthwoodLib.Pools;
-
-    using UnityEngine;
 
     /// <summary>
     /// A wrapper class for <see cref="BodyArmor"/>.

--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Features.Items
 {
-    using System;
     using System.Collections.Generic;
 
     using Exiled.API.Enums;

--- a/Exiled.API/Features/Items/FlashGrenade.cs
+++ b/Exiled.API/Features/Items/FlashGrenade.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Features.Items
 {
-    using System;
     using System.Collections.Generic;
 
     using Exiled.API.Enums;

--- a/Exiled.API/Features/Items/Flashlight.cs
+++ b/Exiled.API/Features/Items/Flashlight.cs
@@ -7,9 +7,6 @@
 
 namespace Exiled.API.Features.Items
 {
-    using System;
-
-    using Exiled.API.Enums;
     using InventorySystem.Items;
     using InventorySystem.Items.Flashlight;
 

--- a/Exiled.API/Features/Items/Item.cs
+++ b/Exiled.API/Features/Items/Item.cs
@@ -8,11 +8,9 @@
 namespace Exiled.API.Features.Items
 {
 #pragma warning disable CS0618
-    using System;
     using System.Collections.Generic;
     using System.Linq;
 
-    using Exiled.API.Enums;
     using Exiled.API.Extensions;
     using Exiled.API.Structs;
 

--- a/Exiled.API/Features/Items/Keycard.cs
+++ b/Exiled.API/Features/Items/Keycard.cs
@@ -7,14 +7,6 @@
 
 namespace Exiled.API.Features.Items
 {
-    using System;
-
-    using Exiled.API.Enums;
-
-    using Interactables.Interobjects.DoorUtils;
-
-    using InventorySystem;
-    using InventorySystem.Items;
     using InventorySystem.Items.Keycards;
 
     /// <summary>

--- a/Exiled.API/Features/Items/MicroHid.cs
+++ b/Exiled.API/Features/Items/MicroHid.cs
@@ -7,10 +7,6 @@
 
 namespace Exiled.API.Features.Items
 {
-    using System;
-
-    using Exiled.API.Enums;
-
     using InventorySystem.Items.MicroHID;
 
     /// <summary>

--- a/Exiled.API/Features/Items/Pickup.cs
+++ b/Exiled.API/Features/Items/Pickup.cs
@@ -7,23 +7,15 @@
 
 namespace Exiled.API.Features.Items
 {
-    using System;
     using System.Collections.Generic;
-    using System.Linq;
-
-    using Exiled.API.Enums;
 
     using InventorySystem;
     using InventorySystem.Items;
     using InventorySystem.Items.Pickups;
 
-    using MapGeneration.Distributors;
-
     using Mirror;
 
     using UnityEngine;
-
-    using Object = UnityEngine.Object;
 
     /// <summary>
     /// A wrapper class for <see cref="ItemPickupBase"/>.

--- a/Exiled.API/Features/Items/Radio.cs
+++ b/Exiled.API/Features/Items/Radio.cs
@@ -7,13 +7,9 @@
 
 namespace Exiled.API.Features.Items
 {
-    using System;
-
     using Exiled.API.Enums;
     using Exiled.API.Structs;
 
-    using InventorySystem;
-    using InventorySystem.Items;
     using InventorySystem.Items.Radio;
 
     /// <summary>

--- a/Exiled.API/Features/Items/Scp330.cs
+++ b/Exiled.API/Features/Items/Scp330.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Features.Items
 {
-    using System;
     using System.Collections.Generic;
 
     using InventorySystem.Items.Usables.Scp330;

--- a/Exiled.API/Features/Items/Throwable.cs
+++ b/Exiled.API/Features/Items/Throwable.cs
@@ -63,7 +63,10 @@ namespace Exiled.API.Features.Items
         /// Throws the item.
         /// </summary>
         /// <param name="fullForce">Whether to use full or half force.</param>
-        public void Throw(bool fullForce = true) => Base.ServerThrow(fullForce);
+        public void Throw(bool fullForce = true)
+        {
+            //Base.ServerThrow(fullForce);
+        }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/Exiled.API/Features/Items/Throwable.cs
+++ b/Exiled.API/Features/Items/Throwable.cs
@@ -7,17 +7,7 @@
 
 namespace Exiled.API.Features.Items
 {
-    using System;
-
-    using Exiled.API.Enums;
-
-    using Footprinting;
-
     using InventorySystem.Items.ThrowableProjectiles;
-
-    using Mirror;
-
-    using UnityEngine;
 
     /// <summary>
     /// A wrapper class for throwable items.
@@ -63,10 +53,7 @@ namespace Exiled.API.Features.Items
         /// Throws the item.
         /// </summary>
         /// <param name="fullForce">Whether to use full or half force.</param>
-        public void Throw(bool fullForce = true)
-        {
-            //Base.ServerThrow(fullForce);
-        }
+        public void Throw(bool fullForce = true) => Base.ServerThrow(fullForce);
 
         /// <inheritdoc/>
         public override string ToString()

--- a/Exiled.API/Features/Items/Usable.cs
+++ b/Exiled.API/Features/Items/Usable.cs
@@ -7,10 +7,6 @@
 
 namespace Exiled.API.Features.Items
 {
-    using System;
-
-    using Exiled.API.Enums;
-
     using InventorySystem.Items.Usables;
 
     /// <summary>

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -27,8 +27,6 @@ namespace Exiled.API.Features
 
     using Mirror;
 
-    using NorthwoodLib.Pools;
-
     using PlayableScps.ScriptableObjects;
 
     using UnityEngine;

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -41,7 +41,6 @@ namespace Exiled.API.Features
     using NorthwoodLib.Pools;
 
     using PlayableScps;
-    using PlayableScps.ScriptableObjects;
 
     using PlayerStatsSystem;
 

--- a/Exiled.API/Features/Ragdoll.cs
+++ b/Exiled.API/Features/Ragdoll.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Features
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
 

--- a/Exiled.API/Features/Round.cs
+++ b/Exiled.API/Features/Round.cs
@@ -11,8 +11,6 @@ namespace Exiled.API.Features
 
     using GameCore;
 
-    using PlayerStatsSystem;
-
     using RoundRestarting;
 
     /// <summary>

--- a/Exiled.API/Features/Server.cs
+++ b/Exiled.API/Features/Server.cs
@@ -13,8 +13,6 @@ namespace Exiled.API.Features
 
     using Mirror;
 
-    using PlayerStatsSystem;
-
     using RoundRestarting;
 
     /// <summary>

--- a/Exiled.API/Features/ShootingTarget.cs
+++ b/Exiled.API/Features/ShootingTarget.cs
@@ -12,8 +12,6 @@ namespace Exiled.API.Features
 
     using Exiled.API.Enums;
 
-    using InventorySystem.Items;
-
     using Mirror;
 
     using PlayerStatsSystem;

--- a/Exiled.API/Features/Spawn/SpawnProperties.cs
+++ b/Exiled.API/Features/Spawn/SpawnProperties.cs
@@ -9,10 +9,6 @@ namespace Exiled.API.Features.Spawn
 {
     using System.Collections.Generic;
 
-    using NorthwoodLib.Pools;
-
-    using UnityEngine;
-
     /// <summary>
     /// Handles special properties of spawning an item.
     /// </summary>

--- a/Exiled.API/Features/Warhead.cs
+++ b/Exiled.API/Features/Warhead.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.API.Features
 {
-    using System;
-
     /// <summary>
     /// A set of tools to easily work with the alpha warhead.
     /// </summary>

--- a/Exiled.API/Structs/AttachmentIdentifier.cs
+++ b/Exiled.API/Structs/AttachmentIdentifier.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Structs
 {
-    using System;
     using System.Linq;
 
     using Exiled.API.Enums;

--- a/Exiled.CustomItems/API/EventArgs/OwnerChangingRoleEventArgs.cs
+++ b/Exiled.CustomItems/API/EventArgs/OwnerChangingRoleEventArgs.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.CustomItems.API.EventArgs
 {
-    using Exiled.API.Enums;
     using Exiled.API.Features;
     using Exiled.CustomItems.API.Features;
     using Exiled.Events.EventArgs;

--- a/Exiled.CustomItems/API/EventArgs/OwnerEscapingEventArgs.cs
+++ b/Exiled.CustomItems/API/EventArgs/OwnerEscapingEventArgs.cs
@@ -12,8 +12,6 @@ namespace Exiled.CustomItems.API.EventArgs
     using Exiled.CustomItems.API.Features;
     using Exiled.Events.EventArgs;
 
-    using InventorySystem.Items;
-
     /// <summary>
     /// Contains all information of a <see cref="CustomItem"/> before a <see cref="Player"/> escapes.
     /// </summary>

--- a/Exiled.CustomItems/API/EventArgs/OwnerHandcuffingEventArgs.cs
+++ b/Exiled.CustomItems/API/EventArgs/OwnerHandcuffingEventArgs.cs
@@ -12,8 +12,6 @@ namespace Exiled.CustomItems.API.EventArgs
     using Exiled.CustomItems.API.Features;
     using Exiled.Events.EventArgs;
 
-    using InventorySystem.Items;
-
     /// <summary>
     /// Contains all information of a <see cref="CustomItem"/> before handcuffing a <see cref="Player"/>.
     /// </summary>

--- a/Exiled.CustomItems/API/EventArgs/UpgradingEventArgs.cs
+++ b/Exiled.CustomItems/API/EventArgs/UpgradingEventArgs.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.CustomItems.API.EventArgs
 {
-    using Exiled.API.Features;
     using Exiled.CustomItems.API.Features;
 
     using InventorySystem.Items.Pickups;

--- a/Exiled.CustomItems/API/Extensions.cs
+++ b/Exiled.CustomItems/API/Extensions.cs
@@ -14,10 +14,6 @@ namespace Exiled.CustomItems.API
     using Exiled.API.Features.Items;
     using Exiled.CustomItems.API.Features;
 
-    using Interactables.Interobjects.DoorUtils;
-
-    using UnityEngine;
-
     /// <summary>
     /// A collection of API methods.
     /// </summary>

--- a/Exiled.CustomItems/API/Features/CustomGrenade.cs
+++ b/Exiled.CustomItems/API/Features/CustomGrenade.cs
@@ -9,7 +9,6 @@ namespace Exiled.CustomItems.API.Features
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
 
     using Exiled.API.Enums;
     using Exiled.API.Extensions;
@@ -106,7 +105,7 @@ namespace Exiled.CustomItems.API.Features
             NetworkServer.Spawn(thrownProjectile.gameObject);
             thrownProjectile.InfoReceived(default, newInfo);
             if (thrownProjectile.TryGetComponent(out Rigidbody component))
-                //throwable.Base.PropelBody(component, throwable.Base.FullThrowSettings.StartTorque, force, throwable.Base.FullThrowSettings.UpwardsFactor);
+                throwable.Base.PropelBody(component, throwable.Base.FullThrowSettings.StartTorque, force, throwable.Base.FullThrowSettings.UpwardsFactor);
             thrownProjectile.ServerActivate();
             Tracked.Add(thrownProjectile);
 

--- a/Exiled.CustomItems/API/Features/CustomGrenade.cs
+++ b/Exiled.CustomItems/API/Features/CustomGrenade.cs
@@ -106,7 +106,7 @@ namespace Exiled.CustomItems.API.Features
             NetworkServer.Spawn(thrownProjectile.gameObject);
             thrownProjectile.InfoReceived(default, newInfo);
             if (thrownProjectile.TryGetComponent(out Rigidbody component))
-                throwable.Base.PropelBody(component, throwable.Base.FullThrowSettings.StartTorque, force, throwable.Base.FullThrowSettings.UpwardsFactor);
+                //throwable.Base.PropelBody(component, throwable.Base.FullThrowSettings.StartTorque, force, throwable.Base.FullThrowSettings.UpwardsFactor);
             thrownProjectile.ServerActivate();
             Tracked.Add(thrownProjectile);
 

--- a/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -21,8 +21,6 @@ namespace Exiled.CustomItems.API.Features
 
     using MEC;
 
-    using PlayerStatsSystem;
-
     using UnityEngine;
 
     using static CustomItems;

--- a/Exiled.CustomRoles/API/Extensions.cs
+++ b/Exiled.CustomRoles/API/Extensions.cs
@@ -14,8 +14,6 @@ namespace Exiled.CustomRoles.API
     using Exiled.API.Features;
     using Exiled.CustomRoles.API.Features;
 
-    using UnityEngine;
-
     /// <summary>
     /// A collection of API methods.
     /// </summary>

--- a/Exiled.CustomRoles/API/Features/ActiveAbility.cs
+++ b/Exiled.CustomRoles/API/Features/ActiveAbility.cs
@@ -14,8 +14,6 @@ namespace Exiled.CustomRoles.API.Features
 
     using MEC;
 
-    using UnityEngine;
-
     using YamlDotNet.Serialization;
 
     /// <summary>

--- a/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -12,15 +12,11 @@ namespace Exiled.CustomRoles.API.Features
     using System.Linq;
     using System.Reflection;
 
-    using Dissonance.Integrations.MirrorIgnorance;
-
     using Exiled.API.Enums;
     using Exiled.API.Extensions;
     using Exiled.API.Features;
     using Exiled.API.Features.Attributes;
-    using Exiled.API.Features.Items;
     using Exiled.API.Features.Spawn;
-    using Exiled.CustomItems;
     using Exiled.CustomItems.API.Features;
     using Exiled.Events.EventArgs;
     using Exiled.Loader;
@@ -32,8 +28,6 @@ namespace Exiled.CustomRoles.API.Features
     using UnityEngine;
 
     using YamlDotNet.Serialization;
-
-    using Ragdoll = Ragdoll;
 
     /// <summary>
     /// The custom role base class.

--- a/Exiled.CustomRoles/API/Features/Extensions/ParserExtension.cs
+++ b/Exiled.CustomRoles/API/Features/Extensions/ParserExtension.cs
@@ -9,7 +9,6 @@ namespace Exiled.CustomRoles.API.Features.Extensions
 {
     using System;
 
-    using Exiled.API.Features;
     using Exiled.CustomRoles.API.Features.Parsers;
 
     using YamlDotNet.Core;

--- a/Exiled.CustomRoles/API/Features/Parsers/AbstractClassNodeTypeResolver.cs
+++ b/Exiled.CustomRoles/API/Features/Parsers/AbstractClassNodeTypeResolver.cs
@@ -12,7 +12,6 @@ namespace Exiled.CustomRoles.API.Features.Parsers
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
 
-    using Exiled.API.Features;
     using Exiled.CustomRoles.API.Features.Interfaces;
 
     using YamlDotNet.Core;

--- a/Exiled.CustomRoles/API/Features/Parsers/AggregateExpectationTypeResolver.cs
+++ b/Exiled.CustomRoles/API/Features/Parsers/AggregateExpectationTypeResolver.cs
@@ -12,7 +12,6 @@ namespace Exiled.CustomRoles.API.Features.Parsers
     using System.Linq;
     using System.Reflection;
 
-    using Exiled.API.Features;
     using Exiled.CustomRoles.API.Features;
     using Exiled.CustomRoles.API.Features.Extensions;
     using Exiled.CustomRoles.API.Features.Interfaces;

--- a/Exiled.CustomRoles/API/Features/PassiveAbility.cs
+++ b/Exiled.CustomRoles/API/Features/PassiveAbility.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.CustomRoles.API.Features
 {
-    using Exiled.API.Features;
-
     /// <summary>
     /// The base class for passive (always active) abilities.
     /// </summary>

--- a/Exiled.CustomRoles/CustomRoles.cs
+++ b/Exiled.CustomRoles/CustomRoles.cs
@@ -14,7 +14,6 @@ namespace Exiled.CustomRoles
     using Exiled.CustomRoles.API.Features.Parsers;
     using Exiled.CustomRoles.Events;
     using Exiled.Loader;
-    using Exiled.Loader.Features.Configs;
     using Exiled.Loader.Features.Configs.CustomConverters;
 
     using YamlDotNet.Serialization;

--- a/Exiled.Events/Commands/Config/Merge.cs
+++ b/Exiled.Events/Commands/Config/Merge.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="Merge.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
@@ -13,7 +13,6 @@ namespace Exiled.Events.Commands.Config
     using Exiled.API.Enums;
     using Exiled.API.Features;
     using Exiled.Loader;
-    using Exiled.Permissions.Extensions;
 
     /// <summary>
     /// The config merge command.

--- a/Exiled.Events/Commands/Config/Split.cs
+++ b/Exiled.Events/Commands/Config/Split.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="Split.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
@@ -13,7 +13,6 @@ namespace Exiled.Events.Commands.Config
     using Exiled.API.Enums;
     using Exiled.API.Features;
     using Exiled.Loader;
-    using Exiled.Permissions.Extensions;
 
     /// <summary>
     /// The config split command.

--- a/Exiled.Events/EventArgs/ChangingAttachmentsEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingAttachmentsEventArgs.cs
@@ -5,6 +5,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using InventorySystem.Items.Firearms.Attachments;
+
 namespace Exiled.Events.EventArgs
 {
     using System.Collections.Generic;
@@ -37,8 +39,8 @@ namespace Exiled.Events.EventArgs
             Firearm = firearm;
             CurrentAttachmentIdentifiers = firearm.AttachmentIdentifiers;
             NewAttachmentIdentifiers = firearm.Type.GetAttachmentIdentifiers(code).ToList();
-            CurrentCode = CurrentAttachmentIdentifiers.GetAttachmentsCode() - (uint)firearm.BaseCode;
-            NewCode = NewAttachmentIdentifiers.GetAttachmentsCode();
+            CurrentCode = firearm.Base.GetCurrentAttachmentsCode();
+            NewCode = code;
             IsAllowed = isAllowed;
         }
 

--- a/Exiled.Events/EventArgs/ChangingAttachmentsEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingAttachmentsEventArgs.cs
@@ -5,13 +5,12 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using Exiled.API.Extensions;
-
 namespace Exiled.Events.EventArgs
 {
     using System.Collections.Generic;
     using System.Linq;
 
+    using Exiled.API.Extensions;
     using Exiled.API.Features;
     using Exiled.API.Features.Items;
     using Exiled.API.Structs;

--- a/Exiled.Events/EventArgs/ChangingAttachmentsEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingAttachmentsEventArgs.cs
@@ -5,8 +5,6 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using InventorySystem.Items.Firearms.Attachments;
-
 namespace Exiled.Events.EventArgs
 {
     using System.Collections.Generic;
@@ -16,6 +14,8 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
     using Exiled.API.Features.Items;
     using Exiled.API.Structs;
+
+    using InventorySystem.Items.Firearms.Attachments;
 
     /// <summary>
     /// Contains all informations before changing item attachments.

--- a/Exiled.Events/EventArgs/ChangingAttachmentsEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingAttachmentsEventArgs.cs
@@ -5,6 +5,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using Exiled.API.Extensions;
+
 namespace Exiled.Events.EventArgs
 {
     using System.Collections.Generic;
@@ -24,20 +26,20 @@ namespace Exiled.Events.EventArgs
         /// </summary>
         /// <param name="player"><inheritdoc cref="Player"/></param>
         /// <param name="firearm"><inheritdoc cref="Firearm"/></param>
-        /// <param name="oldIdentifiers"><inheritdoc cref="OldAttachmentIdentifiers"/></param>
-        /// <param name="newIdentifiers"><inheritdoc cref="NewAttachmentIdentifiers"/></param>
+        /// <param name="code">The attachments code.</param>
         /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
         public ChangingAttachmentsEventArgs(
             Player player,
             Firearm firearm,
-            IEnumerable<AttachmentIdentifier> oldIdentifiers,
-            IEnumerable<AttachmentIdentifier> newIdentifiers,
+            uint code,
             bool isAllowed = true)
         {
             Player = player;
             Firearm = firearm;
-            OldAttachmentIdentifiers = oldIdentifiers.ToArray();
-            NewAttachmentIdentifiers = newIdentifiers.ToList();
+            CurrentAttachmentIdentifiers = firearm.AttachmentIdentifiers;
+            NewAttachmentIdentifiers = firearm.Type.GetAttachmentIdentifiers(code).ToList();
+            CurrentCode = CurrentAttachmentIdentifiers.GetAttachmentsCode() - (uint)firearm.BaseCode;
+            NewCode = NewAttachmentIdentifiers.GetAttachmentsCode();
             IsAllowed = isAllowed;
         }
 
@@ -54,12 +56,22 @@ namespace Exiled.Events.EventArgs
         /// <summary>
         /// Gets the old <see cref="AttachmentIdentifier"/>.
         /// </summary>
-        public AttachmentIdentifier[] OldAttachmentIdentifiers { get; }
+        public IEnumerable<AttachmentIdentifier> CurrentAttachmentIdentifiers { get; }
 
         /// <summary>
         /// Gets or sets the new <see cref="AttachmentIdentifier"/>.
         /// </summary>
         public List<AttachmentIdentifier> NewAttachmentIdentifiers { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="CurrentAttachmentIdentifiers"/> code.
+        /// </summary>
+        public uint CurrentCode { get; }
+
+        /// <summary>
+        /// Gets the <see cref="NewAttachmentIdentifiers"/> code.
+        /// </summary>
+        public uint NewCode { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether or not the attachments can be changed.

--- a/Exiled.Events/EventArgs/ChangingIntoGrenadeEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingIntoGrenadeEventArgs.cs
@@ -9,11 +9,9 @@ namespace Exiled.Events.EventArgs
 {
     using System;
 
-    using Exiled.API.Enums;
     using Exiled.API.Features;
     using Exiled.API.Features.Items;
 
-    using InventorySystem.Items.Pickups;
     using InventorySystem.Items.ThrowableProjectiles;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/ChangingRoleEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingRoleEventArgs.cs
@@ -9,7 +9,6 @@ namespace Exiled.Events.EventArgs
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
 
     using Exiled.API.Enums;
     using Exiled.API.Features;

--- a/Exiled.Events/EventArgs/DroppingAmmoEventArgs.cs
+++ b/Exiled.Events/EventArgs/DroppingAmmoEventArgs.cs
@@ -11,9 +11,6 @@ namespace Exiled.Events.EventArgs
 
     using Exiled.API.Enums;
     using Exiled.API.Features;
-    using Exiled.API.Features.Items;
-
-    using InventorySystem.Items;
 
     /// <summary>
     /// Contains all information before a player drops an item.

--- a/Exiled.Events/EventArgs/HurtingEventArgs.cs
+++ b/Exiled.Events/EventArgs/HurtingEventArgs.cs
@@ -8,7 +8,6 @@
 namespace Exiled.Events.EventArgs
 {
     using System;
-    using System.Runtime.Remoting.Messaging;
 
     using Exiled.API.Features;
 

--- a/Exiled.Events/EventArgs/JumpingEventArgs.cs
+++ b/Exiled.Events/EventArgs/JumpingEventArgs.cs
@@ -11,8 +11,6 @@ namespace Exiled.Events.EventArgs
 
     using Exiled.API.Features;
 
-    using Mirror;
-
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/PlacingBulletHole.cs
+++ b/Exiled.Events/EventArgs/PlacingBulletHole.cs
@@ -10,10 +10,7 @@ namespace Exiled.Events.EventArgs
 #pragma warning disable SA1401
     using System;
 
-    using Exiled.API.Enums;
     using Exiled.API.Features;
-
-    using InventorySystem.Items.Firearms.Modules;
 
     using UnityEngine;
 

--- a/Exiled.Events/EventArgs/ReceivingPreferenceEventArgs.cs
+++ b/Exiled.Events/EventArgs/ReceivingPreferenceEventArgs.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.EventArgs
 {
     using System.Collections.Generic;
+    using System.Linq;
 
+    using Exiled.API.Extensions;
     using Exiled.API.Features;
     using Exiled.API.Structs;
 
@@ -22,20 +24,21 @@ namespace Exiled.Events.EventArgs
         /// </summary>
         /// <param name="player"><inheritdoc cref="Player"/></param>
         /// <param name="itemType"><inheritdoc cref="Item"/></param>
-        /// <param name="oldIdentifiers"><inheritdoc cref="OldAttachmentIdentifiers"/></param>
-        /// <param name="newIdentifiers"><inheritdoc cref="NewAttachmentIdentifiers"/></param>
+        /// <param name="currentCode"><inheritdoc cref="CurrentCode"/></param>
+        /// <param name="newCode"><inheritdoc cref="NewCode"/></param>
         /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
         public ReceivingPreferenceEventArgs(
             Player player,
             ItemType itemType,
-            AttachmentIdentifier[] oldIdentifiers,
-            List<AttachmentIdentifier> newIdentifiers,
+            uint currentCode,
+            uint newCode,
             bool isAllowed = true)
         {
             Player = player;
             Item = itemType;
-            OldAttachmentIdentifiers = oldIdentifiers;
-            NewAttachmentIdentifiers = newIdentifiers;
+            CurrentAttachmentIdentifiers = Item.GetAttachmentIdentifiers(currentCode);
+            NewAttachmentIdentifiers = Item.GetAttachmentIdentifiers(newCode).ToList();
+            CurrentCode = currentCode;
             IsAllowed = isAllowed;
         }
 
@@ -45,19 +48,29 @@ namespace Exiled.Events.EventArgs
         public Player Player { get; }
 
         /// <summary>
-        /// Gets or sets the <see cref="ItemType"/> which is being modified.
+        /// Gets the <see cref="ItemType"/> which is being modified.
         /// </summary>
-        public ItemType Item { get; set; }
+        public ItemType Item { get; }
 
         /// <summary>
         /// Gets the old <see cref="AttachmentIdentifier"/>[].
         /// </summary>
-        public AttachmentIdentifier[] OldAttachmentIdentifiers { get; }
+        public IEnumerable<AttachmentIdentifier> CurrentAttachmentIdentifiers { get; }
 
         /// <summary>
         /// Gets or sets the new <see cref="List{T}"/> of <see cref="AttachmentIdentifier"/>.
         /// </summary>
         public List<AttachmentIdentifier> NewAttachmentIdentifiers { get; set; }
+
+        /// <summary>
+        /// Gets the current attachments code.
+        /// </summary>
+        public uint CurrentCode { get; }
+
+        /// <summary>
+        /// Gets the new attachments code.
+        /// </summary>
+        public uint NewCode => NewAttachmentIdentifiers.GetAttachmentsCode() - (uint)Item.GetBaseCode();
 
         /// <summary>
         /// Gets or sets a value indicating whether or not the attachments preference can be executed.

--- a/Exiled.Events/EventArgs/SpawningItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/SpawningItemEventArgs.cs
@@ -9,7 +9,6 @@ namespace Exiled.Events.EventArgs
 {
     using System;
 
-    using Exiled.API.Features;
     using Exiled.API.Features.Items;
 
     using InventorySystem.Items.Pickups;

--- a/Exiled.Events/Handlers/Internal/MapGenerated.cs
+++ b/Exiled.Events/Handlers/Internal/MapGenerated.cs
@@ -21,8 +21,6 @@ namespace Exiled.Events.Handlers.Internal
 
     using MEC;
 
-    using NorthwoodLib.Pools;
-
     using UnityEngine;
 
     using Object = UnityEngine.Object;

--- a/Exiled.Events/Handlers/Internal/Round.cs
+++ b/Exiled.Events/Handlers/Internal/Round.cs
@@ -14,7 +14,6 @@ namespace Exiled.Events.Handlers.Internal
     using Exiled.Loader.Features;
 
     using InventorySystem;
-    using InventorySystem.Items.ThrowableProjectiles;
 
     using Item = Exiled.API.Features.Items.Item;
 

--- a/Exiled.Events/Handlers/Server.cs
+++ b/Exiled.Events/Handlers/Server.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.Events.Handlers
 {
-    using Exiled.API.Features;
     using Exiled.Events.EventArgs;
     using Exiled.Events.Extensions;
 

--- a/Exiled.Events/Patches/Events/Item/ChangingAttachments.cs
+++ b/Exiled.Events/Patches/Events/Item/ChangingAttachments.cs
@@ -5,12 +5,17 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System;
+
+using InventorySystem.Items;
+
 namespace Exiled.Events.Patches.Events.Item
 {
 #pragma warning disable SA1118
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
+    using Exiled.API.Features;
     using Exiled.API.Extensions;
     using Exiled.API.Structs;
     using Exiled.Events.EventArgs;
@@ -38,29 +43,33 @@ namespace Exiled.Events.Patches.Events.Item
         {
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
 
-            int offset = -3;
+            const int offset = -3;
             int index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Ldc_I4_1) + offset;
 
-            // Values to keep track of both the original codes and the results obtained from IL calculations
-            LocalBuilder wCode_0x01 = generator.DeclareLocal(typeof(uint));
-
-            // The event to implement
             LocalBuilder ev = generator.DeclareLocal(typeof(ChangingAttachmentsEventArgs));
-
-            // Value to extend results obtained from iterations involving memory addresses
-            LocalBuilder store_data_0x01 = generator.DeclareLocal(typeof(List<AttachmentIdentifier>));
+            LocalBuilder curCode = generator.DeclareLocal(typeof(uint));
 
             Label ret = generator.DefineLabel();
 
             newInstructions.InsertRange(index, new[]
             {
+                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
+
+                // curCode = Firearm::GetCurrentAttachmentsCode
+                new CodeInstruction(OpCodes.Ldloc_1),
+                new CodeInstruction(OpCodes.Call, Method(typeof(AttachmentsUtils), nameof(AttachmentsUtils.GetCurrentAttachmentsCode))),
+                new CodeInstruction(OpCodes.Stloc_S, curCode.LocalIndex),
+
+                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
+
                 // If the Firearm::GetCurrentAttachmentsCode isn't changed, prevents the method from being executed
                 new CodeInstruction(OpCodes.Ldarg_1),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(AttachmentsChangeRequest), nameof(AttachmentsChangeRequest.AttachmentsCode))),
-                new CodeInstruction(OpCodes.Ldloc_1),
-                new CodeInstruction(OpCodes.Call, Method(typeof(AttachmentsUtils), nameof(AttachmentsUtils.GetCurrentAttachmentsCode))),
+                new CodeInstruction(OpCodes.Ldloc_S, curCode.LocalIndex),
                 new CodeInstruction(OpCodes.Ceq),
                 new CodeInstruction(OpCodes.Brtrue_S, ret),
+
+                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
 
                 // API::Features::Player::Get(NetworkConnection::identity::netId)
                 new CodeInstruction(OpCodes.Ldarg_0),
@@ -68,25 +77,25 @@ namespace Exiled.Events.Patches.Events.Item
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(NetworkIdentity), nameof(NetworkIdentity.netId))),
                 new CodeInstruction(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(uint) })),
 
-                // firearm
-                new CodeInstruction(OpCodes.Ldloc_1),
+                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
 
-                // GetAttachmentIdentifiers(firearm::ItemTypeId, firearm::GetCurrentAttachmentsCode)
+                // Item::Get(firearm)
                 new CodeInstruction(OpCodes.Ldloc_1),
-                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Firearm), nameof(Firearm.ItemTypeId))),
-                new CodeInstruction(OpCodes.Ldloc_1),
-                new CodeInstruction(OpCodes.Call, Method(typeof(AttachmentsUtils), nameof(AttachmentsUtils.GetCurrentAttachmentsCode))),
-                new CodeInstruction(OpCodes.Call, Method(typeof(ItemExtensions), nameof(ItemExtensions.GetAttachmentIdentifiers), new[] { typeof(ItemType), typeof(uint) })),
+                new CodeInstruction(OpCodes.Call, Method(typeof(API.Features.Items.Item), nameof(API.Features.Items.Item.Get))),
+                new CodeInstruction(OpCodes.Castclass, typeof(API.Features.Items.Firearm)),
 
-                // firearm::ItemTypeId::GetAttachmentIdentifiers(AttachmentsChangeRequest::AttachmentsCode)
-                new CodeInstruction(OpCodes.Ldloc_1),
-                new CodeInstruction(OpCodes.Ldfld, Field(typeof(Firearm), nameof(Firearm.ItemTypeId))),
+                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
+
+                // AttachmentsChangeRequest::AttachmentsCode
                 new CodeInstruction(OpCodes.Ldarg_1),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(AttachmentsChangeRequest), nameof(AttachmentsChangeRequest.AttachmentsCode))),
-                new CodeInstruction(OpCodes.Call, Method(typeof(ItemExtensions), nameof(ItemExtensions.GetAttachmentIdentifiers), new[] { typeof(ItemType), typeof(uint) })),
+
+                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
 
                 // true
                 new CodeInstruction(OpCodes.Ldc_I4_1),
+
+                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
 
                 // ChangingAttachmentsEventArgs ev = new ChangingAttachmentsEventArgs(__ARGS__)
                 new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(ChangingAttachmentsEventArgs))[0]),
@@ -94,34 +103,31 @@ namespace Exiled.Events.Patches.Events.Item
                 new CodeInstruction(OpCodes.Dup),
                 new CodeInstruction(OpCodes.Stloc_S, ev.LocalIndex),
 
+                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
+
                 // Handlers::Item::OnChangingAttachments(ev)
                 new CodeInstruction(OpCodes.Call, Method(typeof(Handlers.Item), nameof(Handlers.Item.OnChangingAttachments))),
+
+                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
 
                 // ev.IsAllowed
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingAttachmentsEventArgs), nameof(ChangingAttachmentsEventArgs.IsAllowed))),
                 new CodeInstruction(OpCodes.Brfalse_S, ret),
 
-                // store_data_0x01 = *ev.NewAttachmentIdentifiers
-                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
-                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingAttachmentsEventArgs), nameof(ChangingAttachmentsEventArgs.NewAttachmentIdentifiers))),
-                new CodeInstruction(OpCodes.Stloc_S, store_data_0x01.LocalIndex),
+                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
 
-                // wCode_0x01 = *store_data_0x01::GetAttachmentsCode + **firearm::GetCurrentAttachmentsCode - **identifiers_0x02::GetAttachmentsCode
-                new CodeInstruction(OpCodes.Ldloc_S, store_data_0x01.LocalIndex),
-                new CodeInstruction(OpCodes.Call, Method(typeof(ItemExtensions), nameof(ItemExtensions.GetAttachmentsCode))),
-                new CodeInstruction(OpCodes.Ldloc_1),
-                new CodeInstruction(OpCodes.Call, Method(typeof(AttachmentsUtils), nameof(AttachmentsUtils.GetCurrentAttachmentsCode))),
+                // **AttachmentsChangeRequest = ev::NewCode + curCode - ev::CurrentCode
+                new CodeInstruction(OpCodes.Ldarga_S, 1),
+                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingAttachmentsEventArgs), nameof(ChangingAttachmentsEventArgs.NewCode))),
+                new CodeInstruction(OpCodes.Ldloc_S, curCode.LocalIndex),
                 new CodeInstruction(OpCodes.Add),
                 new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
-                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingAttachmentsEventArgs), nameof(ChangingAttachmentsEventArgs.OldAttachmentIdentifiers))),
-                new CodeInstruction(OpCodes.Call, Method(typeof(ItemExtensions), nameof(ItemExtensions.GetAttachmentsCode))),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingAttachmentsEventArgs), nameof(ChangingAttachmentsEventArgs.CurrentCode))),
                 new CodeInstruction(OpCodes.Sub),
-                new CodeInstruction(OpCodes.Stloc_S, wCode_0x01.LocalIndex),
-
-                // **AttachmentsChangeRequest = wCode_0x01
-                new CodeInstruction(OpCodes.Ldarga_S, 1),
-                new CodeInstruction(OpCodes.Ldloc_S, wCode_0x01.LocalIndex),
                 new CodeInstruction(OpCodes.Stfld, Field(typeof(AttachmentsChangeRequest), nameof(AttachmentsChangeRequest.AttachmentsCode))),
+
+                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
             });
 
             newInstructions[newInstructions.Count - 1].labels.Add(ret);
@@ -131,5 +137,7 @@ namespace Exiled.Events.Patches.Events.Item
 
             ListPool<CodeInstruction>.Shared.Return(newInstructions);
         }
+
+        private static void InvokeDebug() => Log.Debug($"{DateTime.Now}.{DateTime.Now.Millisecond}");
     }
 }

--- a/Exiled.Events/Patches/Events/Item/ChangingAttachments.cs
+++ b/Exiled.Events/Patches/Events/Item/ChangingAttachments.cs
@@ -5,19 +5,14 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System;
-
-using InventorySystem.Items;
-
 namespace Exiled.Events.Patches.Events.Item
 {
 #pragma warning disable SA1118
+    using System;
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
     using Exiled.API.Features;
-    using Exiled.API.Extensions;
-    using Exiled.API.Structs;
     using Exiled.Events.EventArgs;
 
     using HarmonyLib;
@@ -29,8 +24,6 @@ namespace Exiled.Events.Patches.Events.Item
     using NorthwoodLib.Pools;
 
     using static HarmonyLib.AccessTools;
-
-    using Firearm = InventorySystem.Items.Firearms.Firearm;
 
     /// <summary>
     /// Patches <see cref="AttachmentsServerHandler.ServerReceiveChangeRequest(NetworkConnection, AttachmentsChangeRequest)"/>.
@@ -53,14 +46,10 @@ namespace Exiled.Events.Patches.Events.Item
 
             newInstructions.InsertRange(index, new[]
             {
-                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
-
                 // curCode = Firearm::GetCurrentAttachmentsCode
                 new CodeInstruction(OpCodes.Ldloc_1),
                 new CodeInstruction(OpCodes.Call, Method(typeof(AttachmentsUtils), nameof(AttachmentsUtils.GetCurrentAttachmentsCode))),
                 new CodeInstruction(OpCodes.Stloc_S, curCode.LocalIndex),
-
-                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
 
                 // If the Firearm::GetCurrentAttachmentsCode isn't changed, prevents the method from being executed
                 new CodeInstruction(OpCodes.Ldarg_1),
@@ -69,33 +58,23 @@ namespace Exiled.Events.Patches.Events.Item
                 new CodeInstruction(OpCodes.Ceq),
                 new CodeInstruction(OpCodes.Brtrue_S, ret),
 
-                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
-
                 // API::Features::Player::Get(NetworkConnection::identity::netId)
                 new CodeInstruction(OpCodes.Ldarg_0),
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(NetworkConnection), nameof(NetworkConnection.identity))),
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(NetworkIdentity), nameof(NetworkIdentity.netId))),
                 new CodeInstruction(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(uint) })),
 
-                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
-
                 // Item::Get(firearm)
                 new CodeInstruction(OpCodes.Ldloc_1),
                 new CodeInstruction(OpCodes.Call, Method(typeof(API.Features.Items.Item), nameof(API.Features.Items.Item.Get))),
                 new CodeInstruction(OpCodes.Castclass, typeof(API.Features.Items.Firearm)),
 
-                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
-
                 // AttachmentsChangeRequest::AttachmentsCode
                 new CodeInstruction(OpCodes.Ldarg_1),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(AttachmentsChangeRequest), nameof(AttachmentsChangeRequest.AttachmentsCode))),
 
-                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
-
                 // true
                 new CodeInstruction(OpCodes.Ldc_I4_1),
-
-                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
 
                 // ChangingAttachmentsEventArgs ev = new ChangingAttachmentsEventArgs(__ARGS__)
                 new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(ChangingAttachmentsEventArgs))[0]),
@@ -103,18 +82,12 @@ namespace Exiled.Events.Patches.Events.Item
                 new CodeInstruction(OpCodes.Dup),
                 new CodeInstruction(OpCodes.Stloc_S, ev.LocalIndex),
 
-                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
-
                 // Handlers::Item::OnChangingAttachments(ev)
                 new CodeInstruction(OpCodes.Call, Method(typeof(Handlers.Item), nameof(Handlers.Item.OnChangingAttachments))),
-
-                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
 
                 // ev.IsAllowed
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingAttachmentsEventArgs), nameof(ChangingAttachmentsEventArgs.IsAllowed))),
                 new CodeInstruction(OpCodes.Brfalse_S, ret),
-
-                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
 
                 // **AttachmentsChangeRequest = ev::NewCode + curCode - ev::CurrentCode
                 new CodeInstruction(OpCodes.Ldarga_S, 1),
@@ -126,8 +99,6 @@ namespace Exiled.Events.Patches.Events.Item
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ChangingAttachmentsEventArgs), nameof(ChangingAttachmentsEventArgs.CurrentCode))),
                 new CodeInstruction(OpCodes.Sub),
                 new CodeInstruction(OpCodes.Stfld, Field(typeof(AttachmentsChangeRequest), nameof(AttachmentsChangeRequest.AttachmentsCode))),
-
-                new CodeInstruction(OpCodes.Call, Method(typeof(ChangingAttachments), nameof(InvokeDebug))),
             });
 
             newInstructions[newInstructions.Count - 1].labels.Add(ret);
@@ -137,7 +108,5 @@ namespace Exiled.Events.Patches.Events.Item
 
             ListPool<CodeInstruction>.Shared.Return(newInstructions);
         }
-
-        private static void InvokeDebug() => Log.Debug($"{DateTime.Now}.{DateTime.Now.Millisecond}");
     }
 }

--- a/Exiled.Events/Patches/Events/Item/ReceivingPreference.cs
+++ b/Exiled.Events/Patches/Events/Item/ReceivingPreference.cs
@@ -9,11 +9,9 @@ namespace Exiled.Events.Patches.Events.Item
 {
 #pragma warning disable SA1118
     using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection.Emit;
 
     using Exiled.API.Extensions;
-    using Exiled.API.Structs;
     using Exiled.Events.EventArgs;
 
     using HarmonyLib;
@@ -37,18 +35,14 @@ namespace Exiled.Events.Patches.Events.Item
         {
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
 
-            int index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Ldsfld);
+            int index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Ldloc_1);
 
             LocalBuilder ev = generator.DeclareLocal(typeof(ReceivingPreferenceEventArgs));
 
-            LocalBuilder mem_0x01 = generator.DeclareLocal(typeof(AttachmentIdentifier[]));
             LocalBuilder mem_0x02 = generator.DeclareLocal(typeof(uint));
-            LocalBuilder mem_0x03 = generator.DeclareLocal(typeof(List<AttachmentIdentifier>));
-            LocalBuilder mem_0x04 = generator.DeclareLocal(typeof(uint));
 
             Label cdc = generator.DefineLabel();
             Label ret = generator.DefineLabel();
-            Label std_ovf = generator.DefineLabel();
 
             newInstructions[index].labels.Add(cdc);
 
@@ -56,63 +50,13 @@ namespace Exiled.Events.Patches.Events.Item
 
             newInstructions.InsertRange(index, new[]
             {
-                // referenceHub ?
-                new CodeInstruction(OpCodes.Ldloc_0),
-                new CodeInstruction(OpCodes.Brfalse_S, ret),
-
-                // referenceHub::characterClassManager::get_NetworkCurClass == 2
-                new CodeInstruction(OpCodes.Ldloc_0),
-                new CodeInstruction(OpCodes.Ldfld, Field(typeof(ReferenceHub), nameof(ReferenceHub.characterClassManager))),
-                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(CharacterClassManager), nameof(CharacterClassManager.NetworkCurClass))),
-                new CodeInstruction(OpCodes.Ldc_I4_2),
-                new CodeInstruction(OpCodes.Ceq),
-
-                // Runs the original code
-                new CodeInstruction(OpCodes.Brfalse_S, cdc),
-
                 // dictionary::TryGetValue(AttachmentsSetupPreference::Weapon, *mem_0x02)
                 new CodeInstruction(OpCodes.Ldloc_1),
                 new CodeInstruction(OpCodes.Ldarg_1),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(AttachmentsSetupPreference), nameof(AttachmentsSetupPreference.Weapon))),
                 new CodeInstruction(OpCodes.Ldloca_S, mem_0x02.LocalIndex),
                 new CodeInstruction(OpCodes.Callvirt, Method(typeof(Dictionary<ItemType, uint>), nameof(Dictionary<ItemType, uint>.TryGetValue))),
-
-                // Runs the original code
                 new CodeInstruction(OpCodes.Brfalse_S, cdc),
-
-                // AttachmentsSetupPreference::AttachmentsCode == mem_0x02
-                new CodeInstruction(OpCodes.Ldarg_1),
-                new CodeInstruction(OpCodes.Ldfld, Field(typeof(AttachmentsSetupPreference), nameof(AttachmentsSetupPreference.AttachmentsCode))),
-                new CodeInstruction(OpCodes.Ldloc_S, mem_0x02.LocalIndex),
-                new CodeInstruction(OpCodes.Ceq),
-
-                // Runs the original code
-                new CodeInstruction(OpCodes.Brtrue_S, cdc),
-
-                // mem_0x01 = null
-                new CodeInstruction(OpCodes.Ldnull),
-                new CodeInstruction(OpCodes.Stloc_S, mem_0x01.LocalIndex),
-
-                // mem_0x03 = new List<AttachmentIdentifier>()
-                new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(List<AttachmentIdentifier>))[0]),
-                new CodeInstruction(OpCodes.Stloc_S, mem_0x03.LocalIndex),
-
-                // mem_0x01 = ItemExtensions::GetAttachments(AttachmentsSetupPreference::Weapon, mem_0x02)::ToList()
-                new CodeInstruction(OpCodes.Ldarg_1),
-                new CodeInstruction(OpCodes.Ldfld, Field(typeof(AttachmentsSetupPreference), nameof(AttachmentsSetupPreference.Weapon))),
-                new CodeInstruction(OpCodes.Ldloc_S, mem_0x02.LocalIndex),
-                new CodeInstruction(OpCodes.Call, Method(typeof(ItemExtensions), nameof(ItemExtensions.GetAttachmentIdentifiers), new[] { typeof(ItemType), typeof(uint) })),
-                new CodeInstruction(OpCodes.Call, Method(typeof(Enumerable), nameof(Enumerable.ToArray)).MakeGenericMethod(typeof(AttachmentIdentifier))),
-                new CodeInstruction(OpCodes.Stloc_S, mem_0x01.LocalIndex),
-
-                // mem_0x03 = ItemExtensions::GetAttachments(AttachmentsSetupPreference::Weapon, AttachmentsSetupPreference::AttachmentsCode)::ToList()
-                new CodeInstruction(OpCodes.Ldarg_1),
-                new CodeInstruction(OpCodes.Ldfld, Field(typeof(AttachmentsSetupPreference), nameof(AttachmentsSetupPreference.Weapon))),
-                new CodeInstruction(OpCodes.Ldarg_1),
-                new CodeInstruction(OpCodes.Ldfld, Field(typeof(AttachmentsSetupPreference), nameof(AttachmentsSetupPreference.AttachmentsCode))),
-                new CodeInstruction(OpCodes.Call, Method(typeof(ItemExtensions), nameof(ItemExtensions.GetAttachmentIdentifiers), new[] { typeof(ItemType), typeof(uint) })),
-                new CodeInstruction(OpCodes.Call, Method(typeof(Enumerable), nameof(Enumerable.ToList)).MakeGenericMethod(typeof(AttachmentIdentifier))),
-                new CodeInstruction(OpCodes.Stloc_S, mem_0x03.LocalIndex),
 
                 // API::Features::Player::Get(referenceHub)
                 new CodeInstruction(OpCodes.Ldloc_0),
@@ -121,12 +65,6 @@ namespace Exiled.Events.Patches.Events.Item
                 // AttachmentsSetupPreference::Weapon
                 new CodeInstruction(OpCodes.Ldarg_1),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(AttachmentsSetupPreference), nameof(AttachmentsSetupPreference.Weapon))),
-
-                // mem_0x01
-                new CodeInstruction(OpCodes.Ldloc_S, mem_0x01.LocalIndex),
-
-                // mem_0x03
-                new CodeInstruction(OpCodes.Ldloc_S, mem_0x03.LocalIndex),
 
                 // true
                 new CodeInstruction(OpCodes.Ldc_I4_1),
@@ -144,51 +82,13 @@ namespace Exiled.Events.Patches.Events.Item
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ReceivingPreferenceEventArgs), nameof(ReceivingPreferenceEventArgs.IsAllowed))),
                 new CodeInstruction(OpCodes.Brfalse_S, ret),
 
-                // mem_0x03 = ev::NewAttachmentIdentifiers
-                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
-                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ReceivingPreferenceEventArgs), nameof(ReceivingPreferenceEventArgs.NewAttachmentIdentifiers))),
-                new CodeInstruction(OpCodes.Stloc_S, mem_0x03.LocalIndex),
-
-                // mem_0x03::Count()
-                new CodeInstruction(OpCodes.Ldloc_S, mem_0x03.LocalIndex),
-                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(List<AttachmentIdentifier>), nameof(List<AttachmentIdentifier>.Count))),
-                new CodeInstruction(OpCodes.Brfalse_S, std_ovf),
-
-                // mem_0x04 = ItemExtensions.GetBaseCode(ev::Item)
-                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
-                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ReceivingPreferenceEventArgs), nameof(ReceivingPreferenceEventArgs.Item))),
-                new CodeInstruction(OpCodes.Call, Method(typeof(ItemExtensions), nameof(ItemExtensions.GetBaseCode))),
-                new CodeInstruction(OpCodes.Conv_I4),
-                new CodeInstruction(OpCodes.Stloc_S, mem_0x04.LocalIndex),
-
-                // ItemExtensions::GetAttachmentsCode(mem_0x03)
-                new CodeInstruction(OpCodes.Ldloc_S, mem_0x03.LocalIndex).WithLabels(std_ovf),
-                new CodeInstruction(OpCodes.Call, Method(typeof(ItemExtensions), nameof(ItemExtensions.GetAttachmentsCode))),
-                new CodeInstruction(OpCodes.Conv_I4),
-                new CodeInstruction(OpCodes.Stloc_S, mem_0x04.LocalIndex),
-
-                // ItemExtensions::IsWeapon(ev::Item, false)
-                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
-                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ReceivingPreferenceEventArgs), nameof(ReceivingPreferenceEventArgs.Item))),
-                new CodeInstruction(OpCodes.Ldc_I4_0),
-                new CodeInstruction(OpCodes.Call, Method(typeof(ItemExtensions), nameof(ItemExtensions.IsWeapon))),
-
-                // Runs the original code
-                new CodeInstruction(OpCodes.Brfalse_S, cdc),
-
-                // **AttachmentSetupPreference::Weapon = ev::Item
+                // **AttachmentSetupPreference::AttachmentsCode = ev::NewCode
                 new CodeInstruction(OpCodes.Ldarga_S, 1),
                 new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
-                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ReceivingPreferenceEventArgs), nameof(ReceivingPreferenceEventArgs.Item))),
-                new CodeInstruction(OpCodes.Stfld, Field(typeof(AttachmentsSetupPreference), nameof(AttachmentsSetupPreference.Weapon))),
-
-                // **AttachmentSetupPreference::AttachmentsCode = ItemExtensions::GetBaseCode(ev::Item)
-                new CodeInstruction(OpCodes.Ldarga_S, 1),
-                new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
-                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ReceivingPreferenceEventArgs), nameof(ReceivingPreferenceEventArgs.Item))),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(ReceivingPreferenceEventArgs), nameof(ReceivingPreferenceEventArgs.NewCode))),
+                new CodeInstruction(OpCodes.Ldarg_1),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(AttachmentsSetupPreference), nameof(AttachmentsSetupPreference.Weapon))),
                 new CodeInstruction(OpCodes.Call, Method(typeof(ItemExtensions), nameof(ItemExtensions.GetBaseCode))),
-                new CodeInstruction(OpCodes.Conv_I4),
-                new CodeInstruction(OpCodes.Ldloc_S, mem_0x04.LocalIndex),
                 new CodeInstruction(OpCodes.Add),
                 new CodeInstruction(OpCodes.Stfld, Field(typeof(AttachmentsSetupPreference), nameof(AttachmentsSetupPreference.AttachmentsCode))),
             });

--- a/Exiled.Events/Patches/Events/Map/Decontaminating.cs
+++ b/Exiled.Events/Patches/Events/Map/Decontaminating.cs
@@ -19,8 +19,6 @@ namespace Exiled.Events.Patches.Events.Map
 
     using NorthwoodLib.Pools;
 
-    using UnityEngine;
-
     using static HarmonyLib.AccessTools;
 
     /// <summary>

--- a/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
+++ b/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
@@ -15,15 +15,12 @@ namespace Exiled.Events.Patches.Events.Map
 
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
-    using Exiled.Events.Patches.Generic;
 
     using Footprinting;
 
     using HarmonyLib;
 
     using InventorySystem.Items.ThrowableProjectiles;
-
-    using Mirror;
 
     using NorthwoodLib.Pools;
 

--- a/Exiled.Events/Patches/Events/Map/PlacingBulletHole.cs
+++ b/Exiled.Events/Patches/Events/Map/PlacingBulletHole.cs
@@ -12,7 +12,6 @@ namespace Exiled.Events.Patches.Events.Map
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
-    using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/Died.cs
+++ b/Exiled.Events/Patches/Events/Player/Died.cs
@@ -9,7 +9,6 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1118
     using System.Collections.Generic;
-    using System.Reflection;
     using System.Reflection.Emit;
 
     using Exiled.API.Features;
@@ -20,8 +19,6 @@ namespace Exiled.Events.Patches.Events.Player
     using NorthwoodLib.Pools;
 
     using PlayerStatsSystem;
-
-    using UnityEngine;
 
     using static HarmonyLib.AccessTools;
 

--- a/Exiled.Events/Patches/Events/Player/FlippingCoin.cs
+++ b/Exiled.Events/Patches/Events/Player/FlippingCoin.cs
@@ -9,8 +9,6 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1118
     using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
     using System.Reflection.Emit;
 
     using Exiled.API.Features;

--- a/Exiled.Events/Patches/Events/Player/Hurting.cs
+++ b/Exiled.Events/Patches/Events/Player/Hurting.cs
@@ -9,23 +9,16 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1118
     using System.Collections.Generic;
-    using System.Reflection;
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs;
     using Exiled.Events.Handlers;
 
-    using global::Utils.Networking;
-
     using HarmonyLib;
-
-    using InventorySystem.Disarming;
 
     using NorthwoodLib.Pools;
 
     using PlayerStatsSystem;
-
-    using UnityEngine;
 
     using static HarmonyLib.AccessTools;
 

--- a/Exiled.Events/Patches/Events/Player/InteractingShootingTarget.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingShootingTarget.cs
@@ -9,7 +9,6 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1118
     using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection;
     using System.Reflection.Emit;
 

--- a/Exiled.Events/Patches/Events/Player/SpawningRagdoll.cs
+++ b/Exiled.Events/Patches/Events/Player/SpawningRagdoll.cs
@@ -9,7 +9,6 @@ namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1118
     using System.Collections.Generic;
-    using System.Reflection;
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs;

--- a/Exiled.Events/Patches/Events/Player/TriggeringTesla.cs
+++ b/Exiled.Events/Patches/Events/Player/TriggeringTesla.cs
@@ -8,7 +8,6 @@
 namespace Exiled.Events.Patches.Events.Player
 {
 #pragma warning disable SA1118
-    using System;
     using System.Collections.Generic;
     using System.Reflection.Emit;
 

--- a/Exiled.Events/Patches/Events/Scp330/PickingUp330.cs
+++ b/Exiled.Events/Patches/Events/Scp330/PickingUp330.cs
@@ -16,10 +16,7 @@ namespace Exiled.Events.Patches.Events.Scp330
 
     using HarmonyLib;
 
-    using Interactables.Interobjects;
-
     using InventorySystem.Items.Usables.Scp330;
-    using InventorySystem.Searching;
 
     using NorthwoodLib.Pools;
 

--- a/Exiled.Events/Patches/Events/Warhead/Starting.cs
+++ b/Exiled.Events/Patches/Events/Warhead/Starting.cs
@@ -18,8 +18,6 @@ namespace Exiled.Events.Patches.Events.Warhead
 
     using NorthwoodLib.Pools;
 
-    using UnityEngine;
-
     using static HarmonyLib.AccessTools;
 
     /// <summary>

--- a/Exiled.Events/Patches/Events/Warhead/StartingByCommand.cs
+++ b/Exiled.Events/Patches/Events/Warhead/StartingByCommand.cs
@@ -21,8 +21,6 @@ namespace Exiled.Events.Patches.Events.Warhead
 
     using NorthwoodLib.Pools;
 
-    using RemoteAdmin;
-
     using static HarmonyLib.AccessTools;
 
     /// <summary>

--- a/Exiled.Events/Patches/Fixes/ExplosiveGrenadeFieldsFix.cs
+++ b/Exiled.Events/Patches/Fixes/ExplosiveGrenadeFieldsFix.cs
@@ -11,7 +11,6 @@ namespace Exiled.Events.Patches.Fixes
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
-    using Exiled.API.Features;
     using Exiled.API.Features.Items;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Fixes/FlashbangGrenadeFieldsFix.cs
+++ b/Exiled.Events/Patches/Fixes/FlashbangGrenadeFieldsFix.cs
@@ -11,7 +11,6 @@ namespace Exiled.Events.Patches.Fixes
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
-    using Exiled.API.Features;
     using Exiled.API.Features.Items;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Fixes/GrenadeFuseTimeFix.cs
+++ b/Exiled.Events/Patches/Fixes/GrenadeFuseTimeFix.cs
@@ -11,7 +11,6 @@ namespace Exiled.Events.Patches.Fixes
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
-    using Exiled.API.Features;
     using Exiled.API.Features.Items;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
+++ b/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
@@ -13,10 +13,8 @@ namespace Exiled.Events.Patches.Generic
 #pragma warning disable SA1313
     using System;
     using System.Collections.Generic;
-    using System.Reflection;
     using System.Reflection.Emit;
 
-    using Exiled.API.Extensions;
     using Exiled.API.Features;
 
     using Footprinting;

--- a/Exiled.Events/Patches/Generic/InventoryControlPatch.cs
+++ b/Exiled.Events/Patches/Generic/InventoryControlPatch.cs
@@ -29,7 +29,6 @@ namespace Exiled.Events.Patches.Generic
 
     using static HarmonyLib.AccessTools;
 
-    using Events = Exiled.Events.Events;
     using Inventory = InventorySystem.Inventory;
 
     /// <summary>

--- a/Exiled.Example/Commands/Test.cs
+++ b/Exiled.Example/Commands/Test.cs
@@ -14,8 +14,6 @@ namespace Exiled.Example.Commands
     using Exiled.API.Features;
     using Exiled.API.Features.Items;
 
-    using RemoteAdmin;
-
     /// <summary>
     /// This is an example of how commands should be made.
     /// </summary>

--- a/Exiled.Example/Events/ItemHandler.cs
+++ b/Exiled.Example/Events/ItemHandler.cs
@@ -26,7 +26,7 @@ namespace Exiled.Example.Events
         /// <inheritdoc cref="Exiled.Events.Handlers.Item.OnChangingAttachments(ChangingAttachmentsEventArgs)"/>
         public void OnChangingAttachments(ChangingAttachmentsEventArgs ev)
         {
-            string oldAttachments = ev.OldAttachmentIdentifiers.Aggregate(string.Empty, (current, attachmentIdentifier) => current + $"{attachmentIdentifier.Name}\n");
+            string oldAttachments = ev.CurrentAttachmentIdentifiers.Aggregate(string.Empty, (current, attachmentIdentifier) => current + $"{attachmentIdentifier.Name}\n");
             string newAttachments = ev.NewAttachmentIdentifiers.Aggregate(string.Empty, (current, attachmentIdentifier) => current + $"{attachmentIdentifier.Name}\n");
 
             Log.Info($"Item {ev.Firearm.Type} attachments are changing. Old attachments:\n{oldAttachments} - New Attachments:\n{newAttachments}");

--- a/Exiled.Permissions/Permissions.cs
+++ b/Exiled.Permissions/Permissions.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Permissions
 {
-    using System;
-
     using Exiled.API.Features;
 
     using MEC;


### PR DESCRIPTION
This fixes all possible problems caused by Attachments API.
Also, I did a `using` directives clean up, because Resharper was yelling at me.

# Changelog

## Fixes
`[Exiled.Events]` Fixed an issue that was delaying the change of a specific preset/attachment for firearms with many attachments.
`[Exiled.Events]` Fixed an issue that wasn't correctly applying player preferences for all the firearms before and during the game.

## Additions
`[Exiled.Events]` Added the `ChangingAttachmentsEventArgs::CurrentCode` property.
`[Exiled.Events]` Added the `ChangingAttachmentsEventArgs::NewCode` property.
`[Exiled.Events]` Added the `ReceivingPreferenceEventArgs::CurrentCode` property.
`[Exiled.Events]` Added the `ReceivingPreferenceEventArgs::NewCode` property.

## Changes (breaking)
`[Exiled.Events]` Renamed the `ChangingAttachmentsEventArgs::OldAttachmentIdentifiers` property to `CurrentAttachmentIdentifiers`.
`[Exiled.Events]` Renamed the `ReceivingPreferenceEventArgs::OldAttachmentIdentifiers` property to `CurrentAttachmentIdentifiers`.
`[Exiled.Events]` The `ChangingAttachmentsEventArgs` constructor now requires a `uint` parameter; it doesn't require two `IEnumerable<AttachmentIdentifier>` parameters anymore.
`[Exiled.Events]` The `ChangingAttachmentsEventArgs` constructor now requires a two `uint` parameters; it doesn't require two `IEnumerable<AttachmentIdentifier>` parameters anymore.