### PR TITLE
Introducing Log::Assert

### DIFF
--- a/Exiled.API/Features/Log.cs
+++ b/Exiled.API/Features/Log.cs
@@ -148,7 +148,6 @@ namespace Exiled.API.Features
         /// <param name="condition">The conditional expression to evaluate. If the condition is true it will continue.</param>
         /// <param name="message">The information message. The error and exception will show this message.</param>
         /// <exception cref="System.Exception">If the condition is false. It throws an exception stopping the execution.</exception>
-        [System.Diagnostics.Conditional("DEBUG")]
         public static void Assert(bool condition, object message)
         {
             if (condition)

--- a/Exiled.API/Features/Log.cs
+++ b/Exiled.API/Features/Log.cs
@@ -131,5 +131,31 @@ namespace Exiled.API.Features
         /// <param name="message">The message to be sent.</param>
         /// <param name="color">The <see cref="System.ConsoleColor"/> of the message.</param>
         public static void SendRaw(string message, System.ConsoleColor color) => ServerConsole.AddLog(message, color);
+
+        /// <summary>
+        /// Sends an <see cref="Error(object)"/> with the provided message if the condition is false and stops the execution.
+        /// <para>
+        /// Only works if the assembly calling the method is a debug build.
+        /// </para>
+        /// <example> For example:
+        /// <code>
+        ///     Player ply = Player.Get(2);
+        ///     Log.Assert(ply != null, "The player with the id 2 is null");
+        /// </code>
+        /// results in it logging an error if the player is null and not continuing.
+        /// </example>
+        /// </summary>
+        /// <param name="condition">The conditional expression to evaluate. If the condition is true it will continue.</param>
+        /// <param name="message">The information message. The error and exception will show this message.</param>
+        /// <exception cref="System.Exception">If the condition is false. It throws an exception stopping the execution.</exception>
+        [System.Diagnostics.Conditional("DEBUG")]
+        public static void Assert(bool condition, object message)
+        {
+            if (condition)
+                return;
+
+            Error(message);
+            throw new System.Exception(message.ToString());
+        }
     }
 }

--- a/Exiled.API/Features/Log.cs
+++ b/Exiled.API/Features/Log.cs
@@ -134,9 +134,6 @@ namespace Exiled.API.Features
 
         /// <summary>
         /// Sends an <see cref="Error(object)"/> with the provided message if the condition is false and stops the execution.
-        /// <para>
-        /// Only works if the assembly calling the method is a debug build.
-        /// </para>
         /// <example> For example:
         /// <code>
         ///     Player ply = Player.Get(2);


### PR DESCRIPTION
**Log.Assert** is a useful method for **debugging** which throws an exception when the value isnt the expected, stopping the execution of the method.

```cs
// only works if the build of the plugin is a DEBUG build. Otherwise the method will be ignored.

Player ply = Player.Get(3);
Log.Assert(ply != null, "The player 3 is null. THAT SHOULDNT HAPPEN!!"); 

SomeMethod(ply);

```

If the value isn't the expected (Not Null) it will log an error and stop the execution, therefore `SomeMethod` wont be called.