### PR TITLE
Fix map spawning item event not calling

### DIFF
--- a/Exiled.Events/EventArgs/SpawningItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/SpawningItemEventArgs.cs
@@ -36,7 +36,7 @@ namespace Exiled.Events.EventArgs
         }
 
         /// <summary>
-        /// Gets or sets a value indicating the pickup being spawned.
+        /// Gets or sets a value indicating the pickup being spawned. CAN BE NULL.
         /// </summary>
         public Pickup Pickup { get; set; }
 

--- a/Exiled.Events/EventArgs/SpawningItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/SpawningItemEventArgs.cs
@@ -36,7 +36,7 @@ namespace Exiled.Events.EventArgs
         }
 
         /// <summary>
-        /// Gets or sets a value indicating the pickup being spawned. CAN BE NULL.
+        /// Gets or sets a value indicating the pickup being spawned.
         /// </summary>
         public Pickup Pickup { get; set; }
 

--- a/Exiled.Events/Patches/Events/Map/SpawningItem.cs
+++ b/Exiled.Events/Patches/Events/Map/SpawningItem.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Map
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
+    using Exiled.API.Features;
     using Exiled.Events.EventArgs;
 
     using HarmonyLib;
@@ -32,15 +33,11 @@ namespace Exiled.Events.Patches.Events.Map
 
             Label returnLabel = generator.DefineLabel();
 
-            int offset = 1;
-
-            int index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Ret) + offset;
-
             // var ev = new SpawningItemEventArgs(ipb, true);
             //
             // if (!ev.IsAllowed)
             //     return;
-            newInstructions.InsertRange(index, new[]
+            newInstructions.InsertRange(0, new[]
             {
                 new CodeInstruction(OpCodes.Ldarg_0),
                 new CodeInstruction(OpCodes.Ldc_I4_1),

--- a/Exiled.Events/Patches/Events/Map/SpawningItem.cs
+++ b/Exiled.Events/Patches/Events/Map/SpawningItem.cs
@@ -11,7 +11,6 @@ namespace Exiled.Events.Patches.Events.Map
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
-    using Exiled.API.Features;
     using Exiled.Events.EventArgs;
 
     using HarmonyLib;


### PR DESCRIPTION
This calls it before the null check so the ev.Pickup might be null, but I never saw it happen while testing