### PR TITLE
CustomPlayerInfo colors are back :pray: 

### DIFF
--- a/Exiled.CreditTags/CreditTags.cs
+++ b/Exiled.CreditTags/CreditTags.cs
@@ -48,11 +48,11 @@ namespace Exiled.CreditTags
         /// </summary>
         internal Dictionary<RankType, Rank> Ranks { get; } = new Dictionary<RankType, Rank>
         {
-            [RankType.Dev] = new Rank("Exiled Developer", "aqua", "33DEFF"),
-            [RankType.Contributor] = new Rank("Exiled Contributor", "magenta", "B733FF"),
-            [RankType.PluginDev] = new Rank("Exiled Plugin Developer", "crimson", "E60909"),
-            [RankType.TournamentParticipant] = new Rank("Exiled Tournament Participant", "pink", "FF96DE"),
-            [RankType.TournamentChampion] = new Rank("Exiled Tournament Champion", "deep_pink", "FF1493"),
+            [RankType.Dev] = new Rank("Exiled Developer", "aqua", "aqua"),
+            [RankType.Contributor] = new Rank("Exiled Contributor", "magenta", "magenta"),
+            [RankType.PluginDev] = new Rank("Exiled Plugin Developer", "crimson", "crimson"),
+            [RankType.TournamentParticipant] = new Rank("Exiled Tournament Participant", "pink", "pink"),
+            [RankType.TournamentChampion] = new Rank("Exiled Tournament Champion", "deep_pink", "deep_pink"),
         };
 
         /// <summary>

--- a/Exiled.CreditTags/Features/Rank.cs
+++ b/Exiled.CreditTags/Features/Rank.cs
@@ -17,7 +17,7 @@ namespace Exiled.CreditTags.Features
         /// </summary>
         /// <param name="name">The name of the rank.</param>
         /// <param name="color">The name of the rank's color.</param>
-        /// <param name="hexValue">The hex color value of the rank's color.</param>
+        /// <param name="hexValue">The hex color value of the rank's color (in CustomPlayerInfo).</param>
         public Rank(string name, string color, string hexValue)
         {
             Name = name;


### PR DESCRIPTION
This adds colors back to CreditTags (if the tag is in the CustomInfo)
I'll be real I don't know if we should change the internal name of HexValue (hoping NW adds back full color support there soon™️)