### PR TITLE
Player::AddWeaponAmmo & ItemExtensions::GetWeaponAmmoType

### DIFF
--- a/Exiled.API/Extensions/ItemExtensions.cs
+++ b/Exiled.API/Extensions/ItemExtensions.cs
@@ -125,6 +125,34 @@ namespace Exiled.API.Extensions
                     return AmmoType.None;
             }
         }
+        
+        /// <summary>
+        /// Returns the <see cref="AmmoType"/> of the weapon is using.
+        /// </summary>
+        /// <param name="weapon">The <see cref="ItemType"/> to convert.</param>
+        /// <returns>The given weapon's AmmoType.</returns>
+        public static AmmoType GetWeaponAmmoType(this ItemType weapon)
+        {
+            switch (weapon)
+            {
+                case ItemType.GunCOM15:
+                case ItemType.GunCOM18:
+                case ItemType.GunCrossvec:
+                case ItemType.GunFSP9:
+                    return AmmoType.Nato9;
+                case ItemType.GunE11SR:
+                    return AmmoType.Nato556;
+                case ItemType.GunAK:
+                case ItemType.GunLogicer:
+                    return AmmoType.Nato762;
+                case ItemType.GunRevolver:
+                    return AmmoType.Ammo44Cal;
+                case ItemType.GunShotgun:
+                    return AmmoType.Ammo12Gauge;
+                default:
+                    return AmmoType.None;
+            }
+        }
 
         /// <summary>
         /// Converts an <see cref="AmmoType"/> into it's corresponding <see cref="ItemType"/>.

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1464,6 +1464,13 @@ namespace Exiled.API.Features
         /// <param name="ammoType">The <see cref="AmmoType"/> to be added.</param>
         /// <param name="amount">The amount of ammo to be added.</param>
         public void AddAmmo(AmmoType ammoType, ushort amount) => Inventory.ServerAddAmmo(ammoType.GetItemType(), amount);
+        
+        /// <summary>
+        /// Adds the amount of a weapons's <see cref="AmmoType">ammo type</see> to the player's inventory.
+        /// </summary>
+        /// <param name="weapon">The <see cref="ItemType"/> of the weapon.</param>
+        /// <param name="amount">The amount of ammo to be added.</param>
+        public void AddWeaponAmmo(ItemType weapon, ushort amount) => Inventory.ServerAddAmmo(ItemExtensions.GetWeaponAmmoType(weapon).GetItemType(), amount);
 
         /// <summary>
         /// Sets the amount of a specified <see cref="AmmoType">ammo type</see> to the player's inventory.


### PR DESCRIPTION
Added `ItemExtensions::GetWeaponAmmoType(ItemType)` which allows getting the ammo type for the provided weapon
Added `Player::AddWeaponAmmo(Itemtype, ushort)` using the above method to give ammo to the player for the provided weapon