### PR TITLE
Make unlocking surface warhead event fire regardless of card

### DIFF
--- a/Exiled.Events/Patches/Events/Player/ActivatingWarheadPanel.cs
+++ b/Exiled.Events/Patches/Events/Player/ActivatingWarheadPanel.cs
@@ -43,7 +43,7 @@ namespace Exiled.Events.Patches.Events.Player
                 new CodeInstruction(OpCodes.Ldarg_0),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(PlayerInteract), nameof(PlayerInteract._hub))),
                 new CodeInstruction(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
-                new CodeInstruction(OpCodes.Ldloc, isAllowed.LocalIndex),
+                new CodeInstruction(OpCodes.Ldloc_S, isAllowed.LocalIndex),
                 new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(ActivatingWarheadPanelEventArgs))[0]),
                 new CodeInstruction(OpCodes.Dup),
 

--- a/Exiled.Events/Patches/Events/Player/ActivatingWarheadPanel.cs
+++ b/Exiled.Events/Patches/Events/Player/ActivatingWarheadPanel.cs
@@ -39,7 +39,7 @@ namespace Exiled.Events.Patches.Events.Player
             newInstructions.InsertRange(index, new[]
             {
                 // new ActivatingWarheadPanelEventArgs(_hub, isAllowed);
-                new CodeInstruction(OpCodes.Stloc, isAllowed.LocalIndex),
+                new CodeInstruction(OpCodes.Stloc_S, isAllowed.LocalIndex),
                 new CodeInstruction(OpCodes.Ldarg_0),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(PlayerInteract), nameof(PlayerInteract._hub))),
                 new CodeInstruction(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),


### PR DESCRIPTION
Another option is to have it fire even if the player doesn't have a card in hand at all, but that would make the starting index weird, plus it doesn't seem practical. Then again, what do i know