### PR TITLE
Fixes CustomAbility.Check

### DIFF
--- a/EXILED.sln
+++ b/EXILED.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30225.117
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Exiled.Events", "Exiled.Events\Exiled.Events.csproj", "{1E6C4350-5067-4CE7-91DB-6420D027A4FC}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Exiled.Loader", "Exiled.Loader\Exiled.Loader.csproj", "{1ABEC6CE-E209-4C38-AB45-2F3B7F6091CA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Exiled.Installer", "Exiled.Installer\Exiled.Installer.csproj", "{10A8BFEC-B9E2-4119-BB21-2CF1EA820D19}"
@@ -33,10 +31,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{1E6C4350-5067-4CE7-91DB-6420D027A4FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1E6C4350-5067-4CE7-91DB-6420D027A4FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1E6C4350-5067-4CE7-91DB-6420D027A4FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1E6C4350-5067-4CE7-91DB-6420D027A4FC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1ABEC6CE-E209-4C38-AB45-2F3B7F6091CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1ABEC6CE-E209-4C38-AB45-2F3B7F6091CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1ABEC6CE-E209-4C38-AB45-2F3B7F6091CA}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/EXILED.sln
+++ b/EXILED.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30225.117
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Exiled.Events", "Exiled.Events\Exiled.Events.csproj", "{1E6C4350-5067-4CE7-91DB-6420D027A4FC}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Exiled.Loader", "Exiled.Loader\Exiled.Loader.csproj", "{1ABEC6CE-E209-4C38-AB45-2F3B7F6091CA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Exiled.Installer", "Exiled.Installer\Exiled.Installer.csproj", "{10A8BFEC-B9E2-4119-BB21-2CF1EA820D19}"
@@ -31,6 +33,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1E6C4350-5067-4CE7-91DB-6420D027A4FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E6C4350-5067-4CE7-91DB-6420D027A4FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E6C4350-5067-4CE7-91DB-6420D027A4FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E6C4350-5067-4CE7-91DB-6420D027A4FC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1ABEC6CE-E209-4C38-AB45-2F3B7F6091CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1ABEC6CE-E209-4C38-AB45-2F3B7F6091CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1ABEC6CE-E209-4C38-AB45-2F3B7F6091CA}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/Exiled.CustomRoles/API/Features/CustomAbility.cs
+++ b/Exiled.CustomRoles/API/Features/CustomAbility.cs
@@ -36,6 +36,7 @@ namespace Exiled.CustomRoles.API.Features
         /// <summary>
         /// Gets all players who have this ability.
         /// </summary>
+        [YamlIgnore]
         public IEnumerable<Player> Players
         {
             get

--- a/Exiled.CustomRoles/API/Features/CustomAbility.cs
+++ b/Exiled.CustomRoles/API/Features/CustomAbility.cs
@@ -34,6 +34,18 @@ namespace Exiled.CustomRoles.API.Features
         public static HashSet<CustomAbility> Registered { get; } = new HashSet<CustomAbility>();
 
         /// <summary>
+        /// Gets all players who have this ability.
+        /// </summary>
+        public IEnumerable<Player> Players
+        {
+            get
+            {
+                return Player.List.Where(x =>
+                    x.GetCustomRoles().Any(y => y.CustomAbilities.Any(z => z.AbilityType == AbilityType)));
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the name of the ability.
         /// </summary>
         public abstract string Name { get; set; }
@@ -42,12 +54,6 @@ namespace Exiled.CustomRoles.API.Features
         /// Gets or sets the description of the ability.
         /// </summary>
         public abstract string Description { get; set; }
-
-        /// <summary>
-        /// Gets all players who have this ability.
-        /// </summary>
-        [YamlIgnore]
-        public HashSet<Player> Players { get; } = new HashSet<Player>();
 
         /// <summary>
         /// Gets the <see cref="Type"/> for this ability.
@@ -184,7 +190,6 @@ namespace Exiled.CustomRoles.API.Features
         /// <param name="player">The <see cref="Player"/> to give the ability to.</param>
         public void AddAbility(Player player)
         {
-            Players.Add(player);
             AbilityAdded(player);
         }
 
@@ -194,7 +199,6 @@ namespace Exiled.CustomRoles.API.Features
         /// <param name="player">The <see cref="Player"/> to remove this ability from.</param>
         public void RemoveAbility(Player player)
         {
-            Players.Remove(player);
             AbilityRemoved(player);
         }
 

--- a/Exiled.CustomRoles/API/Features/CustomAbility.cs
+++ b/Exiled.CustomRoles/API/Features/CustomAbility.cs
@@ -37,14 +37,8 @@ namespace Exiled.CustomRoles.API.Features
         /// Gets all players who have this ability.
         /// </summary>
         [YamlIgnore]
-        public IEnumerable<Player> Players
-        {
-            get
-            {
-                return Player.List.Where(x =>
-                    x.GetCustomRoles().Any(y => y.CustomAbilities.Any(z => z.AbilityType == AbilityType)));
-            }
-        }
+        public IEnumerable<Player> Players => Player.Get(x =>
+            x.GetCustomRoles().Any(y => y.CustomAbilities.Any(z => z.AbilityType == AbilityType)));
 
         /// <summary>
         /// Gets or sets the name of the ability.

--- a/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -347,6 +347,8 @@ namespace Exiled.CustomRoles.API.Features
             Log.Debug($"{Name}: Setting player info", CustomRoles.Instance.Config.Debug);
             player.CustomInfo = CustomInfo;
             player.InfoArea &= ~PlayerInfoArea.Role;
+
+            TrackedPlayers.Add(player);
             if (CustomAbilities != null)
             {
                 foreach (CustomAbility ability in CustomAbilities)
@@ -355,7 +357,6 @@ namespace Exiled.CustomRoles.API.Features
 
             ShowMessage(player);
             RoleAdded(player);
-            TrackedPlayers.Add(player);
         }
 
         /// <summary>


### PR DESCRIPTION
I met a strange bug in my own customrole's customability. Method Check was always returning false in any registered events because `CustomAbility.Players.Count == 0`:
![image](https://user-images.githubusercontent.com/63547495/157286282-cf38ae51-5fc6-45f5-b645-389d16fe9d3e.png)
![image](https://user-images.githubusercontent.com/63547495/157286605-aa1cf315-a124-4b38-a906-ef4f59b2b5cd.png)
![image](https://user-images.githubusercontent.com/63547495/157286680-18f609bd-99db-4d14-923b-315af1ac8765.png)
This is the fix of this problem.
First my idea was to make property `CustomAbility.Players` static, but it would make Players tracking common for all CustomRoles at all. So it will be needed to make separated static field for each CustomAbility type, but i have no idea, is it possible.
The only solution i found out it to enumerate all the players and check their CustomRoles and CustomAbilities.
`TrackedPlayers.Add(player);` is moved, because i think, that player already must be in `CustomRole.TrackedPlayers` at the moment, when CustomAbility.AbilityAdded is called for some logic needs.