### PR TITLE
Spectator properties fix

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -909,10 +909,10 @@ namespace Exiled.API.Features
             {
                 foreach (ReferenceHub referenceHub in ReferenceHub.spectatorManager.ServerCurrentSpectatingPlayers)
                 {
-                    Player spectator = Get(referenceHub);
+                    if (referenceHub == ReferenceHub)
+                        continue;
 
-                    if (spectator == this || spectator.IsDead)
-                        yield return spectator;
+                    yield return Get(referenceHub);
                 }
             }
         }

--- a/Exiled.API/Features/Roles/SpectatorRole.cs
+++ b/Exiled.API/Features/Roles/SpectatorRole.cs
@@ -37,27 +37,14 @@ namespace Exiled.API.Features.Roles
         public TimeSpan DeadTime => DateTime.UtcNow - DeathTime;
 
         /// <summary>
-        /// Gets or sets currently spectated player by this <see cref="Player"/>. May be <see langword="null"/>.
+        /// Gets currently spectated player by this <see cref="Player"/>. May be <see langword="null"/>.
         /// </summary>
         public Player SpectatedPlayer
         {
             get
             {
                 Player spectatedPlayer = Player.Get(Owner.ReferenceHub.spectatorManager.CurrentSpectatedPlayer);
-
-                if (spectatedPlayer == Owner)
-                    return null;
-
-                return spectatedPlayer;
-            }
-
-            set
-            {
-                if (Owner.IsAlive)
-                    throw new InvalidOperationException("The spectated player cannot be set on an alive player.");
-
-                Owner.ReferenceHub.spectatorManager.CurrentSpectatedPlayer = value.ReferenceHub;
-                Owner.ReferenceHub.spectatorManager.CmdSendPlayer(value.Id);
+                return spectatedPlayer != Owner ? spectatedPlayer : null;
             }
         }
 

--- a/Exiled.API/Features/Roles/SpectatorRole.cs
+++ b/Exiled.API/Features/Roles/SpectatorRole.cs
@@ -37,7 +37,7 @@ namespace Exiled.API.Features.Roles
         public TimeSpan DeadTime => DateTime.UtcNow - DeathTime;
 
         /// <summary>
-        /// Gets currently spectated player by this <see cref="Player"/>. May be <see langword="null"/>.
+        /// Gets or sets currently spectated player by this <see cref="Player"/>. May be <see langword="null"/>.
         /// </summary>
         public Player SpectatedPlayer
         {
@@ -45,6 +45,10 @@ namespace Exiled.API.Features.Roles
             {
                 Player spectatedPlayer = Player.Get(Owner.ReferenceHub.spectatorManager.CurrentSpectatedPlayer);
                 return spectatedPlayer != Owner ? spectatedPlayer : null;
+            }
+
+            set
+            {
             }
         }
 

--- a/Exiled.API/Features/Roles/SpectatorRole.cs
+++ b/Exiled.API/Features/Roles/SpectatorRole.cs
@@ -47,6 +47,7 @@ namespace Exiled.API.Features.Roles
                 return spectatedPlayer != Owner ? spectatedPlayer : null;
             }
 
+            [Obsolete("Client side feature.", false)]
             set
             {
             }

--- a/Exiled.API/Features/Roles/SpectatorRole.cs
+++ b/Exiled.API/Features/Roles/SpectatorRole.cs
@@ -47,9 +47,14 @@ namespace Exiled.API.Features.Roles
                 return spectatedPlayer != Owner ? spectatedPlayer : null;
             }
 
-            [Obsolete("Client side feature.", false)]
+            [Obsolete("Client side feature.", true)]
             set
             {
+                if (Owner.IsAlive)
+                    throw new InvalidOperationException("The spectated player cannot be set on an alive player.");
+
+                Owner.ReferenceHub.spectatorManager.CurrentSpectatedPlayer = value.ReferenceHub;
+                Owner.ReferenceHub.spectatorManager.CmdSendPlayer(value.Id);
             }
         }
 

--- a/Exiled.Events/Events.cs
+++ b/Exiled.Events/Events.cs
@@ -14,7 +14,6 @@ namespace Exiled.Events
 
     using Exiled.API.Enums;
     using Exiled.API.Features;
-    using Exiled.Events.Patches.Events.Server;
     using Exiled.Loader;
 
     using HarmonyLib;


### PR DESCRIPTION
# Changelog:
- Fixed `Player::CurrentSpectatingPlayers` returning also the player himself
- Removed setter for `SpectatorRole::SpectatedPlayer` because it doesn't syncs with the client