### PR TITLE
Added `Spawned` event for the player

### DIFF
--- a/Exiled.Events/EventArgs/SpawnedEventArgs.cs
+++ b/Exiled.Events/EventArgs/SpawnedEventArgs.cs
@@ -1,0 +1,30 @@
+// -----------------------------------------------------------------------
+// <copyright file="SpawnedEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+
+    using Exiled.API.Features;
+
+    /// <summary>
+    /// Contains all information after spawning a player.
+    /// </summary>
+    public class SpawnedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpawnedEventArgs"/> class.
+        /// </summary>
+        /// <param name="referenceHub"><see cref="ReferenceHub"/> of the spawned player.</param>
+        public SpawnedEventArgs(ReferenceHub referenceHub) => Player = Player.Get(referenceHub);
+
+        /// <summary>
+        /// Gets the <see cref="API.Features.Player"/> who spawned.
+        /// </summary>
+        public Player Player { get; }
+    }
+}

--- a/Exiled.Events/Events.cs
+++ b/Exiled.Events/Events.cs
@@ -82,6 +82,7 @@ namespace Exiled.Events
             Handlers.Server.RestartingRound += Handlers.Internal.Round.OnRestartingRound;
             Handlers.Server.RoundStarted += Handlers.Internal.Round.OnRoundStarted;
             Handlers.Player.ChangingRole += Handlers.Internal.Round.OnChangingRole;
+            PlayerMovementSync.OnPlayerSpawned += Handlers.Player.OnSpawned;
 
             ServerConsole.ReloadServerName();
         }
@@ -101,6 +102,7 @@ namespace Exiled.Events
             Handlers.Server.RestartingRound -= Handlers.Internal.Round.OnRestartingRound;
             Handlers.Server.RoundStarted -= Handlers.Internal.Round.OnRoundStarted;
             Handlers.Player.ChangingRole -= Handlers.Internal.Round.OnChangingRole;
+            PlayerMovementSync.OnPlayerSpawned -= Handlers.Player.OnSpawned;
             Handlers.Map.Generated -= Handlers.Internal.MapGenerated.OnMapGenerated;
 
             MapGeneration.SeedSynchronizer.OnMapGenerated -= Handlers.Map.OnGenerated;

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.Events.Handlers
 {
+    using System;
+
     using Exiled.Events.EventArgs;
     using Exiled.Events.Extensions;
 
@@ -211,6 +213,11 @@ namespace Exiled.Events.Handlers
         /// Invoked before spawning a <see cref="API.Features.Player"/>.
         /// </summary>
         public static event CustomEventHandler<SpawningEventArgs> Spawning;
+
+        /// <summary>
+        /// Invoked after a <see cref="API.Features.Player"/> has spawned.
+        /// </summary>
+        public static event CustomEventHandler<SpawnedEventArgs> Spawned;
 
         /// <summary>
         /// Invoked before a <see cref="API.Features.Player"/> enters the femur breaker.
@@ -655,6 +662,12 @@ namespace Exiled.Events.Handlers
         /// </summary>
         /// <param name="ev">The <see cref="SpawningEventArgs"/> instance.</param>
         public static void OnSpawning(SpawningEventArgs ev) => Spawning.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called after a <see cref="API.Features.Player"/> has spawned.
+        /// </summary>
+        /// <param name="referenceHub">The <see cref="ReferenceHub"/> instance.</param>
+        public static void OnSpawned(ReferenceHub referenceHub) => Spawned.InvokeSafely(new SpawnedEventArgs(referenceHub));
 
         /// <summary>
         /// Called before a <see cref="API.Features.Player"/> enters the femur breaker.


### PR DESCRIPTION
This PR adds `Spawned` event, it is called **after** player has fully spawned.
The difference between this event `ChangingRole`, and `Spawning` event is, that it is called last, after the player has been safely spawned (after the player's position has been set correctly).

The reason for introducing this event is my attempt to fix the very known bug. The bug is being unable to reliable set player's position after his spawn. The easy fix was adding a delay, but it didn't always worked.

The reason behind the bug is most likely they way a player is spawned - in short, the game tries to sets player's position, waits 0.2 seconds and then checks if it's valid (for example, the player has floor under them). If not, it tries again and again until the 50th time when the game gives up and kills the player with `"Client has failed to spawn."` error.

My theory is that players with higher ping are more likely to have more "attempts" of spawn. This result previously mentioned delay too short, because the base-game coroutine still hasn't finished.  On the other hand, players with better connection sometimes need to wait additional time to be moved by the plugin, which is pointless.

The solution would be calling an event after all base-game stuff have been finished. This is basically `Spawned` event.

`Spawned` event is meant to be used either if:
- The player's spawn properties, their spawn inventory, etc. don't need to be changed.
- The dev wants to directly do `player.Position = something` without adding an unreliable delays and they can't/don't want to use `Position` property inside `Spawning` event.
- Calling event only if the player has been safely spawn. Both `ChangingRole` and `Spawning` are called before spawn checks so it is possible that the player will die, because he wasn't able to spawn for some reason. `Spawned` event will be called **only** if a player has spawned successfully. It won't be called at all if he dies while trying to spawn.

The event uses base-game action event. This means I don't patch any method - no transpiler, no prefix. The event contains only a player getter, because it is called after everything else is done, but again if dev wants to change something they should use an other event.