### PR TITLE
Door.LockAll

### DIFF
--- a/Exiled.API/Features/Door.cs
+++ b/Exiled.API/Features/Door.cs
@@ -269,7 +269,7 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="duration">The duration of the lockdown.</param>
         /// <param name="zoneType">The <see cref="ZoneType"/> to affect.</param>
-        /// <param name="lockType">DoorLockType of the lockdown.</param>
+        /// <param name="lockType">The specified <see cref="DoorLockType"/>.</param>
         public static void LockAll(float duration, ZoneType zoneType = ZoneType.Unspecified, DoorLockType lockType = DoorLockType.Regular079)
         {
             foreach (Door door in Get(door => zoneType is not ZoneType.Unspecified && door.Zone == zoneType))
@@ -285,7 +285,7 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="duration">The duration of the lockdown.</param>
         /// <param name="zoneTypes">The <see cref="ZoneType"/>s to affect.</param>
-        /// <param name="lockType">DoorLockType of the lockdown.</param>
+        /// <param name="lockType">The specified <see cref="DoorLockType"/>.</param>
         public static void LockAll(float duration, IEnumerable<ZoneType> zoneTypes, DoorLockType lockType = DoorLockType.Regular079)
         {
             foreach (ZoneType zone in zoneTypes)
@@ -296,7 +296,7 @@ namespace Exiled.API.Features
         /// Locks all <see cref="Door">doors</see> in the facility.
         /// </summary>
         /// <param name="duration">The duration of the lockdown.</param>
-        /// <param name="lockType"><see cref="DoorLockType"/>.</param>
+        /// <param name="lockType">The specified <see cref="DoorLockType"/>.</param>
         public static void LockAll(float duration, DoorLockType lockType = DoorLockType.Regular079)
         {
             foreach (Door door in Door.List)

--- a/Exiled.API/Features/Door.cs
+++ b/Exiled.API/Features/Door.cs
@@ -264,7 +264,7 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Locks all <see cref="Door">doors</see> in the facility.
+        /// Locks all <see cref="Door">doors</see> for a given <see cref="ZoneType">zone</see>.
         /// </summary>
         /// <param name="duration">The duration of the lockdown.</param>
         /// <param name="zoneType">The <see cref="ZoneType"/> to affect.</param>
@@ -280,7 +280,7 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Locks all <see cref="Door">doors</see> in the facility.
+        /// Locks all <see cref="Door">doors</see> for a given <see cref="ZoneType">zones</see>.
         /// </summary>
         /// <param name="duration">The duration of the lockdown.</param>
         /// <param name="zoneTypes">The <see cref="ZoneType"/>s to affect.</param>
@@ -289,6 +289,21 @@ namespace Exiled.API.Features
         {
             foreach (ZoneType zone in zoneTypes)
                 LockAll(duration, zone, lockType);
+        }
+
+        /// <summary>
+        /// Locks all <see cref="Door">doors</see> in the facility.
+        /// </summary>
+        /// <param name="duration">The duration of the lockdown.</param>
+        /// <param name="lockType">DoorLockType of the lockdown.</param>
+        public static void LockAll(float duration, DoorLockType lockType = DoorLockType.Regular079)
+        {
+            foreach (Door door in Door.List)
+            {
+                door.IsOpen = false;
+                door.ChangeLock(lockType);
+                MEC.Timing.CallDelayed(duration, () => door.ChangeLock(DoorLockType.None));
+            }
         }
 
         /// <summary>

--- a/Exiled.API/Features/Door.cs
+++ b/Exiled.API/Features/Door.cs
@@ -18,6 +18,7 @@ namespace Exiled.API.Features
     using Interactables.Interobjects;
     using Interactables.Interobjects.DoorUtils;
 
+    using MEC;
     using Mirror;
 
     using UnityEngine;
@@ -264,7 +265,7 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Locks all <see cref="Door">doors</see> for a given <see cref="ZoneType">zone</see>.
+        /// Locks all <see cref="Door">doors</see> given the specified <see cref="ZoneType"/>.
         /// </summary>
         /// <param name="duration">The duration of the lockdown.</param>
         /// <param name="zoneType">The <see cref="ZoneType"/> to affect.</param>
@@ -275,12 +276,12 @@ namespace Exiled.API.Features
             {
                 door.IsOpen = false;
                 door.ChangeLock(lockType);
-                MEC.Timing.CallDelayed(duration, () => door.ChangeLock(DoorLockType.None));
+                Timing.CallDelayed(duration, () => door.ChangeLock(DoorLockType.None));
             }
         }
 
         /// <summary>
-        /// Locks all <see cref="Door">doors</see> for a given <see cref="ZoneType">zones</see>.
+        /// Locks all <see cref="Door">doors</see> given the specified <see cref="ZoneType"/>.
         /// </summary>
         /// <param name="duration">The duration of the lockdown.</param>
         /// <param name="zoneTypes">The <see cref="ZoneType"/>s to affect.</param>
@@ -295,14 +296,14 @@ namespace Exiled.API.Features
         /// Locks all <see cref="Door">doors</see> in the facility.
         /// </summary>
         /// <param name="duration">The duration of the lockdown.</param>
-        /// <param name="lockType">DoorLockType of the lockdown.</param>
+        /// <param name="lockType"><see cref="DoorLockType"/>.</param>
         public static void LockAll(float duration, DoorLockType lockType = DoorLockType.Regular079)
         {
             foreach (Door door in Door.List)
             {
                 door.IsOpen = false;
                 door.ChangeLock(lockType);
-                MEC.Timing.CallDelayed(duration, () => door.ChangeLock(DoorLockType.None));
+                Timing.CallDelayed(duration, () => door.ChangeLock(DoorLockType.None));
             }
         }
 


### PR DESCRIPTION
Add an overload that only takes duration and lock type allowing _actual lock all doors_.

Changed some docs due to they don't consistent with what they do