### PR TITLE
OnExplodingGrenade Fix

### DIFF
--- a/Exiled.Events/Patches/Events/Map/ExplodingFragGrenade.cs
+++ b/Exiled.Events/Patches/Events/Map/ExplodingFragGrenade.cs
@@ -69,9 +69,8 @@ namespace Exiled.Events.Patches.Events.Map
 
             newInstructions.InsertRange(index, new CodeInstruction[]
             {
-                // Player.Get(this.PreviousOwner);
-                new(OpCodes.Ldarg_2),
-                new(OpCodes.Ldfld, Field(typeof(ExplosionGrenade), nameof(ExplosionGrenade.PreviousOwner))),
+                // Player.Get(attacker);
+                new(OpCodes.Ldarg_0),
                 new(OpCodes.Ldfld, Field(typeof(Footprint), nameof(Footprint.Hub))),
                 new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
 


### PR DESCRIPTION
Fix when candy or Disruptor make an explosion it's have always say it's Server.Host instead of the attacker