### PR TITLE
BugFix, Call PlayerStatsSystem when setting FriendlyFire.

### DIFF
--- a/Exiled.API/Features/Server.cs
+++ b/Exiled.API/Features/Server.cs
@@ -90,6 +90,7 @@ namespace Exiled.API.Features
             {
                 ServerConsole.FriendlyFire = value;
                 ServerConfigSynchronizer.Singleton.RefreshMainBools();
+                PlayerStatsSystem.AttackerDamageHandler.RefreshConfigs();
             }
         }
 


### PR DESCRIPTION
Call PlayerStatsSystem RefreshConfigs to reset FF multiplier. 