### PR TITLE
`Exiled::CustomItems` new features

### DIFF
--- a/Exiled.API/Features/Items/Armor.cs
+++ b/Exiled.API/Features/Items/Armor.cs
@@ -156,33 +156,19 @@ namespace Exiled.API.Features.Items
         /// </summary>
         public IEnumerable<ArmorAmmoLimit> AmmoLimits
         {
-            get
-            {
-                List<ArmorAmmoLimit> limits = new();
-                for (int i = 0; i < Base.AmmoLimits.Length; i++)
-                {
-                    limits.Add(new ArmorAmmoLimit(Base.AmmoLimits[i].AmmoType.GetAmmoType(), Base.AmmoLimits[i].Limit));
-                }
+            get => Base.AmmoLimits.Cast<ArmorAmmoLimit>();
 
-                return limits;
-            }
+            set => Base.AmmoLimits = value.Select(limit => (BodyArmor.ArmorAmmoLimit)limit).ToArray();
+        }
 
-            set
-            {
-                List<BodyArmor.ArmorAmmoLimit> limits = ListPool<BodyArmor.ArmorAmmoLimit>.Shared.Rent();
-                for (int i = 0; i < value.Count(); i++)
-                {
-                    ArmorAmmoLimit limit = value.ElementAt(i);
-                    limits.Add(new BodyArmor.ArmorAmmoLimit
-                    {
-                        AmmoType = limit.AmmoType.GetItemType(),
-                        Limit = limit.Limit,
-                    });
-                }
+        /// <summary>
+        /// Gets or sets the item caterory limit of the wearer when using this armor.
+        /// </summary>
+        public IEnumerable<BodyArmor.ArmorCategoryLimitModifier> CategoryLimits
+        {
+            get => Base.CategoryLimits;
 
-                Base.AmmoLimits = limits.ToArray();
-                ListPool<BodyArmor.ArmorAmmoLimit>.Shared.Return(limits);
-            }
+            set => Base.CategoryLimits = value.ToArray();
         }
     }
 }

--- a/Exiled.API/Features/Items/Armor.cs
+++ b/Exiled.API/Features/Items/Armor.cs
@@ -89,7 +89,7 @@ namespace Exiled.API.Features.Items
             get => Base.HelmetEfficacy;
             set
             {
-                if (value <= 101 && value >= 0)
+                if (value is <= 101 and >= 0)
                     Base.HelmetEfficacy = value;
                 else
                     throw new ArgumentOutOfRangeException(nameof(HelmetEfficacy), "You can only set the efficacy value of armor to a value between 0 and 100.");
@@ -105,7 +105,7 @@ namespace Exiled.API.Features.Items
             get => Base.VestEfficacy;
             set
             {
-                if (value <= 101 && value >= 0)
+                if (value is <= 101 and >= 0)
                     Base.VestEfficacy = value;
                 else
                     throw new ArgumentOutOfRangeException(nameof(VestEfficacy), "You can only set the efficacy value of armor to a value between 0 and 100.");
@@ -121,7 +121,7 @@ namespace Exiled.API.Features.Items
             get => Base.StaminaUseMultiplier;
             set
             {
-                if (value > 2f || value < 1f)
+                if (value is > 2f or < 1f)
                     throw new ArgumentOutOfRangeException(nameof(StaminaUseMultiplier), "You can only set the stamina use multiplier to a value between 1f and 2f.");
                 Base.StaminaUseMultiplier = value;
             }
@@ -136,7 +136,7 @@ namespace Exiled.API.Features.Items
             get => Base.MovementSpeedMultiplier;
             set
             {
-                if (value < 0.0f || value > 1f)
+                if (value is < 0.0f or > 1f)
                     throw new ArgumentOutOfRangeException(nameof(MovementSpeedMultiplier), "You can only set the movement speed multiplier to a value between 0 and 1.");
                 Base.MovementSpeedMultiplier = value;
             }

--- a/Exiled.API/Structs/ArmorAmmoLimit.cs
+++ b/Exiled.API/Structs/ArmorAmmoLimit.cs
@@ -8,6 +8,9 @@
 namespace Exiled.API.Structs
 {
     using Exiled.API.Enums;
+    using Exiled.API.Extensions;
+
+    using InventorySystem.Items.Armor;
 
     /// <summary>
     /// The limit of a certain <see cref="Enums.AmmoType"/> when wearing a piece of armor.
@@ -33,6 +36,24 @@ namespace Exiled.API.Structs
         {
             AmmoType = type;
             Limit = limit;
+        }
+
+        /// <summary>
+        /// Converts a base game <see cref="BodyArmor.ArmorAmmoLimit"/> to its appropriate <see cref="ArmorAmmoLimit"/>.
+        /// </summary>
+        /// <param name="armorLimit">Base game armor limit.</param>
+        public static implicit operator ArmorAmmoLimit(BodyArmor.ArmorAmmoLimit armorLimit)
+        {
+            return new ArmorAmmoLimit(armorLimit.AmmoType.GetAmmoType(), armorLimit.Limit);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="ArmorAmmoLimit"/> to its appropriate base game <see cref="BodyArmor.ArmorAmmoLimit"/>.
+        /// </summary>
+        /// <param name="armorLimit">armor limit.</param>
+        public static explicit operator BodyArmor.ArmorAmmoLimit(ArmorAmmoLimit armorLimit)
+        {
+            return new BodyArmor.ArmorAmmoLimit { AmmoType = armorLimit.AmmoType.GetItemType(), Limit = armorLimit.Limit };
         }
     }
 }

--- a/Exiled.API/Structs/ArmorAmmoLimit.cs
+++ b/Exiled.API/Structs/ArmorAmmoLimit.cs
@@ -42,18 +42,14 @@ namespace Exiled.API.Structs
         /// Converts a base game <see cref="BodyArmor.ArmorAmmoLimit"/> to its appropriate <see cref="ArmorAmmoLimit"/>.
         /// </summary>
         /// <param name="armorLimit">Base game armor limit.</param>
-        public static implicit operator ArmorAmmoLimit(BodyArmor.ArmorAmmoLimit armorLimit)
-        {
-            return new ArmorAmmoLimit(armorLimit.AmmoType.GetAmmoType(), armorLimit.Limit);
-        }
+        public static implicit operator ArmorAmmoLimit(BodyArmor.ArmorAmmoLimit armorLimit) =>
+            new ArmorAmmoLimit(armorLimit.AmmoType.GetAmmoType(), armorLimit.Limit);
 
         /// <summary>
         /// Converts a <see cref="ArmorAmmoLimit"/> to its appropriate base game <see cref="BodyArmor.ArmorAmmoLimit"/>.
         /// </summary>
         /// <param name="armorLimit">armor limit.</param>
-        public static explicit operator BodyArmor.ArmorAmmoLimit(ArmorAmmoLimit armorLimit)
-        {
-            return new BodyArmor.ArmorAmmoLimit { AmmoType = armorLimit.AmmoType.GetItemType(), Limit = armorLimit.Limit };
-        }
+        public static explicit operator BodyArmor.ArmorAmmoLimit(ArmorAmmoLimit armorLimit) =>
+            new BodyArmor.ArmorAmmoLimit { AmmoType = armorLimit.AmmoType.GetItemType(), Limit = armorLimit.Limit };
     }
 }

--- a/Exiled.CustomItems/API/Features/CustomArmor.cs
+++ b/Exiled.CustomItems/API/Features/CustomArmor.cs
@@ -1,0 +1,134 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="CustomArmor.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.CustomItems.API.Features
+{
+    using System;
+    using System.ComponentModel;
+
+    using Exiled.API.Extensions;
+    using Exiled.API.Features;
+    using Exiled.API.Features.Items;
+    using Exiled.Events.EventArgs;
+
+    using MEC;
+
+    /// <summary>
+    /// The Custom Armor base class.
+    /// </summary>
+    public abstract class CustomArmor : CustomItem
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="ItemType"/> to use for this armor.
+        /// </summary>
+        public override ItemType Type
+        {
+            get => base.Type;
+            set
+            {
+                if (!value.IsArmor() && value != ItemType.None)
+                    throw new ArgumentOutOfRangeException("Type", value, "Invalid armor type.");
+
+                base.Type = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Weight of the armor.
+        /// </summary>
+        public virtual float ArmorWeight { get; set; } = 5.5f;
+
+        /// <summary>
+        /// Gets or sets how much faster stamina will drain when wearing this armor.
+        /// </summary>
+        [Description("The value must be above 1 and below 2")]
+        public virtual float StaminaUseMultiplier { get; set; } = 1.15f;
+
+        /// <summary>
+        /// Gets or sets how strong the helmet on the armor is.
+        /// </summary>
+        [Description("The value must be above 0 and below 100")]
+        public virtual int HelmetEfficacy { get; set; } = 80;
+
+        /// <summary>
+        /// Gets or sets how strong the vest on the armor is.
+        /// </summary>
+        [Description("The value must be above 0 and below 100")]
+        public virtual int VestEfficacy { get; set; } = 80;
+
+        /// <summary>
+        /// Gets or sets how much the players movement speed should be affected when wearing this armor. (higher values = slower movement).
+        /// </summary>
+        [Description("The value must be above 0 and below 1")]
+        public virtual float MovementSpeedMultiplier { get; set; } = 0.95f;
+
+        /// <summary>
+        /// Gets or sets how much worse <see cref="RoleType.ClassD"/> and <see cref="RoleType.Scientist"/>s are affected by wearing this armor.
+        /// </summary>
+        public virtual float CivilianDownsideMultiplier { get; set; } = 2f;
+
+        /// <inheritdoc />
+        public override void Give(Player player, bool displayMessage = true)
+        {
+            Item item = Item.Create(Type);
+
+            if (item is Armor armor)
+            {
+                armor.Weight = ArmorWeight;
+
+                armor.StaminaUseMultiplier = StaminaUseMultiplier;
+
+                armor.CivilianDownsideMultiplier = CivilianDownsideMultiplier;
+                armor.MovementSpeedMultiplier = MovementSpeedMultiplier;
+
+                armor.VestEfficacy = VestEfficacy;
+                armor.HelmetEfficacy = HelmetEfficacy;
+            }
+
+            player.AddItem(item);
+
+            TrackedSerials.Add(item.Serial);
+
+            Timing.CallDelayed(0.05f, () => OnAcquired(player));
+
+            if(displayMessage)
+                ShowPickedUpMessage(player);
+        }
+
+        /// <inheritdoc/>
+        protected override void SubscribeEvents()
+        {
+            Events.Handlers.Player.PickingUpArmor += OnInternalPickingUpArmor;
+            base.SubscribeEvents();
+        }
+
+        /// <inheritdoc/>
+        protected override void UnsubscribeEvents()
+        {
+            Events.Handlers.Player.PickingUpArmor -= OnInternalPickingUpArmor;
+            base.UnsubscribeEvents();
+        }
+
+        private void OnInternalPickingUpArmor(PickingUpArmorEventArgs ev)
+        {
+            if (!Check(ev.Pickup) || ev.Player.Items.Count >= 8)
+                return;
+
+            OnPickingUp(ev);
+
+            if (!ev.IsAllowed)
+                return;
+
+            ev.IsAllowed = false;
+
+            TrackedSerials.Remove(ev.Pickup.Serial);
+            ev.Pickup.Destroy();
+
+            Give(ev.Player);
+        }
+    }
+}

--- a/Exiled.CustomItems/API/Features/CustomArmor.cs
+++ b/Exiled.CustomItems/API/Features/CustomArmor.cs
@@ -38,11 +38,6 @@ namespace Exiled.CustomItems.API.Features
         }
 
         /// <summary>
-        /// Gets or sets the Weight of the armor.
-        /// </summary>
-        public virtual float ArmorWeight { get; set; } = 5.5f;
-
-        /// <summary>
         /// Gets or sets how much faster stamina will drain when wearing this armor.
         /// </summary>
         [Description("The value must be above 1 and below 2")]
@@ -60,38 +55,20 @@ namespace Exiled.CustomItems.API.Features
         [Description("The value must be above 0 and below 100")]
         public virtual int VestEfficacy { get; set; } = 80;
 
-        /// <summary>
-        /// Gets or sets how much the players movement speed should be affected when wearing this armor. (higher values = slower movement).
-        /// </summary>
-        [Description("The value must be above 0 and below 1")]
-        public virtual float MovementSpeedMultiplier { get; set; } = 0.95f;
-
-        /// <summary>
-        /// Gets or sets how much worse <see cref="RoleType.ClassD"/> and <see cref="RoleType.Scientist"/>s are affected by wearing this armor.
-        /// </summary>
-        public virtual float CivilianDownsideMultiplier { get; set; } = 2f;
-
         /// <inheritdoc />
         public override void Give(Player player, bool displayMessage = true)
         {
-            Item item = Item.Create(Type);
+            Armor armor = (Armor)Item.Create(Type);
 
-            if (item is Armor armor)
-            {
-                armor.Weight = ArmorWeight;
+            armor.Weight = Weight;
+            armor.StaminaUseMultiplier = StaminaUseMultiplier;
 
-                armor.StaminaUseMultiplier = StaminaUseMultiplier;
+            armor.VestEfficacy = VestEfficacy;
+            armor.HelmetEfficacy = HelmetEfficacy;
 
-                armor.CivilianDownsideMultiplier = CivilianDownsideMultiplier;
-                armor.MovementSpeedMultiplier = MovementSpeedMultiplier;
+            player.AddItem(armor);
 
-                armor.VestEfficacy = VestEfficacy;
-                armor.HelmetEfficacy = HelmetEfficacy;
-            }
-
-            player.AddItem(item);
-
-            TrackedSerials.Add(item.Serial);
+            TrackedSerials.Add(armor.Serial);
 
             Timing.CallDelayed(0.05f, () => OnAcquired(player));
 

--- a/Exiled.CustomItems/API/Features/CustomGrenade.cs
+++ b/Exiled.CustomItems/API/Features/CustomGrenade.cs
@@ -30,7 +30,9 @@ namespace Exiled.CustomItems.API.Features
 
     using YamlDotNet.Serialization;
 
-    /// <inheritdoc />
+    /// <summary>
+    /// The Custom Grenade base class.
+    /// </summary>
     public abstract class CustomGrenade : CustomItem
     {
         /// <summary>

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -1088,8 +1088,12 @@ namespace Exiled.CustomItems.API.Features
             if (!ev.IsAllowed)
                 return;
 
-            if (!TrackedSerials.Contains(ev.Pickup.Serial))
-                TrackedSerials.Add(ev.Pickup.Serial);
+            ev.IsAllowed = false;
+
+            TrackedSerials.Remove(ev.Pickup.Serial);
+            ev.Pickup.Destroy();
+
+            Give(ev.Player);
 
             Timing.CallDelayed(0.05f, () => OnAcquired(ev.Player));
         }

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -881,7 +881,9 @@ namespace Exiled.CustomItems.API.Features
         /// Handles tracking items when they are picked up by a player.
         /// </summary>
         /// <param name="ev"><see cref="PickingUpItemEventArgs"/>.</param>
-        protected virtual void OnPickingUp(PickingUpItemEventArgs ev) => ShowPickedUpMessage(ev.Player);
+        protected virtual void OnPickingUp(PickingUpItemEventArgs ev)
+        {
+        }
 
         /// <summary>
         /// Handles tracking items when they are selected in the player's inventory.
@@ -906,9 +908,7 @@ namespace Exiled.CustomItems.API.Features
         /// Called anytime the item enters a player's inventory by any means.
         /// </summary>
         /// <param name="player">The <see cref="Player"/> acquiring the item.</param>
-        protected virtual void OnAcquired(Player player)
-        {
-        }
+        protected virtual void OnAcquired(Player player) => ShowPickedUpMessage(player);
 
         /// <summary>
         /// Clears the lists of item uniqIDs and Pickups since any still in the list will be invalid.

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -1088,12 +1088,8 @@ namespace Exiled.CustomItems.API.Features
             if (!ev.IsAllowed)
                 return;
 
-            ev.IsAllowed = false;
-
-            TrackedSerials.Remove(ev.Pickup.Serial);
-            ev.Pickup.Destroy();
-
-            Give(ev.Player);
+            if (!TrackedSerials.Contains(ev.Pickup.Serial))
+                TrackedSerials.Add(ev.Pickup.Serial);
 
             Timing.CallDelayed(0.05f, () => OnAcquired(ev.Player));
         }

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -881,9 +881,7 @@ namespace Exiled.CustomItems.API.Features
         /// Handles tracking items when they are picked up by a player.
         /// </summary>
         /// <param name="ev"><see cref="PickingUpItemEventArgs"/>.</param>
-        protected virtual void OnPickingUp(PickingUpItemEventArgs ev)
-        {
-        }
+        protected virtual void OnPickingUp(PickingUpItemEventArgs ev) => ShowPickedUpMessage(ev.Player);
 
         /// <summary>
         /// Handles tracking items when they are selected in the player's inventory.

--- a/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -133,8 +133,7 @@ namespace Exiled.CustomItems.API.Features
             {
                 if (!Attachments.IsEmpty())
                     firearm.AddAttachment(Attachments);
-                byte ammo = firearm.Ammo;
-                Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawning weapon with {ammo} ammo.", Instance.Config.Debug);
+                Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawning weapon with {ClipSize} ammo.", Instance.Config.Debug);
                 Pickup pickup = firearm.Spawn(position);
 
                 TrackedSerials.Add(pickup.Serial);
@@ -143,7 +142,7 @@ namespace Exiled.CustomItems.API.Features
                 {
                     if (pickup.Base is FirearmPickup firearmPickup)
                     {
-                        firearmPickup.Status = new FirearmStatus(ammo, firearmPickup.Status.Flags, firearmPickup.Status.Attachments);
+                        firearmPickup.Status = new FirearmStatus(ClipSize, firearmPickup.Status.Flags, firearmPickup.Status.Attachments);
                         firearmPickup.NetworkStatus = firearmPickup.Status;
                         Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawned item has: {firearmPickup.Status.Ammo}", Instance.Config.Debug);
                     }
@@ -164,8 +163,7 @@ namespace Exiled.CustomItems.API.Features
             {
                 if (!Attachments.IsEmpty())
                     firearm.AddAttachment(Attachments);
-                byte ammo = firearm.Ammo;
-                Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawning weapon with {ammo} ammo.", Instance.Config.Debug);
+                Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawning weapon with {ClipSize} ammo.", Instance.Config.Debug);
                 Pickup pickup = firearm.Spawn(position);
 
                 if (previousOwner is not null)
@@ -177,7 +175,7 @@ namespace Exiled.CustomItems.API.Features
                 {
                     if (pickup.Base is FirearmPickup firearmPickup)
                     {
-                        firearmPickup.Status = new FirearmStatus(ammo, firearmPickup.Status.Flags, firearmPickup.Status.Attachments);
+                        firearmPickup.Status = new FirearmStatus(ClipSize, firearmPickup.Status.Flags, firearmPickup.Status.Attachments);
                         firearmPickup.NetworkStatus = firearmPickup.Status;
                         Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawned item has: {firearmPickup.Status.Ammo}", Instance.Config.Debug);
                     }

--- a/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -133,7 +133,8 @@ namespace Exiled.CustomItems.API.Features
             {
                 if (!Attachments.IsEmpty())
                     firearm.AddAttachment(Attachments);
-                Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawning weapon with {ClipSize} ammo.", Instance.Config.Debug);
+                byte ammo = firearm.Ammo;
+                Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawning weapon with {ammo} ammo.", Instance.Config.Debug);
                 Pickup pickup = firearm.Spawn(position);
 
                 TrackedSerials.Add(pickup.Serial);
@@ -142,7 +143,7 @@ namespace Exiled.CustomItems.API.Features
                 {
                     if (pickup.Base is FirearmPickup firearmPickup)
                     {
-                        firearmPickup.Status = new FirearmStatus(ClipSize, firearmPickup.Status.Flags, firearmPickup.Status.Attachments);
+                        firearmPickup.Status = new FirearmStatus(ammo, firearmPickup.Status.Flags, firearmPickup.Status.Attachments);
                         firearmPickup.NetworkStatus = firearmPickup.Status;
                         Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawned item has: {firearmPickup.Status.Ammo}", Instance.Config.Debug);
                     }
@@ -163,7 +164,8 @@ namespace Exiled.CustomItems.API.Features
             {
                 if (!Attachments.IsEmpty())
                     firearm.AddAttachment(Attachments);
-                Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawning weapon with {ClipSize} ammo.", Instance.Config.Debug);
+                byte ammo = firearm.Ammo;
+                Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawning weapon with {ammo} ammo.", Instance.Config.Debug);
                 Pickup pickup = firearm.Spawn(position);
 
                 if (previousOwner is not null)
@@ -175,7 +177,7 @@ namespace Exiled.CustomItems.API.Features
                 {
                     if (pickup.Base is FirearmPickup firearmPickup)
                     {
-                        firearmPickup.Status = new FirearmStatus(ClipSize, firearmPickup.Status.Flags, firearmPickup.Status.Attachments);
+                        firearmPickup.Status = new FirearmStatus(ammo, firearmPickup.Status.Flags, firearmPickup.Status.Attachments);
                         firearmPickup.NetworkStatus = firearmPickup.Status;
                         Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawned item has: {firearmPickup.Status.Ammo}", Instance.Config.Debug);
                     }

--- a/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -334,7 +334,6 @@ namespace Exiled.CustomItems.API.Features
         {
             if (ev.Attacker is null)
             {
-                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: Attacker null", Instance.Config.Debug);
                 return;
             }
 

--- a/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -122,6 +122,17 @@ namespace Exiled.CustomItems.API.Features
                 pickup.PreviousOwner = previousOwner;
 
             TrackedSerials.Add(pickup.Serial);
+
+            Timing.CallDelayed(1f, () =>
+            {
+                if (pickup.Base is FirearmPickup firearmPickup)
+                {
+                    firearmPickup.Status = new FirearmStatus(ClipSize, firearmPickup.Status.Flags, firearmPickup.Status.Attachments);
+                    firearmPickup.NetworkStatus = firearmPickup.Status;
+                    Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawned item has: {firearmPickup.Status.Ammo}", Instance.Config.Debug);
+                }
+            });
+
             return pickup;
         }
 

--- a/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -30,7 +30,9 @@ namespace Exiled.CustomItems.API.Features
     using Firearm = Exiled.API.Features.Items.Firearm;
     using Player = Exiled.API.Features.Player;
 
-    /// <inheritdoc />
+    /// <summary>
+    /// The Custom Weapon base class.
+    /// </summary>
     public abstract class CustomWeapon : CustomItem
     {
         /// <summary>


### PR DESCRIPTION
Added:

1. `CustomArmor` class
2. Fix of `CustomItem::OnPickingUp` not shows message and `CustomWeapon` properties are not sets
3. New properties in `Exiled::API::Features::Items::Armor`
4. `ArmorAmmoLimit` cast to basegame type

Questions:

- [x] When `CustomArmor::SubscribeEvents` call, many unnecessary events are registered (like `CustomItem::OnPickingUp`, picking up armor dont call this event)
- [x] In `CustomArmor::OnInternalPickingUpArmor` i calls default `CustomItem::OnPickingUp`, and its working cause `PickingUpArmorEventArgs` inherited for `PickingUpItemEventArgs`, i dont like that, dev bois your words?
- [x] Some things in `CustomArmor` class are make position desync, so i delete it (`MovementSpeedMultiplier` and `CivilianDownsideMultiplier`) (issue #1265)