### PR TITLE
UsingBreakneckSpeeds event

### DIFF
--- a/Exiled.Events/EventArgs/UsingBreakneckSpeedsEventArgs.cs
+++ b/Exiled.Events/EventArgs/UsingBreakneckSpeedsEventArgs.cs
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------
+// <copyright file="UsingBreakneckSpeedsEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+
+    using Exiled.API.Features;
+    using Exiled.API.Features.Items;
+
+    /// <summary>
+    /// Contains all informations before an Scp-173 uses breakneck speeds.
+    /// </summary>
+    public class UsingBreakneckSpeedsEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsingBreakneckSpeedsEventArgs"/> class.
+        /// </summary>
+        /// <param name="player"><inheritdoc cref="Player"/></param>
+        /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
+        public UsingBreakneckSpeedsEventArgs(Player player, bool isAllowed = true)
+        {
+            Player = player;
+            IsAllowed = isAllowed;
+        }
+
+        /// <summary>
+        /// Gets the player who's interacting with SCP-244.
+        /// </summary>
+        public Player Player { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not the player can use breakneck speeds.
+        /// </summary>
+        public bool IsAllowed { get; set; }
+    }
+}

--- a/Exiled.Events/EventArgs/UsingBreakneckSpeedsEventArgs.cs
+++ b/Exiled.Events/EventArgs/UsingBreakneckSpeedsEventArgs.cs
@@ -29,7 +29,7 @@ namespace Exiled.Events.EventArgs
         }
 
         /// <summary>
-        /// Gets the player who's interacting with SCP-244.
+        /// Gets the player who's using breakneck speeds.
         /// </summary>
         public Player Player { get; }
 

--- a/Exiled.Events/Handlers/Scp173.cs
+++ b/Exiled.Events/Handlers/Scp173.cs
@@ -28,6 +28,11 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<PlacingTantrumEventArgs> PlacingTantrum;
 
         /// <summary>
+        /// Invoked before using breakneck speeds.
+        /// </summary>
+        public static event CustomEventHandler<UsingBreakneckSpeedsEventArgs> UsingBreakneckSpeeds;
+
+        /// <summary>
         /// Called before players near SCP-173 blink.
         /// </summary>
         /// <param name="ev">The <see cref="BlinkingEventArgs"/> instance.</param>
@@ -38,5 +43,11 @@ namespace Exiled.Events.Handlers
         /// </summary>
         /// <param name="ev">The <see cref="PlacingTantrumEventArgs"/> instance.</param>
         public static void OnPlacingTantrum(PlacingTantrumEventArgs ev) => PlacingTantrum.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a using breakneck speeds.
+        /// </summary>
+        /// <param name="ev">The <see cref="UsingBreakneckSpeedsEventArgs"/> instance.</param>
+        public static void OnUsingBreakneckSpeeds(UsingBreakneckSpeedsEventArgs ev) => UsingBreakneckSpeeds.InvokeSafely(ev);
     }
 }

--- a/Exiled.Events/Patches/Events/Scp173/UsingBreakneckSpeeds.cs
+++ b/Exiled.Events/Patches/Events/Scp173/UsingBreakneckSpeeds.cs
@@ -1,0 +1,69 @@
+// -----------------------------------------------------------------------
+// <copyright file="UsingBreakneckSpeeds.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Scp173
+{
+#pragma warning disable SA1118
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Reflection.Emit;
+
+    using Exiled.Events.EventArgs;
+
+    using HarmonyLib;
+
+    using NorthwoodLib.Pools;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    /// Patches <see cref="PlayableScps.Scp173.ServerDoBreakneckSpeeds"/>.
+    /// Adds the <see cref="Handlers.Scp173.UsingBreakneckSpeeds"/> event.
+    /// </summary>
+    [HarmonyPatch(typeof(PlayableScps.Scp173), nameof(PlayableScps.Scp173.ServerDoBreakneckSpeeds))]
+    internal static class UsingBreakneckSpeeds
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            Label returnLabel = newInstructions[newInstructions.Count - 1].labels[0];
+
+            int offset = -1;
+
+            int index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Ldfld &&
+            (FieldInfo)instruction.operand == Field(typeof(PlayableScps.Scp173), nameof(PlayableScps.Scp173._breakneckSpeedsCooldownRemaining))) + offset;
+
+            newInstructions.RemoveRange(index, 5);
+
+            newInstructions.InsertRange(index, new CodeInstruction[]
+            {
+                new(OpCodes.Ldarg_0),
+                new(OpCodes.Ldfld, Field(typeof(PlayableScps.Scp173), nameof(PlayableScps.Scp173.Hub))),
+                new(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(ReferenceHub) })),
+
+                new(OpCodes.Ldarg_0),
+                new(OpCodes.Ldfld, Field(typeof(PlayableScps.Scp173), nameof(PlayableScps.Scp173._breakneckSpeedsCooldownRemaining))),
+                new(OpCodes.Ldc_R4, 0f),
+                new(OpCodes.Ceq),
+
+                new(OpCodes.Newobj, GetDeclaredConstructors(typeof(UsingBreakneckSpeedsEventArgs))[0]),
+                new(OpCodes.Dup),
+
+                new(OpCodes.Call, Method(typeof(Handlers.Scp173), nameof(Handlers.Scp173.OnUsingBreakneckSpeeds))),
+
+                new(OpCodes.Callvirt, PropertyGetter(typeof(UsingBreakneckSpeedsEventArgs), nameof(UsingBreakneckSpeedsEventArgs.IsAllowed))),
+                new(OpCodes.Brfalse_S, returnLabel),
+            });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Scp173/UsingBreakneckSpeeds.cs
+++ b/Exiled.Events/Patches/Events/Scp173/UsingBreakneckSpeeds.cs
@@ -40,22 +40,32 @@ namespace Exiled.Events.Patches.Events.Scp173
 
             newInstructions.RemoveRange(index, 5);
 
+            // var ev = new UsingBreakneckSpeedsEventArgs(Player, Scp173._breakneckSpeedsCooldownRemaining == 0);
+            // Handlers.Scp173.OnUsingBreakneckSpeeds(ev);
+            // if (!ev.IsAllowed)
+            //   return;
             newInstructions.InsertRange(index, new CodeInstruction[]
             {
+                // Player.Get(this.Hub)
                 new(OpCodes.Ldarg_0),
                 new(OpCodes.Ldfld, Field(typeof(PlayableScps.Scp173), nameof(PlayableScps.Scp173.Hub))),
                 new(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(ReferenceHub) })),
 
+                // Scp173._breakneckSpeedsCooldownRemaining == 0
                 new(OpCodes.Ldarg_0),
                 new(OpCodes.Ldfld, Field(typeof(PlayableScps.Scp173), nameof(PlayableScps.Scp173._breakneckSpeedsCooldownRemaining))),
                 new(OpCodes.Ldc_R4, 0f),
                 new(OpCodes.Ceq),
 
+                // new UsingBreakneckSpeedsEventArgs(...)
                 new(OpCodes.Newobj, GetDeclaredConstructors(typeof(UsingBreakneckSpeedsEventArgs))[0]),
                 new(OpCodes.Dup),
 
+                // Handlers.Scp173.OnUsingBreakneckSpeeds(ev)
                 new(OpCodes.Call, Method(typeof(Handlers.Scp173), nameof(Handlers.Scp173.OnUsingBreakneckSpeeds))),
 
+                // if (!ev.IsAllowed)
+                //   return;
                 new(OpCodes.Callvirt, PropertyGetter(typeof(UsingBreakneckSpeedsEventArgs), nameof(UsingBreakneckSpeedsEventArgs.IsAllowed))),
                 new(OpCodes.Brfalse_S, returnLabel),
             });


### PR DESCRIPTION
Adds an event to 173 for using breakneck speeds. 

Allows for bypassing the cooldown (i.e. it will fire with `ev.IsAllowed == false` if on cooldown, setting it to true will allow the ability to run regardless of this cooldown).