### PR TITLE
Scp939Role.VisiblePlayers

### DIFF
--- a/Exiled.API/Features/Roles/Scp939Role.cs
+++ b/Exiled.API/Features/Roles/Scp939Role.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Roles
 {
+    using System.Collections.Generic;
+
     using PlayableScps;
 
     /// <summary>
@@ -25,7 +27,7 @@ namespace Exiled.API.Features.Roles
         {
             Owner = player;
             RoleType = scp939Type;
-            script = player.ReferenceHub.scpsController.CurrentScp as Scp939;
+            script = player.CurrentScp as Scp939;
         }
 
         /// <inheritdoc/>
@@ -34,7 +36,7 @@ namespace Exiled.API.Features.Roles
         /// <summary>
         /// Gets the <see cref="Scp939"/> script for this role.
         /// </summary>
-        public Scp939 Script => script ??= Owner.ReferenceHub.scpsController.CurrentScp as Scp939;
+        public Scp939 Script => script ??= Owner.CurrentScp as Scp939;
 
         /// <summary>
         /// Gets or sets the amount of time before SCP-939 can attack again.
@@ -49,6 +51,11 @@ namespace Exiled.API.Features.Roles
         /// Gets SCP-939's move speed.
         /// </summary>
         public float MoveSpeed => Script.GetMovementSpeed();
+
+        /// <summary>
+        /// Gets a list of players this SCP-939 instance can see regardless of their movement.
+        /// </summary>
+        public List<Player> CanSee { get; } = new();
 
         /// <inheritdoc/>
         internal override RoleType RoleType { get; }

--- a/Exiled.API/Features/Roles/Scp939Role.cs
+++ b/Exiled.API/Features/Roles/Scp939Role.cs
@@ -55,7 +55,7 @@ namespace Exiled.API.Features.Roles
         /// <summary>
         /// Gets a list of players this SCP-939 instance can see regardless of their movement.
         /// </summary>
-        public List<Player> CanSee { get; } = new();
+        public List<Player> VisiblePlayers { get; } = new();
 
         /// <inheritdoc/>
         internal override RoleType RoleType { get; }

--- a/Exiled.Events/Patches/Generic/GhostMode.cs
+++ b/Exiled.Events/Patches/Generic/GhostMode.cs
@@ -87,7 +87,7 @@ namespace Exiled.Events.Patches.Generic
                             {
                                 Player player2 = Player.Get(__instance._transmitBuffer[index].playerID);
 
-                                if (scp939Role.CanSee.Contains(player2))
+                                if (scp939Role.VisiblePlayers.Contains(player2))
                                     continue;
 
                                 if (player2.Role.Team != Team.SCP

--- a/Exiled.Events/Patches/Generic/GhostMode.cs
+++ b/Exiled.Events/Patches/Generic/GhostMode.cs
@@ -17,6 +17,7 @@ namespace Exiled.Events.Patches.Generic
     using CustomPlayerEffects;
 
     using Exiled.API.Features;
+    using Exiled.API.Features.Roles;
 
     using HarmonyLib;
 
@@ -78,17 +79,20 @@ namespace Exiled.Events.Patches.Generic
 
                     Array.Copy(__instance.ReceivedData, __instance._transmitBuffer, __instance._usedData);
 
-                    if (player.Role.Type.Is939())
+                    if (player.Role is Scp939Role scp939Role)
                     {
                         for (int index = 0; index < __instance._usedData; ++index)
                         {
                             if (__instance._transmitBuffer[index].position.y < 800f)
                             {
-                                ReferenceHub hub2 = ReferenceHub.GetHub(__instance._transmitBuffer[index].playerID);
+                                Player player2 = Player.Get(__instance._transmitBuffer[index].playerID);
 
-                                if (hub2.characterClassManager.CurRole.team != Team.SCP
-                                    && hub2.characterClassManager.CurRole.team != Team.RIP
-                                    && !hub2
+                                if (scp939Role.CanSee.Contains(player2))
+                                    continue;
+
+                                if (player2.Role.Team != Team.SCP
+                                    && player2.Role.Team != Team.RIP
+                                    && !player2.ReferenceHub
                                         .GetComponent<Scp939_VisionController>()
                                         .CanSee(player.ReferenceHub.playerEffectsController.GetEffect<Visuals939>()))
                                 {


### PR DESCRIPTION
Basically forces 939 to be able to see players in the list. I would do this in a separate plugin, however, the existence of the `TransmitData` patch in exiled makes that almost impossible to do without breaking something, so I figured this would be the best approach.