### PR TITLE
Bug fix ff prefix

### DIFF
--- a/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
+++ b/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
@@ -80,7 +80,7 @@ namespace Exiled.Events.Patches.Generic
         {
             ffMultiplier = 1f;
 
-            // Return false, no custom friendly fire allowed, default to NW logic for FF.
+            // Return false, no custom friendly fire allowed, default to NW logic for FF. No point in processing if FF is enabled across the board.
             if (Server.FriendlyFire)
                 return false;
 

--- a/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
+++ b/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
@@ -62,6 +62,17 @@ namespace Exiled.Events.Patches.Generic
         /// </summary>
         /// <param name="attackerHub">The person attacking.</param>
         /// <param name="victimHub">The person being attacked.</param>
+        /// <returns>True if the attacker can damage the victim.</returns>
+        public static bool CheckFriendlyFirePlayerHitbox(ReferenceHub attackerHub, ReferenceHub victimHub)
+        {
+            return Server.FriendlyFire || CheckFriendlyFirePlayerRules(attackerHub, victimHub, out _);
+        }
+
+        /// <summary>
+        /// Checks if there can be damage between two players, according to the FF rules.
+        /// </summary>
+        /// <param name="attackerHub">The person attacking.</param>
+        /// <param name="victimHub">The person being attacked.</param>
         /// <param name="ffMultiplier"> FF multiplier. </param>
         /// <returns> True if the attacker can damage the victim.</returns>
         /// <remarks> Friendly fire multiplier is also provided back if needed. </remarks>
@@ -157,7 +168,7 @@ namespace Exiled.Events.Patches.Generic
         {
             try
             {
-                __result = IndividualFriendlyFire.CheckFriendlyFirePlayer(attacker, victim);
+                __result = IndividualFriendlyFire.CheckFriendlyFirePlayerHitbox(attacker, victim);
 
                 return false;
             }

--- a/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
+++ b/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
@@ -168,8 +168,13 @@ namespace Exiled.Events.Patches.Generic
         {
             try
             {
-                __result = IndividualFriendlyFire.CheckFriendlyFirePlayerHitbox(attacker, victim);
+                bool currentResult = IndividualFriendlyFire.CheckFriendlyFirePlayerHitbox(attacker, victim);
+                if(!currentResult)
+                {
+                    return true;
+                }
 
+                __result = currentResult;
                 return false;
             }
             catch (Exception e)


### PR DESCRIPTION
@steven4547466 Again, sorry - Anyway, this should resolve the Micro.Fire issue (as it calls HitboxIdentifier.CheckFriendlyFire) which was that its logic path was different than transpiler's.

1. Prefix originally (The design before I touched) did not handle if the FriendlyFireCheck returning false, in which it should of called base game FriendlyFire (Which would of returned true) (likely why https://discord.com/channels/656673194693885975/933781456172486686 existed)
2. Prefix modified did not handle the Server.FriendlyFire path correctly, nor did it handle the return false because the code was modified for a transpiler approach, rather than the prefix. In addition, the biggest problem being # 1 -> This meant that it would always take the IDestructible path because the original prefix code did.

This fix is to customize a hitbox function that handles the fact CheckFriendlyFirePlayerRules will return a false (If server.FriendlyFire is true) which is correct for a transpiler, but wrong for a prefix (since branching is different). Therefore,

Server.FriendlyFire || CheckFriendlyFirePlayerRules allows it to always be true or false depending on the scenario, 

if Server.FriendlyFire is true, doesn't matter what CheckFriendlyFirePlayerRules states
if Server.FriendlyFire is false, CheckFriendlyFirePlayerRules states whether its allowed or not

Thereafter in the prefix, if we get a true, we do not run NW FF logic, and return true - otherwise, run NW ff logic. (This being the biggest problem of them all - see https://github.com/Exiled-Team/EXILED/blob/249197a57e82c88051cc71ca8c3fa36f1bf420b4/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs for original)

![image](https://user-images.githubusercontent.com/24619207/172011739-5e69959c-626e-4344-847d-604a206ee7e1.png)

_If you dislike the format of the prefix, I can change it, it's just my personal preference to split things up, it can be reduced to

```
__result = IndividualFriendlyFire.CheckFriendlyFirePlayerHitbox(attacker, victim);
                if(!__result)
                    return true;
                return false;
``` 

but I have no trust in __result being updated correctly after the return true so I stored it in local variable. If this is not preferable, I can copy paste what I wrote above 