### PR TITLE
`Player::UnloadingWeapon` fix

### DIFF
--- a/Exiled.Events/Patches/Events/Player/FirearmRequestReceived.cs
+++ b/Exiled.Events/Patches/Events/Player/FirearmRequestReceived.cs
@@ -59,7 +59,7 @@ namespace Exiled.Events.Patches.Events.Player
                 new(OpCodes.Brfalse, returnLabel),
             });
 
-            offset = 2;
+            offset = -2;
             index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Callvirt &&
             (MethodInfo)instruction.operand == Method(typeof(IAmmoManagerModule), nameof(IAmmoManagerModule.ServerTryUnload))) + offset;
 


### PR DESCRIPTION
basegame code:
```cs
if (!curInstance6.AmmoManagerModule.ServerTryUnload())
    break;
conn.Send<RequestMessage>(new RequestMessage(msg.Serial, RequestType.Unload));
```
Exiled code was inserted after `ServerTryUnload()`, and `IsAllowed = false` only canceled animation, now Exiled code inserted before `ServerTryUnload()` method