### PR TITLE
CustomRole to CustomRole friendly fire damage extenstion (See discord link as to why)

### DIFF
--- a/Exiled.API/Features/FriendlyFireStatusCode.cs
+++ b/Exiled.API/Features/FriendlyFireStatusCode.cs
@@ -5,10 +5,12 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Exiled.API.Features
+namespace Exiled.API.Enums
 {
+    using Exiled.API.Features;
+
     /// <summary>
-    /// Status code for adding FriendlyFire rules.
+    /// Status code for adding FriendlyFire rules. <seealso cref="Player.FriendlyFireMultiplier"/>
     /// </summary>
     public enum FriendlyFireStatusCode
     {

--- a/Exiled.API/Features/FriendlyFireStatusCode.cs
+++ b/Exiled.API/Features/FriendlyFireStatusCode.cs
@@ -18,18 +18,13 @@ namespace Exiled.API.Features
         UnableToAdd,
 
         /// <summary>
-        /// Current role successfully added
-        /// </summary>
-        AddedRole,
-
-        /// <summary>
         /// Partial roles were added, cannot guarantee all.
         /// </summary>
-        AddedSomeRoles,
+        PartialSuccess,
 
         /// <summary>
         /// All roles were successfully added
         /// </summary>
-        AddedAllRoles,
+        Success,
     }
 }

--- a/Exiled.API/Features/FriendlyFireStatusCode.cs
+++ b/Exiled.API/Features/FriendlyFireStatusCode.cs
@@ -1,0 +1,35 @@
+// -----------------------------------------------------------------------
+// <copyright file="FriendlyFireStatusCode.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Features
+{
+    /// <summary>
+    /// Status code for adding FriendlyFire rules.
+    /// </summary>
+    public enum FriendlyFireStatusCode
+    {
+        /// <summary>
+        /// Adding specific role failed, unable to be added.
+        /// </summary>
+        UnableToAdd,
+
+        /// <summary>
+        /// Current role successfully added
+        /// </summary>
+        AddedRole,
+
+        /// <summary>
+        /// Partial roles were added, cannot guarantee all.
+        /// </summary>
+        AddedSomeRoles,
+
+        /// <summary>
+        /// All roles were successfully added
+        /// </summary>
+        AddedAllRoles,
+    }
+}

--- a/Exiled.API/Features/FriendlyFireStatusCode.cs
+++ b/Exiled.API/Features/FriendlyFireStatusCode.cs
@@ -10,8 +10,11 @@ namespace Exiled.API.Enums
     using Exiled.API.Features;
 
     /// <summary>
-    /// Status code for adding FriendlyFire rules. <seealso cref="Player.FriendlyFireMultiplier"/>
+    /// Status code for adding FriendlyFire rules.
     /// </summary>
+    /// <seealso cref="Player.FriendlyFireMultiplier"/>
+    /// <seealso cref="Player.CustomRoleFriendlyFireMultiplier"/>
+    /// <seealso cref="Player.CustomRoleToCustomRoleFriendlyFireMultiplier"/>
     public enum FriendlyFireStatusCode
     {
         /// <summary>

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -649,15 +649,13 @@ namespace Exiled.API.Features
         /// This player can be damaged by other players on their own team even if this property is <see langword="false"/> due to other player friendly fire rules.
         /// If you directly assign this to true, then <see cref="AlwaysDealsFriendlyFireDamage"/> will be assigned to such. Meaning this player
         /// will be able to do damage to anyone. Only set this if you are 100% certain that is the behavior you want, otherwise,
-        /// customize your damage using <see cref="FriendlyFireMultiplier"/>, <see cref="CustomRoleFriendlyFireMultiplier"/>, and <see cref="CustomRoleToCustomRoleFriendlyFireMultiplier"/>
+        /// customize your damage using <see cref="FriendlyFireMultiplier"/>, <see cref="CustomRoleFriendlyFireMultiplier"/>, and <see cref="CustomRoleToCustomRoleFriendlyFireMultiplier"/>.
         /// </summary>
         public bool IsFriendlyFireEnabled
         {
-            get => FriendlyFireMultiplier.Count > 0 || CustomRoleFriendlyFireMultiplier.Count > 0;
-            [Obsolete("Use SetFriendlyFire instead.", true)]
-            set
+            get
             {
-                return this.FriendlyFireMultiplier.Count > 0 || this.CustomRoleFriendlyFireMultiplier.Count > 0;
+                return this.FriendlyFireMultiplier.Count > 0 || this.CustomRoleFriendlyFireMultiplier.Count > 0 || this.CustomRoleToCustomRoleFriendlyFireMultiplier.Count > 0 || this.AlwaysDealsFriendlyFireDamage;
             }
 
             set
@@ -1403,7 +1401,7 @@ namespace Exiled.API.Features
         /// <param name="ffRules"> Roles to add with friendly fire values. </param>
         /// <param name="overwrite"> Whether to overwrite current values if they exist. </param>
         /// <returns> Whether the item was able to be added. </returns>
-        public bool TryAddFriendlyFire(Dictionary<RoleType, float> ffRules, bool overwrite = false)
+        public FriendlyFireStatusCode TryAddFriendlyFire(Dictionary<RoleType, float> ffRules, bool overwrite = false)
         {
             Dictionary<RoleType, float> temporaryFriendlyFireRules = new();
             bool partialRoleAddition = false;
@@ -1440,6 +1438,10 @@ namespace Exiled.API.Features
             if(partialRoleAddition && atLeastOneAdded)
             {
                 return FriendlyFireStatusCode.PartialSuccess;
+            }
+            else if (!partialRoleAddition && !atLeastOneAdded)
+            {
+                return FriendlyFireStatusCode.UnableToAdd;
             }
 
             return FriendlyFireStatusCode.Success;
@@ -1488,7 +1490,7 @@ namespace Exiled.API.Features
         /// <param name="roleType"> Role associated for CustomFF. </param>
         /// <param name="roleFF"> Role to add and FF multiplier. </param>
         /// <returns> Whether the item was able to be added. </returns>
-        public bool TryAddCustomRoleFriendlyFire(string roleType, KeyValuePair<RoleType, float> roleFF)
+        public FriendlyFireStatusCode TryAddCustomRoleFriendlyFire(string roleType, KeyValuePair<RoleType, float> roleFF)
         {
             return TryAddCustomRoleFriendlyFire(roleType, roleFF.Key, roleFF.Value);
         }
@@ -1565,6 +1567,10 @@ namespace Exiled.API.Features
                 if (partialRoleAddition && atLeastOneAdded)
                 {
                     return FriendlyFireStatusCode.PartialSuccess;
+                }
+                else if (!partialRoleAddition && !atLeastOneAdded)
+                {
+                    return FriendlyFireStatusCode.UnableToAdd;
                 }
             }
             else
@@ -1756,6 +1762,10 @@ namespace Exiled.API.Features
                 if(partialRoleAddition && atLeastOneAdded)
                 {
                     return FriendlyFireStatusCode.PartialSuccess;
+                }
+                else if(!partialRoleAddition && !atLeastOneAdded)
+                {
+                    return FriendlyFireStatusCode.UnableToAdd;
                 }
             }
             else

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1242,7 +1242,7 @@ namespace Exiled.API.Features
             }
 
             FriendlyFireMultiplier.Add(roleToAdd, ffMult);
-            return FriendlyFireStatusCode.AddedRole;
+            return FriendlyFireStatusCode.Success;
         }
 
         /// <summary>
@@ -1297,10 +1297,10 @@ namespace Exiled.API.Features
 
             if(partialRoleAddition && atLeastOneAdded)
             {
-                return FriendlyFireStatusCode.AddedSomeRoles;
+                return FriendlyFireStatusCode.PartialSuccess;
             }
 
-            return FriendlyFireStatusCode.AddedAllRoles;
+            return FriendlyFireStatusCode.Success;
         }
 
         /// <summary>
@@ -1374,7 +1374,7 @@ namespace Exiled.API.Features
                 SetCustomRoleFriendlyFire(roleType, roleToAdd, ffMult);
             }
 
-            return FriendlyFireStatusCode.AddedRole;
+            return FriendlyFireStatusCode.Success;
         }
 
         /// <summary>
@@ -1422,7 +1422,7 @@ namespace Exiled.API.Features
 
                 if (partialRoleAddition && atLeastOneAdded)
                 {
-                    return FriendlyFireStatusCode.AddedSomeRoles;
+                    return FriendlyFireStatusCode.PartialSuccess;
                 }
             }
             else
@@ -1433,7 +1433,7 @@ namespace Exiled.API.Features
                 }
             }
 
-            return FriendlyFireStatusCode.AddedAllRoles;
+            return FriendlyFireStatusCode.Success;
         }
 
         /// <summary>
@@ -1517,7 +1517,7 @@ namespace Exiled.API.Features
                 SetCustomRoleToCustomRoleFriendlyFireInternal(roleType, customRoleToAdd, ffMult);
             }
 
-            return FriendlyFireStatusCode.AddedRole;
+            return FriendlyFireStatusCode.Success;
         }
 
         /// <summary>
@@ -1613,7 +1613,7 @@ namespace Exiled.API.Features
 
                 if(partialRoleAddition && atLeastOneAdded)
                 {
-                    return FriendlyFireStatusCode.AddedSomeRoles;
+                    return FriendlyFireStatusCode.PartialSuccess;
                 }
             }
             else
@@ -1624,7 +1624,7 @@ namespace Exiled.API.Features
                 }
             }
 
-            return FriendlyFireStatusCode.AddedAllRoles;
+            return FriendlyFireStatusCode.Success;
         }
 
         /// <summary>

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -634,15 +634,22 @@ namespace Exiled.API.Features
         public bool IsTutorial => Role?.Type == RoleType.Tutorial;
 
         /// <summary>
-        /// Gets a value indicating whether the player's friendly fire is enabled.
-        /// This property only determines if this player can deal damage to players on the same team;
-        /// This player can be damaged by other players on their own team even if this property is <see langword="false"/>.
+        /// Gets or sets a value indicating whether the player's friendly fire is enabled.
+        /// This player can be damaged by other players on their own team even if this property is <see langword="false"/> due to other player friendly fire rules.
+        /// If you directly assign this to true, then <see cref="AlwaysDealsFriendlyFireDamage"/> will be assigned to such. Meaning this player
+        /// will be able to do damage to anyone. Only set this if you are 100% certain that is the behavior you want, otherwise,
+        /// customize your damage using <see cref="FriendlyFireMultiplier"/>, <see cref="CustomRoleFriendlyFireMultiplier"/>, and <see cref="CustomRoleToCustomRoleFriendlyFireMultiplier"/>
         /// </summary>
         public bool IsFriendlyFireEnabled
         {
             get
             {
-                return this.FriendlyFireMultiplier.Count > 0 || this.CustomRoleFriendlyFireMultiplier.Count > 0;
+                return this.FriendlyFireMultiplier.Count > 0 || this.CustomRoleFriendlyFireMultiplier.Count > 0 || this.CustomRoleToCustomRoleFriendlyFireMultiplier.Count > 0 || this.AlwaysDealsFriendlyFireDamage;
+            }
+
+            set
+            {
+                this.AlwaysDealsFriendlyFireDamage = value;
             }
         }
 

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -78,6 +78,8 @@ namespace Exiled.API.Features
         internal readonly List<Item> ItemsValue = new(8);
 #pragma warning restore SA1401
 
+        private const float DefaultFriendlyFireValue = 0.4f;
+
         private readonly IReadOnlyCollection<Item> readOnlyItems;
 
         /// <summary>
@@ -158,6 +160,18 @@ namespace Exiled.API.Features
         /// </summary>
         /// <remarks> Consider adding this as object, Dict so that CustomRoles, and Strings can be parsed. </remarks>
         public Dictionary<string, Dictionary<string, float>> CustomRoleToCustomRoleFriendlyFireMultiplier { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets default NW friendly fire multiplier.
+        /// </summary>
+        public float UniversalFriendlyFireMultiplier { get; set; } = DefaultFriendlyFireValue;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether any target is allowed to take friendly fire damage.
+        /// By default, if this is enabled, all damage is applied to any target.
+        /// Utilizes <see cref="UniversalFriendlyFireMultiplier"/> to damage target.
+        /// </summary>
+        public bool AlwaysDealsFriendlyFireDamage { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a unique custom role that does not adbide to base game for this player. Used in conjunction with <see cref="CustomRoleFriendlyFireMultiplier"/>.

--- a/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
+++ b/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
@@ -94,7 +94,7 @@ namespace Exiled.Events.Patches.Generic
                     return true;
                 }
 
-                Log.Debug($"CheckFriendlyFirePlayerRules, Attacker role {attacker.Role}, \"{attacker.UniqueRole}\" and Victim {victim.Role}, \"{victim.UniqueRole}\" and what were their unique roles", Loader.Loader.ShouldDebugBeShown);
+                Log.Debug($"CheckFriendlyFirePlayerRules, Attacker role {attacker.Role}, \"{attacker.UniqueRole}\" and Victim {victim.Role}, \"{victim.UniqueRole}\"", Loader.Loader.ShouldDebugBeShown);
 
                 if (!string.IsNullOrEmpty(victim.UniqueRole))
                 {

--- a/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
+++ b/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
@@ -94,7 +94,7 @@ namespace Exiled.Events.Patches.Generic
                     return true;
                 }
 
-                Log.Debug($"CheckFriendlyFirePlayerRules, Attacker role {attacker.Role} and Victim {victim.Role}", Loader.Loader.ShouldDebugBeShown);
+                Log.Debug($"CheckFriendlyFirePlayerRules, Attacker role {attacker.Role}, \"{attacker.UniqueRole}\" and Victim {victim.Role}, \"{victim.UniqueRole}\" and what were their unique roles", Loader.Loader.ShouldDebugBeShown);
 
                 if (!string.IsNullOrEmpty(victim.UniqueRole))
                 {
@@ -110,6 +110,18 @@ namespace Exiled.Events.Patches.Generic
                             }
                         }
                     }
+
+                    if (victim.CustomRoleToCustomRoleFriendlyFireMultiplier.Count > 0)
+                    {
+                        if (victim.CustomRoleToCustomRoleFriendlyFireMultiplier.TryGetValue(victim.UniqueRole, out Dictionary<string, float> pairedData))
+                        {
+                            if (pairedData.ContainsKey(attacker.UniqueRole))
+                            {
+                                ffMultiplier = pairedData[attacker.UniqueRole];
+                                return true;
+                            }
+                        }
+                    }
                 }
                 else if(!string.IsNullOrEmpty(attacker.UniqueRole))
                 {
@@ -121,6 +133,18 @@ namespace Exiled.Events.Patches.Generic
                             if (pairedData.ContainsKey(victim.Role))
                             {
                                 ffMultiplier = pairedData[victim.Role];
+                                return true;
+                            }
+                        }
+                    }
+
+                    if (attacker.CustomRoleToCustomRoleFriendlyFireMultiplier.Count > 0)
+                    {
+                        if (attacker.CustomRoleToCustomRoleFriendlyFireMultiplier.TryGetValue(attacker.UniqueRole, out Dictionary<string, float> pairedData))
+                        {
+                            if (pairedData.ContainsKey(victim.UniqueRole))
+                            {
+                                ffMultiplier = pairedData[victim.UniqueRole];
                                 return true;
                             }
                         }

--- a/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
+++ b/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
@@ -96,6 +96,12 @@ namespace Exiled.Events.Patches.Generic
 
                 Log.Debug($"CheckFriendlyFirePlayerRules, Attacker role {attacker.Role}, \"{attacker.UniqueRole}\" and Victim {victim.Role}, \"{victim.UniqueRole}\"", Loader.Loader.ShouldDebugBeShown);
 
+                if(attacker.AlwaysDealsFriendlyFireDamage)
+                {
+                    ffMultiplier = attacker.UniversalFriendlyFireMultiplier;
+                    return true;
+                }
+
                 if (!string.IsNullOrEmpty(victim.UniqueRole))
                 {
                     // If 035 is being shot, then we need to check if we are an 035, then check if the attacker is allowed to attack us


### PR DESCRIPTION
https://discord.com/channels/656673194693885975/668963275790221346/992910603469463572

https://discord.com/channels/656673194693885975/668963275790221346/992571334188081293

tl;dr custom role to custom role friendly fire rules otherwise you get lazy approach 

I am very tempted to consolidate all of this to just the Dict<string, Pair< string, float>> to just avoid all of this code