### PR TITLE
Process items in player inventory fix (For 914)

### DIFF
--- a/Exiled.Events/Patches/Events/Scp914/UpgradingPlayer.cs
+++ b/Exiled.Events/Patches/Events/Scp914/UpgradingPlayer.cs
@@ -101,17 +101,12 @@ namespace Exiled.Events.Patches.Events.Scp914
                 new(OpCodes.Callvirt, Method(typeof(Player), nameof(Player.Teleport), new[] { typeof(Vector3) })),
             });
 
-
-
             Label continueLabel = generator.DefineLabel();
-
-
 
             LocalBuilder ev2 = generator.DeclareLocal(typeof(UpgradingInventoryItemEventArgs));
 
             int addOffset = 2;
             index = newInstructions.FindLastIndex(instr => instr.Calls(Method(typeof(Scp914Upgrader), nameof(Scp914Upgrader.TryGetProcessor)))) + addOffset;
-            Log.Info($"What was the index {index}");
 
             int cntIndex = newInstructions.FindLastIndex(index, i => i.opcode == OpCodes.Br_S);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24619207/177084004-d0702d12-7545-45c7-abb3-00e59ef0f835.png)

Versus original

![image](https://user-images.githubusercontent.com/24619207/177084313-7ddce8fd-8c58-4db8-b07f-2cc0e8d4b71d.png)

(tl;dr process player didn't process items in player inventory)