### PR TITLE
Making people don't use Mirror::ChangeRunningSpeed

### DIFF
--- a/Exiled.API/Extensions/MirrorExtensions.cs
+++ b/Exiled.API/Extensions/MirrorExtensions.cs
@@ -244,6 +244,7 @@ namespace Exiled.API.Extensions
         /// <param name="player">Player to change.</param>
         /// <param name="multiplier">Speed multiplier.</param>
         /// <param name="useCap">Allow <paramref name="multiplier"></paramref> values to be larger than safe amount.</param>
+        [Obsolete("Use Player.WalkingSpeed", false)] // TODO : Put this Internal or private
         public static void ChangeWalkingSpeed(this Player player, float multiplier, bool useCap = true)
         {
             if (useCap)
@@ -257,6 +258,7 @@ namespace Exiled.API.Extensions
         /// <param name="player">Player to change.</param>
         /// <param name="multiplier">Speed multiplier.</param>
         /// <param name="useCap">Allow <paramref name="multiplier"></paramref> values to be larger than safe amount.</param>
+        [Obsolete("Use Player.RunningSpeed", false)] // TODO : Put this Internal or private
         public static void ChangeRunningSpeed(this Player player, float multiplier, bool useCap = true)
         {
             if (useCap)

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -333,7 +333,9 @@ namespace Exiled.API.Features
             set
             {
                 runningSpeed = value;
+#pragma warning disable CS0618
                 this.ChangeRunningSpeed(value, false);
+#pragma warning restore CS0618
             }
         }
 
@@ -346,7 +348,9 @@ namespace Exiled.API.Features
             set
             {
                 walkingSpeed = value;
+#pragma warning disable CS0618
                 this.ChangeWalkingSpeed(value, false);
+#pragma warning restore CS0618
             }
         }
 


### PR DESCRIPTION
Make people not using a method who caused desync between client and server

- do not merged it now i will add a fix for Negative value in Player::RunningSpeed