### PR TITLE
Call finishing recall earlier

### DIFF
--- a/Exiled.Events/Patches/Events/Scp049/StartingAndFinishingRecall.cs
+++ b/Exiled.Events/Patches/Events/Scp049/StartingAndFinishingRecall.cs
@@ -35,7 +35,7 @@ namespace Exiled.Events.Patches.Events.Scp049
         {
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
 
-            int offset = -4;
+            const int offset = -4;
 
             int index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Stfld &&
             (FieldInfo)instruction.operand == Field(typeof(Scp049), nameof(Scp049._recallHubServer))) + offset;
@@ -61,9 +61,8 @@ namespace Exiled.Events.Patches.Events.Scp049
                 new(OpCodes.Callvirt, PropertyGetter(typeof(StartingRecallEventArgs), nameof(StartingRecallEventArgs.IsAllowed))),
                 new(OpCodes.Brfalse_S, ret),
             });
-
-            offset = 0;
-            index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Beq_S) + offset;
+            
+            index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Beq_S);
 
             newInstructions.InsertRange(index, new CodeInstruction[]
             {

--- a/Exiled.Events/Patches/Events/Scp049/StartingAndFinishingRecall.cs
+++ b/Exiled.Events/Patches/Events/Scp049/StartingAndFinishingRecall.cs
@@ -61,7 +61,6 @@ namespace Exiled.Events.Patches.Events.Scp049
                 new(OpCodes.Callvirt, PropertyGetter(typeof(StartingRecallEventArgs), nameof(StartingRecallEventArgs.IsAllowed))),
                 new(OpCodes.Brfalse_S, ret),
             });
-            
             index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Beq_S);
 
             newInstructions.InsertRange(index, new CodeInstruction[]

--- a/Exiled.Events/Patches/Events/Scp049/StartingAndFinishingRecall.cs
+++ b/Exiled.Events/Patches/Events/Scp049/StartingAndFinishingRecall.cs
@@ -40,6 +40,8 @@ namespace Exiled.Events.Patches.Events.Scp049
             int index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Stfld &&
             (FieldInfo)instruction.operand == Field(typeof(Scp049), nameof(Scp049._recallHubServer))) + offset;
 
+            LocalBuilder finishRecallAllowed = generator.DeclareLocal(typeof(bool));
+
             Label ret = generator.DefineLabel();
 
             newInstructions.InsertRange(index, new CodeInstruction[]
@@ -60,23 +62,28 @@ namespace Exiled.Events.Patches.Events.Scp049
                 new(OpCodes.Brfalse_S, ret),
             });
 
-            offset = -2;
-            index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Ldc_I4_S) + offset;
+            offset = 0;
+            index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Beq_S) + offset;
 
             newInstructions.InsertRange(index, new CodeInstruction[]
             {
+                // store whether player's role is spectator or not
+                new(OpCodes.Ceq),
+                new(OpCodes.Stloc_S, finishRecallAllowed.LocalIndex),
                 new(OpCodes.Ldloc_S, 6),
                 new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
                 new(OpCodes.Ldarg_0),
                 new(OpCodes.Ldfld, Field(typeof(Scp049), nameof(Scp049.Hub))),
                 new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
                 new(OpCodes.Ldloc, 5),
-                new(OpCodes.Ldc_I4_1),
+                new(OpCodes.Ldloc_S, finishRecallAllowed.LocalIndex),
                 new(OpCodes.Newobj, GetDeclaredConstructors(typeof(FinishingRecallEventArgs))[0]),
                 new(OpCodes.Dup),
                 new(OpCodes.Call, Method(typeof(Handlers.Scp049), nameof(Handlers.Scp049.OnFinishingRecall))),
+
+                // load isAllowed for original methods beq to evaluate
                 new(OpCodes.Callvirt, PropertyGetter(typeof(FinishingRecallEventArgs), nameof(FinishingRecallEventArgs.IsAllowed))),
-                new(OpCodes.Brfalse_S, ret),
+                new(OpCodes.Ldc_I4_1),
             });
 
             newInstructions[newInstructions.Count - 1].labels.Add(ret);


### PR DESCRIPTION
This calls OnFinishingRecall even if the person being recalled isn't a spectator, and it just sets IsAllowed to false if this is the case.