### PR TITLE
Fixed `Scp173::TurnedPlayers` not working for tutorial class.

### DIFF
--- a/Exiled.Events/Patches/Generic/Scp173BeingLooked.cs
+++ b/Exiled.Events/Patches/Generic/Scp173BeingLooked.cs
@@ -40,13 +40,10 @@ namespace Exiled.Events.Patches.Generic
             Player player = Player.Get(curPlayerHub);
             if (player is not null)
             {
-                if (player.Role.Type == RoleType.Tutorial)
+                if (player.Role.Type == RoleType.Tutorial && !Exiled.Events.Events.Instance.Config.CanTutorialBlockScp173)
                 {
-                    if (!Exiled.Events.Events.Instance.Config.CanTutorialBlockScp173)
-                    {
-                        instance._observingPlayers.Remove(curPlayerHub);
-                        return true;
-                    }
+                    instance._observingPlayers.Remove(curPlayerHub);
+                    return true;
                 }
                 else if (API.Features.Scp173.TurnedPlayers.Contains(player))
                 {


### PR DESCRIPTION
For:

https://discord.com/channels/656673194693885975/664263236048388097/997501151723409408

Previous logic did not consider this (original patch) and new patch did not change it. This should work functionally the same as before, just needs people to correctly configure