### PR TITLE
Fix Round.IsStarted sense, added Round.InProgress

### DIFF
--- a/Exiled.API/Features/Round.cs
+++ b/Exiled.API/Features/Round.cs
@@ -37,7 +37,12 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a value indicating whether the round is started or not.
         /// </summary>
-        public static bool IsStarted => ReferenceHub.LocalHub is not null && RoundSummary.RoundInProgress();
+        public static bool IsStarted => ReferenceHub.LocalHub?.characterClassManager.RoundStarted ?? false;
+
+        /// <summary>
+        /// Gets a value indicating whether the round in progress or not.
+        /// </summary>
+        public static bool InProgress => ReferenceHub.LocalHub is not null && RoundSummary.RoundInProgress();
 
         /// <summary>
         /// Gets a value indicating whether the round is ended or not.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/72656712/181380593-6cb9af05-e55c-43a1-9e9f-6ed4afe7f45b.png)
![image](https://user-images.githubusercontent.com/72656712/181380671-73d7a709-fd8a-42dc-b9cd-885ac427648b.png)

Old `IsStarted` have a wrong sense. That property indicated `InProgress` status, instead of `Started` status.
Maybe that change isn't necessary, but sense of `IsStarted` not compare with `InProgress`, imho.