### PR TITLE
`Player::UsingRadioBattery` event fix

### DIFF
--- a/Exiled.Events/Patches/Events/Player/UsingRadioBattery.cs
+++ b/Exiled.Events/Patches/Events/Player/UsingRadioBattery.cs
@@ -37,7 +37,7 @@ namespace Exiled.Events.Patches.Events.Player
             int index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Ldloc_0) + offset;
 
             Label returnLabel = newInstructions[newInstructions.Count - 1].labels[0];
-            Label continueLabel = newInstructions[newInstructions.Count - 1].labels[0];
+            Label continueLabel = generator.DefineLabel();
 
             LocalBuilder ev = generator.DeclareLocal(typeof(UsingRadioBatteryEventArgs));
             LocalBuilder player = generator.DeclareLocal(typeof(Player));

--- a/Exiled.Events/Patches/Events/Player/UsingRadioBattery.cs
+++ b/Exiled.Events/Patches/Events/Player/UsingRadioBattery.cs
@@ -32,19 +32,22 @@ namespace Exiled.Events.Patches.Events.Player
         {
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
 
-            // The index offset.
             int offset = -4;
 
-            // Search for the first "ldloc.0".
             int index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Ldloc_0) + offset;
 
-            // Get the return label of the last "ret".
             Label returnLabel = newInstructions[newInstructions.Count - 1].labels[0];
+            Label continueLabel = newInstructions[newInstructions.Count - 1].labels[0];
 
-            // Declare an "UsingRadioBatteryEventArgs" local variable.
             LocalBuilder ev = generator.DeclareLocal(typeof(UsingRadioBatteryEventArgs));
+            LocalBuilder player = generator.DeclareLocal(typeof(Player));
 
-            // var ev = new UsingRadioBatteryEventArgs(this, Player.Get(base.Owner), num);
+            newInstructions[index].labels.Add(continueLabel);
+
+            // if (Player.Get(base.Owner) is not Player player)
+            //   continue;
+            //
+            // var ev = new UsingRadioBatteryEventArgs(this, player, num, true);
             //
             // Handlers.Player.OnUsingRadioBattery(ev);
             //
@@ -54,35 +57,32 @@ namespace Exiled.Events.Patches.Events.Player
             // num = ev.Drain;
             newInstructions.InsertRange(index, new CodeInstruction[]
             {
-                // this
-                new(OpCodes.Ldarg_0),
-
-                // Player.Get(base.Owner)
                 new(OpCodes.Ldarg_0),
                 new(OpCodes.Call, PropertyGetter(typeof(RadioItem), nameof(RadioItem.Owner))),
                 new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
+                new(OpCodes.Dup),
+                new(OpCodes.Stloc_S, player.LocalIndex),
 
-                // num
+                new(OpCodes.Brfalse_S, continueLabel),
+
+                new(OpCodes.Ldarg_0),
+
+                new(OpCodes.Ldloc_S, player.LocalIndex),
+
                 new(OpCodes.Ldloc_0),
 
-                // true
                 new(OpCodes.Ldc_I4_1),
 
-                // var ev = new UsingRadioBatteryEventArgs(...)
                 new(OpCodes.Newobj, GetDeclaredConstructors(typeof(UsingRadioBatteryEventArgs))[0]),
                 new(OpCodes.Dup),
                 new(OpCodes.Dup),
                 new(OpCodes.Stloc_S, ev.LocalIndex),
 
-                // Handlers.Player.OnUsingRadioBattery(ev)
                 new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnUsingRadioBattery))),
 
-                // if (!ev.IsAllowed)
-                //   return;
                 new(OpCodes.Callvirt, PropertyGetter(typeof(UsingRadioBatteryEventArgs), nameof(UsingRadioBatteryEventArgs.IsAllowed))),
                 new(OpCodes.Brfalse_S, returnLabel),
 
-                // num = ev.Drain
                 new(OpCodes.Ldloc_S, ev.LocalIndex),
                 new(OpCodes.Callvirt, PropertyGetter(typeof(UsingRadioBatteryEventArgs), nameof(UsingRadioBatteryEventArgs.Drain))),
                 new(OpCodes.Stloc_0),


### PR DESCRIPTION
Radio is in inventory of the `Server.Host`, wastes energy, and triggering an event with a null player
(I just made it so that event is not called in this case)
