### PR TITLE
Add IgnoreRequiredVersionCheck

### DIFF
--- a/Exiled.API/Features/Plugin.cs
+++ b/Exiled.API/Features/Plugin.cs
@@ -61,6 +61,9 @@ namespace Exiled.API.Features
         public virtual Version RequiredExiledVersion { get; } = typeof(IPlugin<>).Assembly.GetName().Version;
 
         /// <inheritdoc/>
+        public virtual bool IgnoreRequiredVersionCheck { get; } = false;
+
+        /// <inheritdoc/>
         public Dictionary<Type, Dictionary<Type, ICommand>> Commands { get; } = new()
         {
             { typeof(RemoteAdminCommandHandler), new Dictionary<Type, ICommand>() },

--- a/Exiled.API/Interfaces/IPlugin.cs
+++ b/Exiled.API/Interfaces/IPlugin.cs
@@ -65,6 +65,12 @@ namespace Exiled.API.Interfaces
         Version RequiredExiledVersion { get; }
 
         /// <summary>
+        /// Gets a value indicating if a plugin should bypass the required EXILED version check.
+        /// This should only be used by plugins which do not need to be updated across major version updates.
+        /// </summary>
+        bool IgnoreRequiredVersionCheck { get; }
+
+        /// <summary>
         /// Gets the plugin config.
         /// </summary>
         TConfig Config { get; }

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -431,6 +431,9 @@ namespace Exiled.Loader
 
         private static bool CheckPluginRequiredExiledVersion(IPlugin<IConfig> plugin)
         {
+            if(plugin.IgnoreRequiredVersionCheck)
+                return false;
+
             Version requiredVersion = plugin.RequiredExiledVersion;
             Version actualVersion = Version;
 


### PR DESCRIPTION
This adds a little option which allows plugins to ignore the required version check. This is useful for plugins which do not expect to break across major version changes (LogArchiver) or ones which can fix themselves automatically if they do (SCPStats).