### PR TITLE
Fixes `ExplosionGrenade.Explode` + better understandable ctos in  `Explode` patches

### DIFF
--- a/Exiled.Events/Patches/Events/Map/BreakingScp2176.cs
+++ b/Exiled.Events/Patches/Events/Map/BreakingScp2176.cs
@@ -44,7 +44,7 @@ namespace Exiled.Events.Patches.Events.Map
                 new(OpCodes.Ldarg_0),
                 new(OpCodes.Ldc_I4_0),
                 new(OpCodes.Newarr, typeof(UnityEngine.Collider)),
-                new(OpCodes.Newobj, GetDeclaredConstructors(typeof(ExplodingGrenadeEventArgs))[0]),
+                new(OpCodes.Newobj, DeclaredConstructor(typeof(ExplodingGrenadeEventArgs), new[] { typeof(API.Features.Player), typeof(EffectGrenade), typeof(UnityEngine.Collider[]) })),
                 new(OpCodes.Dup),
 
                 // Handlers.Map.OnExplodingGrenade(ev);

--- a/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
+++ b/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
@@ -85,7 +85,7 @@ namespace Exiled.Events.Patches.Events.Map
                 new(OpCodes.Call, Method(typeof(ExplodingFlashGrenade), nameof(ConvertHubs))),
 
                 // var ev = new ExplodingGrenadeEventArgs(player, this, players);
-                new(OpCodes.Newobj, GetDeclaredConstructors(typeof(ExplodingGrenadeEventArgs))[1]),
+                new(OpCodes.Newobj, DeclaredConstructor(typeof(ExplodingGrenadeEventArgs), new[] { typeof(Player), typeof(EffectGrenade), typeof(List<Player>) })),
                 new(OpCodes.Dup),
                 new(OpCodes.Dup),
                 new(OpCodes.Stloc, ev.LocalIndex),


### PR DESCRIPTION
The problem was when Yamato added the constructor and the indexes changed, I thought it would be clearer to use a DeclaredConstructor with arguments in those patches