### PR TITLE
`CustomGrenade::OnThrowing` fix

### DIFF
--- a/Exiled.CustomItems/API/Features/CustomGrenade.cs
+++ b/Exiled.CustomItems/API/Features/CustomGrenade.cs
@@ -182,13 +182,11 @@ namespace Exiled.CustomItems.API.Features
                 return;
 
             Log.Debug($"{ev.Player.Nickname} has thrown a {Name}!", CustomItems.Instance.Config.Debug);
-            if (ev.RequestType == ThrowRequest.BeginThrow)
-            {
-                OnThrowing(ev);
-                return;
-            }
 
             OnThrowing(ev);
+
+            if (ev.RequestType == ThrowRequest.BeginThrow)
+                return;
 
             switch (ev.Item)
             {

--- a/Exiled.CustomItems/API/Features/CustomGrenade.cs
+++ b/Exiled.CustomItems/API/Features/CustomGrenade.cs
@@ -185,7 +185,6 @@ namespace Exiled.CustomItems.API.Features
             if (ev.RequestType == ThrowRequest.BeginThrow)
             {
                 OnThrowing(ev);
-                ev.IsAllowed = false;
                 return;
             }
 


### PR DESCRIPTION
old cringe code was:
```cs
if (!ev.IsAllowed)
    ev.IsAllowed = false;
```
new code with #1347 pr(current dev):
```cs
ev.IsAllowed = false;
```
so It's not the same, and when using the flash as a CustomGrenade it caused errors