### PR TITLE
Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ $tf/
 _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
+*.DotSettings
 
 # TeamCity is a build add-in
 _TeamCity*

--- a/EXILED.sln
+++ b/EXILED.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Exiled.CreditTags", "Exiled
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Exiled.CustomRoles", "Exiled.CustomRoles\Exiled.CustomRoles.csproj", "{417C3309-8B93-4218-A1D1-D4BB7B09BE0F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Exiled.Metrics", "Exiled.Metrics\Exiled.Metrics.csproj", "{4F73D1A2-3101-4785-9564-3ECAEDB1AFD1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -94,6 +96,12 @@ Global
 		{417C3309-8B93-4218-A1D1-D4BB7B09BE0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{417C3309-8B93-4218-A1D1-D4BB7B09BE0F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{417C3309-8B93-4218-A1D1-D4BB7B09BE0F}.Programs|Any CPU.ActiveCfg = Programs|Any CPU
+		{4F73D1A2-3101-4785-9564-3ECAEDB1AFD1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F73D1A2-3101-4785-9564-3ECAEDB1AFD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F73D1A2-3101-4785-9564-3ECAEDB1AFD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F73D1A2-3101-4785-9564-3ECAEDB1AFD1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F73D1A2-3101-4785-9564-3ECAEDB1AFD1}.Programs|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F73D1A2-3101-4785-9564-3ECAEDB1AFD1}.Programs|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Exiled.API/Extensions/StringExtensions.cs
+++ b/Exiled.API/Extensions/StringExtensions.cs
@@ -166,13 +166,13 @@ namespace Exiled.API.Extensions
         public static string GetRawUserId(this string userId) => userId.Substring(0, userId.LastIndexOf('@'));
 
         /// <summary>
-        /// Gets a SHA256 hash of a player's user id without the authentication.
+        /// Gets a SHA256 hash of a <see cref="string"/>.
         /// </summary>
-        /// <param name="userId">The user id.</param>
-        /// <returns>The hashed userid.</returns>
-        public static string GetHashedUserId(this string userId)
+        /// <param name="str">The <see cref="string"/>.</param>
+        /// <returns>The hashed <see cref="string"/>.</returns>
+        public static string GetHash(this string str)
         {
-            byte[] textData = Encoding.UTF8.GetBytes(userId.Substring(0, userId.LastIndexOf('@')));
+            byte[] textData = Encoding.UTF8.GetBytes(str);
             byte[] hash = Sha256.ComputeHash(textData);
             return BitConverter.ToString(hash).Replace("-", string.Empty);
         }

--- a/Exiled.CreditTags/CreditTags.cs
+++ b/Exiled.CreditTags/CreditTags.cs
@@ -79,7 +79,7 @@ namespace Exiled.CreditTags
 
         internal void MakeRequest(string userId, Action<ThreadSafeRequest> errorHandler, Action<string> successHandler, GameObject issuer)
         {
-            ThreadSafeRequest.Go($"{Url}?userid={userId.GetHashedUserId()}", errorHandler, successHandler, issuer);
+            ThreadSafeRequest.Go($"{Url}?userid={userId.GetHash()}", errorHandler, successHandler, issuer);
         }
 
         // returns true if the player was in the cache
@@ -95,7 +95,7 @@ namespace Exiled.CreditTags
             }
             else
             {
-                MakeRequest(player.UserId, ErrorHandler, SuccessHandler, player.GameObject);
+                MakeRequest(player.RawUserId, ErrorHandler, SuccessHandler, player.GameObject);
                 return false;
             }
 

--- a/Exiled.Metrics/API/Enums/EventType.cs
+++ b/Exiled.Metrics/API/Enums/EventType.cs
@@ -1,0 +1,15 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventType.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Metrics.API.Enums;
+
+public enum EventType
+{
+    RoundStart,
+    RoundEnd,
+    None,
+}

--- a/Exiled.Metrics/Config.cs
+++ b/Exiled.Metrics/Config.cs
@@ -1,0 +1,26 @@
+// -----------------------------------------------------------------------
+// <copyright file="Config.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Metrics;
+
+using System.ComponentModel;
+
+using Exiled.API.Interfaces;
+
+/// <inheritdoc />
+public class Config : IConfig
+{
+    /// <inheritdoc/>
+    [Description("Whether or not this plugin is enabled.")]
+    public bool IsEnabled { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether debug messages should appear.
+    /// </summary>
+    [Description("Whether or not debug logs should be shown in the console.")]
+    public bool Debug { get; set; }
+}

--- a/Exiled.Metrics/EventHandlers.cs
+++ b/Exiled.Metrics/EventHandlers.cs
@@ -33,16 +33,13 @@ public class EventHandlers
     public void OnRoundStarted()
     {
         coroutine = Timing.RunCoroutine(CalculateMetrics());
-        tps = Server.Tps;
     }
 
     private IEnumerator<float> CalculateMetrics()
     {
         for (; ;)
         {
-            tps = (Server.Tps + tps) / 2;
-
-            plugin.Methods.SendMetrics(EventType.None, tps);
+            plugin.Methods.SendMetrics(EventType.None);
 
             yield return Timing.WaitForSeconds(2f);
         }
@@ -51,6 +48,6 @@ public class EventHandlers
     public void OnRoundEnded(RoundEndedEventArgs ev)
     {
         Timing.KillCoroutines(coroutine);
-        plugin.Methods.SendMetrics(EventType.RoundEnd, ev.LeadingTeam, tps);
+        plugin.Methods.SendMetrics(EventType.RoundEnd, ev.LeadingTeam);
     }
 }

--- a/Exiled.Metrics/EventHandlers.cs
+++ b/Exiled.Metrics/EventHandlers.cs
@@ -1,0 +1,56 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventHandlers.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Metrics;
+
+using System.Collections.Generic;
+
+using Exiled.API.Features;
+using Exiled.Events.EventArgs;
+using Exiled.Metrics.API.Enums;
+
+using MEC;
+
+/// <summary>
+/// General event handlers.
+/// </summary>
+public class EventHandlers
+{
+    private readonly Plugin plugin;
+    private double tps;
+    private CoroutineHandle coroutine;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventHandlers"/> class.
+    /// </summary>
+    /// <param name="plugin">The <see cref="Plugin{TConfig}"/> class reference.</param>
+    public EventHandlers(Plugin plugin) => this.plugin = plugin;
+
+    public void OnRoundStarted()
+    {
+        coroutine = Timing.RunCoroutine(CalculateMetrics());
+        tps = Server.Tps;
+    }
+
+    private IEnumerator<float> CalculateMetrics()
+    {
+        for (; ;)
+        {
+            tps = (Server.Tps + tps) / 2;
+
+            plugin.Methods.SendMetrics(EventType.None, tps);
+
+            yield return Timing.WaitForSeconds(2f);
+        }
+    }
+
+    public void OnRoundEnded(RoundEndedEventArgs ev)
+    {
+        Timing.KillCoroutines(coroutine);
+        plugin.Methods.SendMetrics(EventType.RoundEnd, ev.LeadingTeam, tps);
+    }
+}

--- a/Exiled.Metrics/Exiled.Metrics.csproj
+++ b/Exiled.Metrics/Exiled.Metrics.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../EXILED.props" />
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <AssemblyName>Exiled.Metrics</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Configurations>Debug;Release;Programs</Configurations>
+    <Platforms>AnyCPU</Platforms>
+    <LangVersion>11</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Exiled.API\Exiled.API.csproj" />
+    <ProjectReference Include="..\Exiled.CustomItems\Exiled.CustomItems.csproj" />
+    <ProjectReference Include="..\Exiled.Events\Exiled.Events.csproj" />
+    <ProjectReference Include="..\Exiled.Loader\Exiled.Loader.csproj" />
+    <ProjectReference Include="..\Exiled.Permissions\Exiled.Permissions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopVersion)" IncludeAssets="All" PrivateAssets="All" />
+    <PackageReference Include="YamlDotNet" Version="$(YamlDotNetVersion)" />
+    <PackageReference Include="Lib.Harmony" Version="$(HarmonyVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Assembly-CSharp" HintPath="$(EXILED_REFERENCES)\Assembly-CSharp-Publicized.dll" Private="false" />
+    <Reference Include="Assembly-CSharp-firstpass" HintPath="$(EXILED_REFERENCES)\Assembly-CSharp-firstpass.dll" Private="false" />
+    <Reference Include="BouncyCastle.Crypto" HintPath="$(EXILED_REFERENCES)\BouncyCastle.Crypto.dll" Private="false" />
+    <Reference Include="CommandSystem.Core" HintPath="$(EXILED_REFERENCES)\CommandSystem.Core.dll" Private="false" />
+    <Reference Include="Mirror" HintPath="$(EXILED_REFERENCES)\Mirror.dll" Private="false" />
+    <Reference Include="NorthwoodLib" HintPath="$(EXILED_REFERENCES)\NorthwoodLib.dll" Private="false" />
+    <Reference Include="UnityEngine" HintPath="$(EXILED_REFERENCES)\UnityEngine.dll" Private="false" />
+    <Reference Include="UnityEngine.AudioModule" HintPath="$(EXILED_REFERENCES)\UnityEngine.AudioModule.dll" Private="false" />
+    <Reference Include="UnityEngine.AnimationModule" HintPath="$(EXILED_REFERENCES)\UnityEngine.AnimationModule.dll" Private="false" />
+    <Reference Include="UnityEngine.CoreModule" HintPath="$(EXILED_REFERENCES)\UnityEngine.CoreModule.dll" Private="false" />
+    <Reference Include="UnityEngine.PhysicsModule" HintPath="$(EXILED_REFERENCES)\UnityEngine.PhysicsModule.dll" Private="false" />
+    <Reference Include="System.ComponentModel.DataAnnotations" Private="false" />
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+    <PostBuildEvent>if not "$(EXILED_DEV_REFERENCES)"=="" copy /y "$(OutputPath)$(AssemblyName).dll" "$(EXILED_DEV_REFERENCES)\Plugins\"</PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' == 'Unix' ">
+    <PostBuildEvent>if [[ ! -z "$EXILED_DEV_REFERENCES" ]]; then cp "$(OutputPath)$(AssemblyName).dll" "$EXILED_DEV_REFERENCES/Plugins/"; fi</PostBuildEvent>
+  </PropertyGroup>
+
+</Project>

--- a/Exiled.Metrics/Methods.cs
+++ b/Exiled.Metrics/Methods.cs
@@ -39,17 +39,16 @@ public class Methods
         int playerCount = Server.PlayerCount;
         int maxPlayers = Server.MaxPlayerCount;
         LeadingTeam? team = null;
-        float? tps = (float)args[0];
 
         if (type == EventType.RoundEnd)
-            team = (LeadingTeam)args[1];
+            team = (LeadingTeam)args[0];
 
         IEnumerable<IPlugin<IConfig>> plugins = Loader.Plugins;
         string pluginInfo = string.Empty;
         foreach (IPlugin<IConfig> plg in plugins)
             pluginInfo += $"{plg.Name}|{plg.Version}|{plg.Author}|{plg.Config.IsEnabled}||";
 
-        string message = $"srvId={serverIdentifier}&exiled={exiledVersion}&players={playerCount}&playerMax={maxPlayers}&team={(team is null ? "None" : team)}&tps={tps}&plugins={pluginInfo}";
+        string message = $"srvId={serverIdentifier}&exiled={exiledVersion}&players={playerCount}&playerMax={maxPlayers}&team={(team is null ? "None" : team)}&tps={Server.Tps}&plugins={pluginInfo}";
 
         HttpQuery.Post(Url, message, out bool success, out HttpStatusCode code);
         switch (success)

--- a/Exiled.Metrics/Methods.cs
+++ b/Exiled.Metrics/Methods.cs
@@ -1,0 +1,65 @@
+// -----------------------------------------------------------------------
+// <copyright file="Methods.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Metrics;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+using Exiled.API.Enums;
+using Exiled.API.Extensions;
+using Exiled.API.Features;
+using Exiled.API.Interfaces;
+using Exiled.Loader;
+using Exiled.Metrics.API.Enums;
+
+/// <summary>
+/// General methods.
+/// </summary>
+public class Methods
+{
+    private const string Url = "https://exiled.host/utilities/metrics.php";
+    private readonly Plugin plugin;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Methods"/> class.
+    /// </summary>
+    /// <param name="plugin">The <see cref="Plugin{TConfig}"/> class reference.</param>
+    public Methods(Plugin plugin) => this.plugin = plugin;
+
+    internal void SendMetrics(EventType type, params object[] args)
+    {
+        string serverIdentifier = $"{Server.IpAddress.GetHash()}-{Server.Port.ToString().GetHash()}";
+        string exiledVersion = Events.Events.Instance.Version.ToString();
+        int playerCount = Server.PlayerCount;
+        int maxPlayers = Server.MaxPlayerCount;
+        LeadingTeam? team = null;
+        float? tps = (float)args[0];
+
+        if (type == EventType.RoundEnd)
+            team = (LeadingTeam)args[1];
+
+        IEnumerable<IPlugin<IConfig>> plugins = Loader.Plugins;
+        string pluginInfo = string.Empty;
+        foreach (IPlugin<IConfig> plg in plugins)
+            pluginInfo += $"{plg.Name}|{plg.Version}|{plg.Author}|{plg.Config.IsEnabled}||";
+
+        string message = $"srvId={serverIdentifier}&exiled={exiledVersion}&players={playerCount}&playerMax={maxPlayers}&team={(team is null ? "None" : team)}&tps={tps}&plugins={pluginInfo}";
+
+        HttpQuery.Post(Url, message, out bool success, out HttpStatusCode code);
+        switch (success)
+        {
+            case true:
+                Log.Debug($"{nameof(SendMetrics)}: Metrics posted.", plugin.Config.Debug);
+                break;
+            case false:
+                Log.Warn($"{nameof(SendMetrics)}: Metrics unable to post: {code}");
+                break;
+        }
+    }
+}

--- a/Exiled.Metrics/Methods.cs
+++ b/Exiled.Metrics/Methods.cs
@@ -5,6 +5,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using Exiled.Metrics.Verification;
+
 namespace Exiled.Metrics;
 
 using System.Collections.Generic;
@@ -34,7 +36,11 @@ public class Methods
 
     internal void SendMetrics(EventType type, params object[] args)
     {
-        string serverIdentifier = $"{Server.IpAddress.GetHash()}-{Server.Port.ToString().GetHash()}";
+        // Only send metrics if a server has verification data.
+        VerificationData? verificationData = Verifier.GetVerificationData();
+        if (verificationData == null)
+            return;
+
         string exiledVersion = Events.Events.Instance.Version.ToString();
         int playerCount = Server.PlayerCount;
         int maxPlayers = Server.MaxPlayerCount;
@@ -48,7 +54,7 @@ public class Methods
         foreach (IPlugin<IConfig> plg in plugins)
             pluginInfo += $"{plg.Name}|{plg.Version}|{plg.Author}|{plg.Config.IsEnabled}||";
 
-        string message = $"srvId={serverIdentifier}&exiled={exiledVersion}&players={playerCount}&playerMax={maxPlayers}&team={(team is null ? "None" : team)}&tps={Server.Tps}&plugins={pluginInfo}";
+        string message = $"srvId={verificationData.Value.ID}&timestamp={verificationData.Value.Timestamp}&hmac={verificationData.Value.Hmac}&exiled={exiledVersion}&players={playerCount}&playerMax={maxPlayers}&team={(team is null ? "None" : team)}&tps={Server.Tps}&plugins={pluginInfo}";
 
         HttpQuery.Post(Url, message, out bool success, out HttpStatusCode code);
         switch (success)

--- a/Exiled.Metrics/Methods.cs
+++ b/Exiled.Metrics/Methods.cs
@@ -23,7 +23,7 @@ using Exiled.Metrics.API.Enums;
 /// </summary>
 public class Methods
 {
-    private const string Url = "https://exiled.host/utilities/metrics.php";
+    private const string Url = "https://exiled.host/metrics/";
     private readonly Plugin plugin;
 
     /// <summary>

--- a/Exiled.Metrics/Plugin.cs
+++ b/Exiled.Metrics/Plugin.cs
@@ -1,0 +1,55 @@
+// -----------------------------------------------------------------------
+// <copyright file="Plugin.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Metrics;
+
+using Exiled.API.Features;
+
+using MapEvents = Exiled.Events.Handlers.Map;
+using PlayerEvents = Exiled.Events.Handlers.Player;
+using Scp049Events = Exiled.Events.Handlers.Scp049;
+using Scp079Events = Exiled.Events.Handlers.Scp079;
+using Scp096Events = Exiled.Events.Handlers.Scp096;
+using Scp106Events = Exiled.Events.Handlers.Scp106;
+using Scp914Events = Exiled.Events.Handlers.Scp914;
+using ServerEvents = Exiled.Events.Handlers.Server;
+using WarheadEvents = Exiled.Events.Handlers.Warhead;
+
+/// <inheritdoc />
+public class Plugin : Plugin<Config>
+{
+    /// <summary>
+    /// Gets the class reference for general methods.
+    /// </summary>
+    public Methods Methods { get; private set; }
+
+    /// <summary>
+    /// Gets the class reference for general event handlers.
+    /// </summary>
+    public EventHandlers EventHandlers { get; private set; }
+
+    /// <inheritdoc/>
+    public override void OnEnabled()
+    {
+        EventHandlers = new EventHandlers(this);
+        Methods = new Methods(this);
+
+        ServerEvents.RoundStarted += EventHandlers.OnRoundStarted;
+        ServerEvents.RoundEnded += EventHandlers.OnRoundEnded;
+
+        base.OnEnabled();
+    }
+
+    /// <inheritdoc/>
+    public override void OnDisabled()
+    {
+        EventHandlers = null;
+        Methods = null;
+
+        base.OnDisabled();
+    }
+}

--- a/Exiled.Metrics/Plugin.cs
+++ b/Exiled.Metrics/Plugin.cs
@@ -47,6 +47,9 @@ public class Plugin : Plugin<Config>
     /// <inheritdoc/>
     public override void OnDisabled()
     {
+        ServerEvents.RoundStarted -= EventHandlers.OnRoundStarted;
+        ServerEvents.RoundEnded -= EventHandlers.OnRoundEnded;
+
         EventHandlers = null;
         Methods = null;
 

--- a/Exiled.Metrics/Verification/VerificationData.cs
+++ b/Exiled.Metrics/Verification/VerificationData.cs
@@ -1,0 +1,29 @@
+namespace Exiled.Metrics.Verification;
+
+/// <summary>
+/// Data used to verify a server's identity.
+/// </summary>
+internal readonly struct VerificationData
+{
+    /// <summary>
+    /// A unique and anonymous ID that identifies this server.
+    /// </summary>
+    public readonly string ID;
+
+    /// <summary>
+    /// A UNIX timestamp describing when this was issued.
+    /// </summary>
+    public readonly string Timestamp;
+
+    /// <summary>
+    /// A HMAC used for validating the authenticity of this.
+    /// </summary>
+    public readonly string Hmac;
+
+    public VerificationData(string id, string timestamp, string hmac)
+    {
+        ID = id;
+        Timestamp = timestamp;
+        Hmac = hmac;
+    }
+}

--- a/Exiled.Metrics/Verification/Verifier.cs
+++ b/Exiled.Metrics/Verification/Verifier.cs
@@ -1,0 +1,74 @@
+using System.Linq;
+
+using Exiled.API.Features;
+
+using Mirror.LiteNetLib4Mirror;
+
+namespace Exiled.Metrics.Verification;
+
+/// <summary>
+/// Handles the client-side part of server verification (making sure that a server is who they say they are).
+/// </summary>
+public class Verifier
+{
+    private static VerificationData? data;
+
+    private const string IDPrefix = "EXILED-ID-";
+    private const string TimestampPrefix = "EXILED-TIMESTAMP-";
+    private const string HmacPrefix = "EXILED-HMAC-";
+
+    /// <summary>
+    /// Refreshes the cached verification data.
+    /// </summary>
+    internal static void RefreshVerificationData()
+    {
+        // We need the server to be able to contact the server list.
+        if (string.IsNullOrEmpty(ServerConsole.Password))
+            return;
+
+        // To get the verification data, we need to send a request to the Northwood authenticator API.
+        string response = HttpQuery.Post(CentralServer.MasterUrl + "v4/authenticator.php", HttpQuery.ToPostArgs(new []
+        {
+            $"ip={ServerConsole.Ip}",
+            "players=" + ServerConsole.PlayersAmount + "/" + CustomNetworkManager.slots,
+            "port=" + (ServerConsole.PortOverride == 0 ? LiteNetLib4MirrorTransport.Singleton.port : ServerConsole.PortOverride),
+            "version=2",
+            "passcode=" + ServerConsole.Password,
+            // This is a special flag to give us verification data.
+            "extAuth=EXILED"
+        }));
+        AuthenticatorResponse authenticatorResponse = JsonSerialize.FromJson<AuthenticatorResponse>(response);
+
+        // Now, we need to perform a few checks.
+        // If we received an error, we should print it.
+        // If the request was unsuccessful or the server isn't verified, we can quit.
+
+        if (!string.IsNullOrEmpty(authenticatorResponse.error))
+        {
+            Log.Error($"Received an error while requesting verification data: {authenticatorResponse.error}");
+            return;
+        }
+
+        if (!authenticatorResponse.success || !authenticatorResponse.verified)
+            return;
+
+        // We should also verify that we received the verification data.
+        string id = authenticatorResponse.actions.FirstOrDefault(action => action.StartsWith(IDPrefix))?.Substring(IDPrefix.Length);
+        string timestamp = authenticatorResponse.actions.FirstOrDefault(action => action.StartsWith(TimestampPrefix))?.Substring(TimestampPrefix.Length);
+        string hmac = authenticatorResponse.actions.FirstOrDefault(action => action.StartsWith(HmacPrefix))?.Substring(HmacPrefix.Length);
+
+        if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(timestamp) || string.IsNullOrEmpty(hmac))
+            return;
+
+        // Finally, cache the verification data.
+        data = new VerificationData(id, timestamp, hmac);
+    }
+
+    /// <summary>
+    /// Retrieves (cached) verification data from the Northwood API.
+    /// </summary>
+    internal static VerificationData? GetVerificationData()
+    {
+        return data;
+    }
+}


### PR DESCRIPTION
Keeps track of various information about servers.
The endpoint will be an asp.net app that will keep records of various information about each server and allow the public to search through it to identify trends, such as the most popular plugins, avg tps of servers, the team that wins the most rounds, the avg player count/max player count of servers, etc.

More data can be added onto these metrics in the future.

All of this is with server anonymity in mind. Since you need the Server IP and Port hashed together before correlating a server to it's data, it will not be possible to identify from the database alone what servers have what stats, except via a command in the metrics plugin that I will add at a future time.

I will likely replace this server hash identifier with a unique api key stored in the plugin config, that way only those with access to the api key may be able to correlate the data at all (in it's current form, you could hash a server's ip and port yourself in the same fashion used here, to get it's stats)