### PR TITLE
[Breaking] FirearmType enum

### DIFF
--- a/Exiled.API/Enums/FirearmType.cs
+++ b/Exiled.API/Enums/FirearmType.cs
@@ -1,0 +1,70 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="FirearmType.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Enums
+{
+    /// <summary>
+    /// Represents a type of firearm.
+    /// </summary>
+    public enum FirearmType
+    {
+        /// <summary>
+        /// Represents an unknown firearm type.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Represents a <see cref="ItemType.GunCOM15"/>.
+        /// </summary>
+        COM15,
+
+        /// <summary>
+        /// Represents a <see cref="ItemType.GunCOM18"/>.
+        /// </summary>
+        COM18,
+
+        /// <summary>
+        /// Represents a <see cref="ItemType.GunE11SR"/>.
+        /// </summary>
+        E11SR,
+
+        /// <summary>
+        /// Represents a <see cref="ItemType.GunCrossvec"/>.
+        /// </summary>
+        Crossvec,
+
+        /// <summary>
+        /// Represents a <see cref="ItemType.GunFSP9"/>.
+        /// </summary>
+        FSP9,
+
+        /// <summary>
+        /// Represents a <see cref="ItemType.GunLogicer"/>.
+        /// </summary>
+        Logicer,
+
+        /// <summary>
+        /// Represents a <see cref="ItemType.GunRevolver"/>.
+        /// </summary>
+        Revolver,
+
+        /// <summary>
+        /// Represents a <see cref="ItemType.GunAK"/>.
+        /// </summary>
+        AK,
+
+        /// <summary>
+        /// Represents a <see cref="ItemType.GunShotgun"/>.
+        /// </summary>
+        Shotgun,
+
+        /// <summary>
+        /// Represents a <see cref="ItemType.ParticleDisruptor"/>.
+        /// </summary>
+        ParticleDisruptor,
+    }
+}

--- a/Exiled.API/Extensions/ItemExtensions.cs
+++ b/Exiled.API/Extensions/ItemExtensions.cs
@@ -303,13 +303,13 @@ namespace Exiled.API.Extensions
         /// </summary>
         /// <param name="type">The <see cref="FirearmType"/> to check.</param>
         /// <returns>The corresponding <see cref="BaseCode"/>.</returns>
-        public static BaseCode GetBaseCode(this FirearmType type) => GetBaseCode(type.GetItemType());
+        public static BaseCode GetBaseCode(this FirearmType type) => Firearm.FirearmPairs[type];
 
         /// <summary>
         /// Gets the <see cref="BaseCode"/> of the specified <see cref="ItemType"/>.
         /// </summary>
         /// <param name="type">The <see cref="ItemType"/> to check.</param>
         /// <returns>The corresponding <see cref="BaseCode"/>.</returns>
-        public static BaseCode GetBaseCode(this ItemType type) => !type.IsWeapon() ? 0 : Firearm.FirearmPairs[type.GetFirearmType()];
+        public static BaseCode GetBaseCode(this ItemType type) => !type.IsWeapon() ? 0 : GetBaseCode(type.GetFirearmType());
     }
 }

--- a/Exiled.API/Extensions/ItemExtensions.cs
+++ b/Exiled.API/Extensions/ItemExtensions.cs
@@ -272,7 +272,7 @@ namespace Exiled.API.Extensions
         {
             identifiers = default;
 
-            if (!type.GetItemType().IsWeapon())
+            if (type is FirearmType.None)
                 return false;
 
             identifiers = GetAttachmentIdentifiers(type, code);

--- a/Exiled.API/Extensions/ItemExtensions.cs
+++ b/Exiled.API/Extensions/ItemExtensions.cs
@@ -164,6 +164,26 @@ namespace Exiled.API.Extensions
         };
 
         /// <summary>
+        /// Converts a valid firearm <see cref="ItemType"/> into a <see cref="FirearmType"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="ItemType"/> to convert.</param>
+        /// <returns>The firearm type of the given item type.</returns>
+        public static FirearmType GetFirearmType(this ItemType type) => type switch
+        {
+            ItemType.GunCOM15 => FirearmType.COM15,
+            ItemType.GunCOM18 => FirearmType.COM18,
+            ItemType.GunE11SR => FirearmType.E11SR,
+            ItemType.GunCrossvec => FirearmType.Crossvec,
+            ItemType.GunFSP9 => FirearmType.FSP9,
+            ItemType.GunLogicer => FirearmType.Logicer,
+            ItemType.GunRevolver => FirearmType.Revolver,
+            ItemType.GunAK => FirearmType.AK,
+            ItemType.GunShotgun => FirearmType.Shotgun,
+            ItemType.ParticleDisruptor => FirearmType.ParticleDisruptor,
+            _ => FirearmType.None,
+        };
+
+        /// <summary>
         /// Converts an <see cref="AmmoType"/> into it's corresponding <see cref="ItemType"/>.
         /// </summary>
         /// <param name="type">The <see cref="AmmoType"/> to convert.</param>
@@ -189,6 +209,26 @@ namespace Exiled.API.Extensions
             GrenadeType.Scp018 => ItemType.SCP018,
             GrenadeType.FragGrenade => ItemType.GrenadeHE,
             GrenadeType.Scp2176 => ItemType.SCP2176,
+            _ => ItemType.None,
+        };
+
+        /// <summary>
+        /// Converts a <see cref="FirearmType"/> into the corresponding <see cref="ItemType"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="FirearmType"/> to convert.</param>
+        /// <returns>The Item type of the specified firearm.</returns>
+        public static ItemType GetItemType(this FirearmType type) => type switch
+        {
+            FirearmType.COM15 => ItemType.GunCOM15,
+            FirearmType.COM18 => ItemType.GunCOM18,
+            FirearmType.E11SR => ItemType.GunE11SR,
+            FirearmType.Crossvec => ItemType.GunCrossvec,
+            FirearmType.FSP9 => ItemType.GunFSP9,
+            FirearmType.Logicer => ItemType.GunLogicer,
+            FirearmType.Revolver => ItemType.GunRevolver,
+            FirearmType.AK => ItemType.GunAK,
+            FirearmType.Shotgun => ItemType.GunShotgun,
+            FirearmType.ParticleDisruptor => ItemType.ParticleDisruptor,
             _ => ItemType.None,
         };
 
@@ -265,6 +305,6 @@ namespace Exiled.API.Extensions
         /// </summary>
         /// <param name="type">The <see cref="ItemType"/> to check.</param>
         /// <returns>The corresponding <see cref="BaseCode"/>.</returns>
-        public static BaseCode GetBaseCode(this ItemType type) => !type.IsWeapon() ? 0 : Firearm.FirearmPairs[type];
+        public static BaseCode GetBaseCode(this ItemType type) => !type.IsWeapon() ? 0 : Firearm.FirearmPairs[type.GetFirearmType()];
     }
 }

--- a/Exiled.API/Extensions/ItemExtensions.cs
+++ b/Exiled.API/Extensions/ItemExtensions.cs
@@ -295,7 +295,7 @@ namespace Exiled.API.Extensions
         public static IEnumerable<AttachmentIdentifier> GetAttachmentIdentifiers(this Firearm firearm)
         {
             foreach (Attachment attachment in firearm.Attachments.Where(att => att.IsEnabled))
-                yield return Firearm.AvailableAttachments[firearm.Type].FirstOrDefault(att => att == attachment);
+                yield return Firearm.AvailableAttachments[firearm.Type.GetFirearmType()].FirstOrDefault(att => att == attachment);
         }
 
         /// <summary>

--- a/Exiled.API/Extensions/ItemExtensions.cs
+++ b/Exiled.API/Extensions/ItemExtensions.cs
@@ -310,6 +310,6 @@ namespace Exiled.API.Extensions
         /// </summary>
         /// <param name="type">The <see cref="ItemType"/> to check.</param>
         /// <returns>The corresponding <see cref="BaseCode"/>.</returns>
-        public static BaseCode GetBaseCode(this ItemType type) => !type.IsWeapon() ? 0 : Firearm.FirearmPairs[type];
+        public static BaseCode GetBaseCode(this ItemType type) => !type.IsWeapon() ? 0 : Firearm.FirearmPairs[type.GetFirearmType()];
     }
 }

--- a/Exiled.API/Extensions/MirrorExtensions.cs
+++ b/Exiled.API/Extensions/MirrorExtensions.cs
@@ -14,7 +14,7 @@ namespace Exiled.API.Extensions
     using System.Reflection;
     using System.Reflection.Emit;
     using System.Text;
-
+    using Exiled.API.Enums;
     using Exiled.API.Features;
 
     using InventorySystem.Items.Firearms;
@@ -138,11 +138,11 @@ namespace Exiled.API.Extensions
         /// <param name="itemType">Weapon' sound to play.</param>
         /// <param name="volume">Sound's volume to set.</param>
         /// <param name="audioClipId">GunAudioMessage's audioClipId to set (default = 0).</param>
-        public static void PlayGunSound(this Player player, Vector3 position, ItemType itemType, byte volume, byte audioClipId = 0)
+        public static void PlayGunSound(this Player player, Vector3 position, FirearmType itemType, byte volume, byte audioClipId = 0)
         {
             GunAudioMessage message = new()
             {
-                Weapon = itemType,
+                Weapon = itemType.GetItemType(),
                 AudioClipId = audioClipId,
                 MaxDistance = volume,
                 ShooterNetId = 0U,

--- a/Exiled.API/Extensions/MirrorExtensions.cs
+++ b/Exiled.API/Extensions/MirrorExtensions.cs
@@ -14,6 +14,7 @@ namespace Exiled.API.Extensions
     using System.Reflection;
     using System.Reflection.Emit;
     using System.Text;
+
     using Exiled.API.Enums;
     using Exiled.API.Features;
 

--- a/Exiled.API/Features/DamageHandlers/CustomDamageHandler.cs
+++ b/Exiled.API/Features/DamageHandlers/CustomDamageHandler.cs
@@ -63,7 +63,7 @@ namespace Exiled.API.Features.DamageHandlers
         {
             Damage = damage;
             Type = damageType;
-            Firearm firearm = new(ItemType.GunAK)
+            Firearm firearm = new(FirearmType.AK)
             {
                 Base =
                 {

--- a/Exiled.API/Features/DamageHandlers/GenericDamageHandler.cs
+++ b/Exiled.API/Features/DamageHandlers/GenericDamageHandler.cs
@@ -108,34 +108,34 @@ namespace Exiled.API.Features.DamageHandlers
                     Base = new ExplosionDamageHandler(attacker.Footprint, UnityEngine.Vector3.zero, damage, 0);
                     break;
                 case DamageType.Firearm:
-                    GenericFirearm(player, attacker, damage, damageType, ItemType.GunAK);
+                    GenericFirearm(player, attacker, damage, damageType, FirearmType.AK);
                     break;
                 case DamageType.Crossvec:
-                    GenericFirearm(player, attacker, damage, damageType, ItemType.GunCrossvec);
+                    GenericFirearm(player, attacker, damage, damageType, FirearmType.Crossvec);
                     break;
                 case DamageType.Logicer:
-                    GenericFirearm(player, attacker, damage, damageType, ItemType.GunLogicer);
+                    GenericFirearm(player, attacker, damage, damageType, FirearmType.Logicer);
                     break;
                 case DamageType.Revolver:
-                    GenericFirearm(player, attacker, damage, damageType, ItemType.GunRevolver);
+                    GenericFirearm(player, attacker, damage, damageType, FirearmType.Revolver);
                     break;
                 case DamageType.Shotgun:
-                    GenericFirearm(player, attacker, damage, damageType, ItemType.GunShotgun);
+                    GenericFirearm(player, attacker, damage, damageType, FirearmType.Shotgun);
                     break;
                 case DamageType.AK:
-                    GenericFirearm(player, attacker, damage, damageType, ItemType.GunAK);
+                    GenericFirearm(player, attacker, damage, damageType, FirearmType.AK);
                     break;
                 case DamageType.Com15:
-                    GenericFirearm(player, attacker, damage, damageType, ItemType.GunCOM15);
+                    GenericFirearm(player, attacker, damage, damageType, FirearmType.COM15);
                     break;
                 case DamageType.Com18:
-                    GenericFirearm(player, attacker, damage, damageType, ItemType.GunCOM18);
+                    GenericFirearm(player, attacker, damage, damageType, FirearmType.COM18);
                     break;
                 case DamageType.Fsp9:
-                    GenericFirearm(player, attacker, damage, damageType, ItemType.GunFSP9);
+                    GenericFirearm(player, attacker, damage, damageType, FirearmType.FSP9);
                     break;
                 case DamageType.E11Sr:
-                    GenericFirearm(player, attacker, damage, damageType, ItemType.GunE11SR);
+                    GenericFirearm(player, attacker, damage, damageType, FirearmType.E11SR);
                     break;
                 case DamageType.ParticleDisruptor:
                     Base = new DisruptorDamageHandler(Attacker, damage);
@@ -229,8 +229,8 @@ namespace Exiled.API.Features.DamageHandlers
         /// <param name="attacker"> Current attacker. </param>
         /// <param name="amount"> Damage amount. </param>
         /// <param name="damageType"> Damage type. </param>
-        /// <param name="itemType"> ItemType. </param>
-        private void GenericFirearm(Player player, Player attacker, float amount, DamageType damageType, ItemType itemType)
+        /// <param name="itemType"> FirearmType. </param>
+        private void GenericFirearm(Player player, Player attacker, float amount, DamageType damageType, FirearmType itemType)
         {
             Firearm firearm = new(itemType)
             {

--- a/Exiled.API/Features/Items/Firearm.cs
+++ b/Exiled.API/Features/Items/Firearm.cs
@@ -109,7 +109,7 @@ namespace Exiled.API.Features.Items
                                 Player.Get(keyValuePair.Key),
                                 keyValuePair.Value.ToDictionary(
                                     kvp => kvp.Key,
-                                    kvp => kvp.Key.GetAttachmentIdentifiers(kvp.Value).ToArray()));
+                                    kvp => kvp.Key.GetFirearmType().GetAttachmentIdentifiers(kvp.Value).ToArray()));
                         });
 
                 return playerPreferences.Where(kvp => kvp.Key is not null).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
@@ -497,7 +497,7 @@ namespace Exiled.API.Features.Items
         /// </summary>
         /// <param name="player">The <see cref="Player"/> of which must be removed.</param>
         /// <param name="itemType">The <see cref="ItemType"/> to remove.</param>
-        public void RemovePreference(Player player, ItemType itemType)
+        public void RemovePreference(Player player, FirearmType itemType)
         {
             foreach (KeyValuePair<Player, Dictionary<ItemType, AttachmentIdentifier[]>> kvp in PlayerPreferences)
             {
@@ -505,7 +505,7 @@ namespace Exiled.API.Features.Items
                     continue;
 
                 if (AttachmentsServerHandler.PlayerPreferences.TryGetValue(player.ReferenceHub, out Dictionary<ItemType, uint> dictionary))
-                    dictionary[itemType] = (uint)itemType.GetBaseCode();
+                    dictionary[itemType.GetItemType()] = (uint)itemType.GetBaseCode();
             }
         }
 
@@ -551,7 +551,7 @@ namespace Exiled.API.Features.Items
             if (AttachmentsServerHandler.PlayerPreferences.TryGetValue(player.ReferenceHub, out Dictionary<ItemType, uint> dictionary))
             {
                 foreach (KeyValuePair<ItemType, uint> kvp in dictionary)
-                    dictionary[kvp.Key] = (uint)kvp.Key.GetBaseCode();
+                    dictionary[kvp.Key] = (uint)kvp.Key.GetFirearmType().GetBaseCode();
             }
         }
 

--- a/Exiled.API/Features/Items/Firearm.cs
+++ b/Exiled.API/Features/Items/Firearm.cs
@@ -36,18 +36,18 @@ namespace Exiled.API.Features.Items
         /// <summary>
         /// Gets a <see cref="IReadOnlyDictionary{TKey, TValue}"/> which contains all pairs for <see cref="ItemType"/> and <see cref="Enums.BaseCode"/>.
         /// </summary>
-        internal static readonly IReadOnlyDictionary<ItemType, BaseCode> FirearmPairs = new Dictionary<ItemType, BaseCode>()
+        internal static readonly IReadOnlyDictionary<FirearmType, BaseCode> FirearmPairs = new Dictionary<FirearmType, BaseCode>()
         {
-            { ItemType.GunCOM15, BaseCode.GunCOM15 },
-            { ItemType.GunCOM18, BaseCode.GunCOM18 },
-            { ItemType.GunRevolver, BaseCode.GunRevolver },
-            { ItemType.GunE11SR, BaseCode.GunE11SR },
-            { ItemType.GunCrossvec, BaseCode.GunCrossvec },
-            { ItemType.GunFSP9, BaseCode.GunFSP9 },
-            { ItemType.GunLogicer, BaseCode.GunLogicer },
-            { ItemType.GunAK, BaseCode.GunAK },
-            { ItemType.GunShotgun, BaseCode.GunShotgun },
-            { ItemType.ParticleDisruptor, BaseCode.Disruptor },
+            { FirearmType.COM15, BaseCode.GunCOM15 },
+            { FirearmType.COM18, BaseCode.GunCOM18 },
+            { FirearmType.Revolver, BaseCode.GunRevolver },
+            { FirearmType.E11SR, BaseCode.GunE11SR },
+            { FirearmType.Crossvec, BaseCode.GunCrossvec },
+            { FirearmType.FSP9, BaseCode.GunFSP9 },
+            { FirearmType.Logicer, BaseCode.GunLogicer },
+            { FirearmType.AK, BaseCode.GunAK },
+            { FirearmType.Shotgun, BaseCode.GunShotgun },
+            { FirearmType.ParticleDisruptor, BaseCode.Disruptor },
         };
 
         /// <summary>
@@ -75,6 +75,15 @@ namespace Exiled.API.Features.Items
         /// <param name="type">The <see cref="ItemType"/> of the firearm.</param>
         internal Firearm(ItemType type)
             : this((InventorySystem.Items.Firearms.Firearm)Server.Host.Inventory.CreateItemInstance(type, false))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Firearm"/> class.
+        /// </summary>
+        /// <param name="type">The <see cref="FirearmType"/> of the firearm.</param>
+        internal Firearm(FirearmType type)
+            : this((InventorySystem.Items.Firearms.Firearm)Server.Host.Inventory.CreateItemInstance(type.GetItemType(), false))
         {
         }
 
@@ -174,7 +183,7 @@ namespace Exiled.API.Features.Items
         /// </summary>
         public BaseCode BaseCode
         {
-            get => FirearmPairs[Type];
+            get => FirearmPairs[Type.GetFirearmType()];
         }
 
         /// <summary>

--- a/Exiled.API/Features/Items/Item.cs
+++ b/Exiled.API/Features/Items/Item.cs
@@ -9,6 +9,7 @@ namespace Exiled.API.Features.Items
 {
     using System.Collections.Generic;
     using System.Linq;
+
     using Exiled.API.Enums;
     using Exiled.API.Extensions;
     using Exiled.API.Structs;

--- a/Exiled.API/Features/Items/Item.cs
+++ b/Exiled.API/Features/Items/Item.cs
@@ -324,7 +324,7 @@ namespace Exiled.API.Features.Items
                         Revolver revolver => revolver.AmmoManagerModule.MaxAmmo,
                         _ => 0,
                     };
-                    uint code = identifiers is not null ? (uint)firearmPickup.Info.ItemId.GetBaseCode() + identifiers.GetAttachmentsCode() : firearmPickup.Status.Attachments;
+                    uint code = identifiers is not null ? (uint)firearmPickup.Info.ItemId.GetFirearmType().GetBaseCode() + identifiers.GetAttachmentsCode() : firearmPickup.Status.Attachments;
                     firearmPickup.Status = new FirearmStatus(ammo, FirearmStatusFlags.MagazineInserted, code);
                 }
 

--- a/Exiled.API/Features/Items/Item.cs
+++ b/Exiled.API/Features/Items/Item.cs
@@ -9,7 +9,7 @@ namespace Exiled.API.Features.Items
 {
     using System.Collections.Generic;
     using System.Linq;
-
+    using Exiled.API.Enums;
     using Exiled.API.Extensions;
     using Exiled.API.Structs;
 
@@ -277,6 +277,22 @@ namespace Exiled.API.Features.Items
             ItemType.SCP2176 => new Scp2176(owner),
             _ => new Item(type),
         };
+
+        /// <summary>
+        /// Creates a new <see cref="Firearm"/> from the given <see cref="FirearmType"/>.
+        /// </summary>
+        /// <param name="type">The type of firearm.</param>
+        /// <param name="owner">The <see cref="Player"/> who owns the item by default.</param>
+        /// <returns>The Firearm.</returns>
+        public static Firearm Create(FirearmType type, Player owner = null) => (Firearm)Create(type.GetItemType(), owner);
+
+        /// <summary>
+        /// Creates a new <see cref="Throwable"/> from the given <see cref="GrenadeType"/>.
+        /// </summary>
+        /// <param name="type">The type of grenade.</param>
+        /// <param name="owner">The <see cref="Player"/> who owns the item by default.</param>
+        /// <returns>The throwable.</returns>
+        public static Throwable Create(GrenadeType type, Player owner = null) => (Throwable)Create(type.GetItemType(), owner);
 
         /// <summary>
         /// Gives this item to a <see cref="Player"/>.

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1144,7 +1144,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a <see cref="Dictionary{TKey, TValue}"/> which contains all player's preferences.
         /// </summary>
-        public Dictionary<ItemType, AttachmentIdentifier[]> Preferences
+        public Dictionary<FirearmType, AttachmentIdentifier[]> Preferences
         {
             get => Firearm.PlayerPreferences.FirstOrDefault(kvp => kvp.Key == this).Value;
         }
@@ -2173,9 +2173,9 @@ namespace Exiled.API.Features
         /// <summary>
         /// Adds the amount of a weapon's <see cref="AmmoType">ammo type</see> to the player's inventory.
         /// </summary>
-        /// <param name="weaponType">The <see cref="ItemType"/> of the weapon.</param>
+        /// <param name="weaponType">The <see cref="firearmtype"/> of the weapon.</param>
         /// <param name="amount">The amount of ammo to be added.</param>
-        public void AddAmmo(ItemType weaponType, ushort amount) => AddAmmo(weaponType.GetWeaponAmmoType(), amount);
+        public void AddAmmo(FirearmType weaponType, ushort amount) => AddAmmo(weaponType.GetWeaponAmmoType(), amount);
 
         /// <summary>
         /// Sets the amount of a specified <see cref="AmmoType">ammo type</see> to the player's inventory.
@@ -2235,7 +2235,7 @@ namespace Exiled.API.Features
                 {
                     firearm.AddAttachment(identifiers);
                 }
-                else if (Preferences.TryGetValue(itemType, out AttachmentIdentifier[] attachments))
+                else if (Preferences.TryGetValue(itemType.GetFirearmType(), out AttachmentIdentifier[] attachments))
                 {
                     firearm.Base.ApplyAttachmentsCode(attachments.GetAttachmentsCode(), true);
                 }
@@ -2416,7 +2416,7 @@ namespace Exiled.API.Features
 
                 if (itemBase is InventorySystem.Items.Firearms.Firearm firearm)
                 {
-                    if (Preferences.TryGetValue(firearm.ItemTypeId, out AttachmentIdentifier[] attachments))
+                    if (Preferences.TryGetValue(firearm.ItemTypeId.GetFirearmType(), out AttachmentIdentifier[] attachments))
                     {
                         firearm.ApplyAttachmentsCode(attachments.GetAttachmentsCode(), true);
                     }
@@ -2904,8 +2904,8 @@ namespace Exiled.API.Features
             Connection.Send(new RoundRestartMessage(roundRestartType, delay, newPort, reconnect, false));
         }
 
-        /// <inheritdoc cref="MirrorExtensions.PlayGunSound(Player, Vector3, ItemType, byte, byte)"/>
-        public void PlayGunSound(ItemType type, byte volume, byte audioClipId = 0) =>
+        /// <inheritdoc cref="MirrorExtensions.PlayGunSound(Player, Vector3, FirearmType, byte, byte)"/>
+        public void PlayGunSound(FirearmType type, byte volume, byte audioClipId = 0) =>
             MirrorExtensions.PlayGunSound(this, Position, type, volume, audioClipId);
 
         /// <inheritdoc cref="Map.PlaceBlood(Vector3, BloodType, float)"/>

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -2173,7 +2173,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Adds the amount of a weapon's <see cref="AmmoType">ammo type</see> to the player's inventory.
         /// </summary>
-        /// <param name="weaponType">The <see cref="firearmtype"/> of the weapon.</param>
+        /// <param name="weaponType">The <see cref="FirearmType"/> of the weapon.</param>
         /// <param name="amount">The amount of ammo to be added.</param>
         public void AddAmmo(FirearmType weaponType, ushort amount) => AddAmmo(weaponType.GetWeaponAmmoType(), amount);
 

--- a/Exiled.Events/EventArgs/Item/ReceivingPreferenceEventArgs.cs
+++ b/Exiled.Events/EventArgs/Item/ReceivingPreferenceEventArgs.cs
@@ -9,7 +9,7 @@ namespace Exiled.Events.EventArgs.Item
 {
     using System.Collections.Generic;
     using System.Linq;
-
+    using Exiled.API.Enums;
     using Exiled.API.Extensions;
     using Exiled.API.Features;
     using Exiled.API.Structs;
@@ -40,7 +40,7 @@ namespace Exiled.Events.EventArgs.Item
         /// </param>
         public ReceivingPreferenceEventArgs(
             Player player,
-            ItemType itemType,
+            FirearmType itemType,
             uint currentCode,
             uint newCode,
             bool isAllowed = true)
@@ -56,7 +56,7 @@ namespace Exiled.Events.EventArgs.Item
         /// <summary>
         ///     Gets the <see cref="ItemType" /> which is being modified.
         /// </summary>
-        public ItemType Item { get; }
+        public FirearmType Item { get; }
 
         /// <summary>
         ///     Gets the old <see cref="AttachmentIdentifier" />[].

--- a/Exiled.Events/EventArgs/Item/ReceivingPreferenceEventArgs.cs
+++ b/Exiled.Events/EventArgs/Item/ReceivingPreferenceEventArgs.cs
@@ -54,7 +54,7 @@ namespace Exiled.Events.EventArgs.Item
         }
 
         /// <summary>
-        ///     Gets the <see cref="ItemType" /> which is being modified.
+        ///     Gets the <see cref="FirearmType" /> which is being modified.
         /// </summary>
         public FirearmType Item { get; }
 

--- a/Exiled.Events/Handlers/Internal/MapGenerated.cs
+++ b/Exiled.Events/Handlers/Internal/MapGenerated.cs
@@ -125,10 +125,7 @@ namespace Exiled.Events.Handlers.Internal
         {
             foreach (FirearmType type in Enum.GetValues(typeof(FirearmType)))
             {
-                Item item = Item.Create(type.GetItemType());
-                if (item is not Firearm firearm)
-                    continue;
-
+                Firearm firearm = Item.Create(type);
                 Firearm.FirearmInstances.Add(firearm);
                 uint code = 1;
                 List<AttachmentIdentifier> attachmentIdentifiers = new();

--- a/Exiled.Events/Handlers/Internal/MapGenerated.cs
+++ b/Exiled.Events/Handlers/Internal/MapGenerated.cs
@@ -141,7 +141,7 @@ namespace Exiled.Events.Handlers.Internal
                     code *= 2U;
                 }
 
-                Firearm.AvailableAttachmentsValue.Add(type, attachmentIdentifiers.ToArray());
+                Firearm.AvailableAttachmentsValue.Add(type.GetFirearmType(), attachmentIdentifiers.ToArray());
             }
         }
     }

--- a/Exiled.Events/Handlers/Internal/MapGenerated.cs
+++ b/Exiled.Events/Handlers/Internal/MapGenerated.cs
@@ -10,7 +10,7 @@ namespace Exiled.Events.Handlers.Internal
     using System;
     using System.Collections.Generic;
     using System.Linq;
-
+    using Exiled.API.Enums;
     using Exiled.API.Extensions;
     using Exiled.API.Features;
     using Exiled.API.Features.Items;
@@ -123,12 +123,9 @@ namespace Exiled.Events.Handlers.Internal
 
         private static void GenerateAttachments()
         {
-            foreach (ItemType type in Enum.GetValues(typeof(ItemType)))
+            foreach (FirearmType type in Enum.GetValues(typeof(FirearmType)))
             {
-                if (!type.IsWeapon(false))
-                    continue;
-
-                Item item = Item.Create(type);
+                Item item = Item.Create(type.GetItemType());
                 if (item is not Firearm firearm)
                     continue;
 
@@ -141,7 +138,7 @@ namespace Exiled.Events.Handlers.Internal
                     code *= 2U;
                 }
 
-                Firearm.AvailableAttachmentsValue.Add(type.GetFirearmType(), attachmentIdentifiers.ToArray());
+                Firearm.AvailableAttachmentsValue.Add(type, attachmentIdentifiers.ToArray());
             }
         }
     }


### PR DESCRIPTION
Replace firearm-related methods using ItemType with FirearmType (similar to GrenadeType) so invalid items cannot be passed