### PR TITLE
Fix TickComponent instantiation

### DIFF
--- a/Exiled.API/Features/Core/TickComponent.cs
+++ b/Exiled.API/Features/Core/TickComponent.cs
@@ -33,9 +33,9 @@ namespace Exiled.API.Features.Core
         protected TickComponent()
             : base()
         {
-            CanEverTick = true;
             executeAllHandle = Timing.RunCoroutine(ExecuteAll());
             boundHandles = new HashSet<CoroutineHandle>();
+            CanEverTick = true;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes an ArgumentNullException in the TickComponent constructor. This is caused by calling CanEverTick's setter prior to instantiating boundHandles as CanEverTick calls .ToArray() on boundHandles.