### PR TITLE
Fix for code broken by #148 and fixed a broken if

### DIFF
--- a/Exiled.Events/EventArgs/Player/PreAuthenticatingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/PreAuthenticatingEventArgs.cs
@@ -106,7 +106,7 @@ namespace Exiled.Events.EventArgs.Player
         /// <param name="isForced">Indicates whether the player has to be rejected forcefully or not.</param>
         public void Delay(byte seconds, bool isForced)
         {
-            if ((seconds < 1) && (seconds > 25))
+            if (seconds is < 1 or > 25)
                 throw new Exception("Delay duration must be between 1 and 25 seconds.");
 
             Reject(RejectionReason.Delay, isForced, null, 0, seconds);
@@ -213,9 +213,6 @@ namespace Exiled.Events.EventArgs.Player
                 case RejectionReason.Redirect:
                     rejectData.Put(port);
                     break;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(rejectionReason), rejectionReason, null);
             }
 
             if (isForced)


### PR DESCRIPTION
 - Fixed code broken by #148 - there are other values possible for that switch. No action should be taken then.
 - Fixed seconds check in `Delay`. The expression was always false, because `&&` was used instead of `||`.