### PR TITLE
Fix duplicate `RoundStart` event

### DIFF
--- a/Exiled.Events/Patches/Events/Server/RoundStarted.cs
+++ b/Exiled.Events/Patches/Events/Server/RoundStarted.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.Patches.Events.Server
 {
-#pragma warning disable SA1313
-
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
@@ -19,10 +17,10 @@ namespace Exiled.Events.Patches.Events.Server
     using NorthwoodLib.Pools;
 
     /// <summary>
-    /// Patches <see cref="RoundSummary.SetStartClassList"/>.
+    /// Patches <see cref="CharacterClassManager.RpcRoundStarted"/>.
     /// Adds the RoundStarted event.
     /// </summary>
-    [HarmonyPatch(typeof(RoundSummary), nameof(RoundSummary.SetStartClassList))]
+    [HarmonyPatch(typeof(CharacterClassManager), nameof(CharacterClassManager.RpcRoundStarted))]
     internal static class RoundStarted
     {
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)


### PR DESCRIPTION
Event patches the cringe method(for role selection on round start), that can invokes randomly 1 - 3 times (NW logic)
