### PR TITLE
Changed the default value of CanFlashbangsAffectThrower to `false`

### DIFF
--- a/Exiled.Events/Config.cs
+++ b/Exiled.Events/Config.cs
@@ -22,13 +22,13 @@ namespace Exiled.Events
         /// Gets or sets a value indicating whether SCP-173 can be blocked or not by the tutorial.
         /// </summary>
         [Description("Indicates whether SCP-173 can be blocked or not by the tutorial")]
-        public bool CanTutorialBlockScp173 { get; set; } = true;
+        public bool CanTutorialBlockScp173 { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether SCP-096 can be triggered or not by the tutorial.
         /// </summary>
         [Description("Indicates whether SCP-096 can be triggered or not by the tutorial")]
-        public bool CanTutorialTriggerScp096 { get; set; } = true;
+        public bool CanTutorialTriggerScp096 { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether flashbangs flash original thrower.

--- a/Exiled.Events/Config.cs
+++ b/Exiled.Events/Config.cs
@@ -34,7 +34,7 @@ namespace Exiled.Events
         /// Gets or sets a value indicating whether flashbangs flash original thrower.
         /// </summary>
         [Description("Indicates whether flashbangs flash original thrower.")]
-        public bool CanFlashbangsAffectThrower { get; set; } = true;
+        public bool CanFlashbangsAffectThrower { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether the name tracking is enabled or not.

--- a/Exiled.Events/Config.cs
+++ b/Exiled.Events/Config.cs
@@ -22,13 +22,13 @@ namespace Exiled.Events
         /// Gets or sets a value indicating whether SCP-173 can be blocked or not by the tutorial.
         /// </summary>
         [Description("Indicates whether SCP-173 can be blocked or not by the tutorial")]
-        public bool CanTutorialBlockScp173 { get; set; } = false;
+        public bool CanTutorialBlockScp173 { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether SCP-096 can be triggered or not by the tutorial.
         /// </summary>
         [Description("Indicates whether SCP-096 can be triggered or not by the tutorial")]
-        public bool CanTutorialTriggerScp096 { get; set; } = false;
+        public bool CanTutorialTriggerScp096 { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether flashbangs flash original thrower.


### PR DESCRIPTION
In the base-game the thrower of the flashbangs does not get flashed no matter what (FF settings for example). Therefore, this config option should match base-game behaviour.