### PR TITLE
`Player.OnAimingDownSight` event fix

### DIFF
--- a/Exiled.Events/EventArgs/AimingDownSightEventArgs.cs
+++ b/Exiled.Events/EventArgs/AimingDownSightEventArgs.cs
@@ -22,8 +22,7 @@ namespace Exiled.Events.EventArgs
         /// </summary>
         /// <param name="player"><inheritdoc cref="Player"/></param>
         /// <param name="adsIn"><inheritdoc cref="AdsIn"/></param>
-        /// <param name="adsOut"><inheritdoc cref="AdsOut"/></param>
-        public AimingDownSightEventArgs(Player player, bool adsIn, bool adsOut)
+        public AimingDownSightEventArgs(Player player, bool adsIn)
         {
             if (player?.CurrentItem is Firearm firearm)
                 Firearm = firearm;
@@ -32,7 +31,7 @@ namespace Exiled.Events.EventArgs
 
             Player = player;
             AdsIn = adsIn;
-            AdsOut = adsOut;
+            AdsOut = !adsIn;
         }
 
         /// <summary>

--- a/Exiled.Events/EventArgs/AimingDownSightEventArgs.cs
+++ b/Exiled.Events/EventArgs/AimingDownSightEventArgs.cs
@@ -22,6 +22,25 @@ namespace Exiled.Events.EventArgs
         /// </summary>
         /// <param name="player"><inheritdoc cref="Player"/></param>
         /// <param name="adsIn"><inheritdoc cref="AdsIn"/></param>
+        /// <param name="adsOut"><inheritdoc cref="AdsOut"/></param>
+        [Obsolete("Use AimingDownSightEventArgs(Player, bool) instead.", true)]
+        public AimingDownSightEventArgs(Player player, bool adsIn, bool adsOut)
+        {
+            if (player?.CurrentItem is Firearm firearm)
+                Firearm = firearm;
+            else
+                Firearm = null;
+
+            Player = player;
+            AdsIn = adsIn;
+            AdsOut = adsOut;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AimingDownSightEventArgs"/> class.
+        /// </summary>
+        /// <param name="player"><inheritdoc cref="Player"/></param>
+        /// <param name="adsIn"><inheritdoc cref="AdsIn"/></param>
         public AimingDownSightEventArgs(Player player, bool adsIn)
         {
             if (player?.CurrentItem is Firearm firearm)

--- a/Exiled.Events/EventArgs/AimingDownSightEventArgs.cs
+++ b/Exiled.Events/EventArgs/AimingDownSightEventArgs.cs
@@ -43,10 +43,7 @@ namespace Exiled.Events.EventArgs
         /// <param name="adsIn"><inheritdoc cref="AdsIn"/></param>
         public AimingDownSightEventArgs(Player player, bool adsIn)
         {
-            if (player?.CurrentItem is Firearm firearm)
-                Firearm = firearm;
-            else
-                Firearm = null;
+            Firearm = player?.CurrentItem as Firearm;
 
             Player = player;
             AdsIn = adsIn;

--- a/Exiled.Events/Patches/Events/Player/FirearmRequestReceived.cs
+++ b/Exiled.Events/Patches/Events/Player/FirearmRequestReceived.cs
@@ -91,37 +91,38 @@ namespace Exiled.Events.Patches.Events.Player
                 new(OpCodes.Brfalse, returnLabel),
             });
 
-            offset = 2;
-            index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Pop) + offset;
+            offset = -3;
+            index = newInstructions.FindIndex(instruction => instruction.Calls(PropertySetter(typeof(IAdsModule), nameof(IAdsModule.ServerAds)))) + offset;
 
-            newInstructions.InsertRange(index, new[]
-            {
-                new CodeInstruction(OpCodes.Ldloc_0).MoveLabelsFrom(newInstructions[index]),
-                new(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(ReferenceHub) })),
-                new(OpCodes.Dup),
-                new(OpCodes.Stloc, player.LocalIndex),
-                new(OpCodes.Brfalse_S, skipAdsLabel),
-                new(OpCodes.Ldloc, player.LocalIndex),
-                new(OpCodes.Ldc_I4_1),
-                new(OpCodes.Ldc_I4_0),
-                new(OpCodes.Newobj, GetDeclaredConstructors(typeof(AimingDownSightEventArgs))[0]),
-                new(OpCodes.Call, Method(typeof(Player), nameof(Player.OnAimingDownSight))),
-                new CodeInstruction(OpCodes.Nop).WithLabels(skipAdsLabel),
-            });
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    new CodeInstruction(OpCodes.Ldloc_0).MoveLabelsFrom(newInstructions[index]),
+                    new(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(ReferenceHub) })),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Stloc, player.LocalIndex),
+                    new(OpCodes.Brfalse_S, skipAdsLabel),
+                    new(OpCodes.Ldloc, player.LocalIndex),
+                    new(OpCodes.Ldc_I4_1),
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(AimingDownSightEventArgs))[0]),
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.OnAimingDownSight))),
+                    new CodeInstruction(OpCodes.Nop).WithLabels(skipAdsLabel),
+                });
 
             offset = -3;
-            index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Ldfld &&
-            (FieldInfo)instruction.operand == Field(typeof(FirearmStatus), nameof(FirearmStatus.Flags))) + offset;
+            index = newInstructions.FindLastIndex(instruction => instruction.Calls(PropertySetter(typeof(IAdsModule), nameof(IAdsModule.ServerAds)))) + offset;
 
-            newInstructions.InsertRange(index, new[]
-            {
-                new CodeInstruction(OpCodes.Ldloc_0).MoveLabelsFrom(newInstructions[index]),
-                new(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(ReferenceHub) })),
-                new(OpCodes.Ldc_I4_0),
-                new(OpCodes.Ldc_I4_1),
-                new(OpCodes.Newobj, GetDeclaredConstructors(typeof(AimingDownSightEventArgs))[0]),
-                new(OpCodes.Call, Method(typeof(Player), nameof(Player.OnAimingDownSight))),
-            });
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    new CodeInstruction(OpCodes.Ldloc_0).MoveLabelsFrom(newInstructions[index]),
+                    new(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(ReferenceHub) })),
+                    new(OpCodes.Ldc_I4_0),
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(AimingDownSightEventArgs))[0]),
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.OnAimingDownSight))),
+                });
 
             offset = -6;
             index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Call) + offset;

--- a/Exiled.Events/Patches/Events/Player/FirearmRequestReceived.cs
+++ b/Exiled.Events/Patches/Events/Player/FirearmRequestReceived.cs
@@ -105,7 +105,7 @@ namespace Exiled.Events.Patches.Events.Player
                     new(OpCodes.Brfalse_S, skipAdsLabel),
                     new(OpCodes.Ldloc, player.LocalIndex),
                     new(OpCodes.Ldc_I4_1),
-                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(AimingDownSightEventArgs))[0]),
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(AimingDownSightEventArgs))[1]),
                     new(OpCodes.Call, Method(typeof(Player), nameof(Player.OnAimingDownSight))),
                     new CodeInstruction(OpCodes.Nop).WithLabels(skipAdsLabel),
                 });
@@ -120,7 +120,7 @@ namespace Exiled.Events.Patches.Events.Player
                     new CodeInstruction(OpCodes.Ldloc_0).MoveLabelsFrom(newInstructions[index]),
                     new(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(ReferenceHub) })),
                     new(OpCodes.Ldc_I4_0),
-                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(AimingDownSightEventArgs))[0]),
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(AimingDownSightEventArgs))[1]),
                     new(OpCodes.Call, Method(typeof(Player), nameof(Player.OnAimingDownSight))),
                 });
 


### PR DESCRIPTION
yea, now event works for both states, but i think in Exiled 6.0 we need change event name to something like `ChangingAimStatus`, and I don't see the point of two props `AdsIn` and `AdsOut` instead of one, for example `AdsStatus`