### PR TITLE
Some post-merge fixes

### DIFF
--- a/Exiled.API/Enums/DamageType.cs
+++ b/Exiled.API/Enums/DamageType.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Enums
 {
     using Features;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.API/Enums/EffectType.cs
+++ b/Exiled.API/Enums/EffectType.cs
@@ -118,11 +118,6 @@ namespace Exiled.API.Enums
         SinkHole,
 
         /// <summary>
-        /// Gives the player the SCP-939 sound vision.
-        /// </summary>
-        Visuals939,
-
-        /// <summary>
         /// Reduces overall damage taken.
         /// </summary>
         DamageReduction,

--- a/Exiled.API/Enums/LeadingTeam.cs
+++ b/Exiled.API/Enums/LeadingTeam.cs
@@ -8,7 +8,9 @@
 namespace Exiled.API.Enums
 {
     using Extensions;
+
     using Features;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.API/Enums/RespawnEffectType.cs
+++ b/Exiled.API/Enums/RespawnEffectType.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Enums
 {
     using Features;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.API/Enums/Side.cs
+++ b/Exiled.API/Enums/Side.cs
@@ -8,7 +8,9 @@
 namespace Exiled.API.Enums
 {
     using Extensions;
+
     using Features;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.API/Extensions/DamageTypeExtensions.cs
+++ b/Exiled.API/Extensions/DamageTypeExtensions.cs
@@ -10,6 +10,7 @@ namespace Exiled.API.Extensions
     using System.Collections.Generic;
 
     using Enums;
+
     using Features;
 
     using PlayerStatsSystem;

--- a/Exiled.API/Extensions/EffectTypeExtension.cs
+++ b/Exiled.API/Extensions/EffectTypeExtension.cs
@@ -14,6 +14,7 @@ namespace Exiled.API.Extensions
     using Enums;
 
     using InventorySystem.Items.Usables.Scp244.Hypothermia;
+
     using PlayerRoles.FirstPersonControl;
 
     /// <summary>

--- a/Exiled.API/Extensions/ItemExtensions.cs
+++ b/Exiled.API/Extensions/ItemExtensions.cs
@@ -12,10 +12,13 @@ namespace Exiled.API.Extensions
     using System.Linq;
 
     using Enums;
+
     using Features.Items;
+
     using InventorySystem;
     using InventorySystem.Items;
     using InventorySystem.Items.Firearms.Attachments;
+
     using Structs;
 
     /// <summary>

--- a/Exiled.API/Extensions/MirrorExtensions.cs
+++ b/Exiled.API/Extensions/MirrorExtensions.cs
@@ -214,15 +214,15 @@ namespace Exiled.API.Extensions
         /// <param name="isSubtitles">Same on <see cref="Cassie.MessageTranslated(string, string, bool, bool, bool)"/>'s isSubtitles.</param>
         public static void MessageTranslated(this Player player, string words, string translation, bool makeHold = false, bool makeNoise = true, bool isSubtitles = true)
         {
-            StringBuilder annoucement = StringBuilderPool.Shared.Rent();
+            StringBuilder announcement = StringBuilderPool.Shared.Rent();
 
             string[] cassies = words.Split('\n');
             string[] translations = translation.Split('\n');
 
             for (int i = 0; i < cassies.Length; i++)
-                annoucement.Append($"{translations[i]}<size=0> {cassies[i].Replace(' ', ' ')} </size><split>");
+                announcement.Append($"{translations[i]}<size=0> {cassies[i].Replace(' ', ' ')} </size><split>");
 
-            string message = annoucement.ToString();
+            string message = StringBuilderPool.Shared.ToStringReturn(announcement);
 
             foreach (RespawnEffectsController controller in RespawnEffectsController.AllControllers)
             {
@@ -231,8 +231,6 @@ namespace Exiled.API.Extensions
                     SendFakeTargetRpc(player, controller.netIdentity, typeof(RespawnEffectsController), nameof(RespawnEffectsController.RpcCassieAnnouncement), message, makeHold, makeNoise, isSubtitles);
                 }
             }
-
-            StringBuilderPool.Shared.Return(annoucement);
         }
 
         /// <summary>

--- a/Exiled.API/Extensions/MirrorExtensions.cs
+++ b/Exiled.API/Extensions/MirrorExtensions.cs
@@ -212,16 +212,20 @@ namespace Exiled.API.Extensions
         public static void MessageTranslated(this Player player, string words, string translation, bool makeHold = false, bool makeNoise = true, bool isSubtitles = true)
         {
             StringBuilder annoucement = StringBuilderPool.Shared.Rent();
+
             string[] cassies = words.Split('\n');
             string[] translations = translation.Split('\n');
+
             for (int i = 0; i < cassies.Length; i++)
                 annoucement.Append($"{translations[i]}<size=0> {cassies[i].Replace(' ', ' ')} </size><split>");
+
+            string message = annoucement.ToString();
 
             foreach (RespawnEffectsController controller in RespawnEffectsController.AllControllers)
             {
                 if (controller != null)
                 {
-                    SendFakeTargetRpc(player, controller.netIdentity, typeof(RespawnEffectsController), nameof(RespawnEffectsController.RpcCassieAnnouncement), annoucement, makeHold, makeNoise, isSubtitles);
+                    SendFakeTargetRpc(player, controller.netIdentity, typeof(RespawnEffectsController), nameof(RespawnEffectsController.RpcCassieAnnouncement), message, makeHold, makeNoise, isSubtitles);
                 }
             }
 

--- a/Exiled.API/Extensions/MirrorExtensions.cs
+++ b/Exiled.API/Extensions/MirrorExtensions.cs
@@ -22,8 +22,11 @@ namespace Exiled.API.Extensions
     using Mirror;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles;
+
     using RelativePositioning;
+
     using Respawning;
 
     using UnityEngine;

--- a/Exiled.API/Extensions/RoleExtensions.cs
+++ b/Exiled.API/Extensions/RoleExtensions.cs
@@ -8,10 +8,13 @@
 namespace Exiled.API.Extensions
 {
     using Enums;
+
     using Exiled.API.Features;
     using Exiled.API.Features.Spawn;
+
     using PlayerRoles;
     using PlayerRoles.FirstPersonControl;
+
     using UnityEngine;
 
     using Team = PlayerRoles.Team;

--- a/Exiled.API/Extensions/RoomExtensions.cs
+++ b/Exiled.API/Extensions/RoomExtensions.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Extensions
 {
     using Exiled.API.Enums;
+
     using MapGeneration;
 
     /// <summary>

--- a/Exiled.API/Features/Camera.cs
+++ b/Exiled.API/Features/Camera.cs
@@ -12,7 +12,9 @@ namespace Exiled.API.Features
     using System.Linq;
 
     using Enums;
+
     using PlayerRoles.PlayableScps.Scp079.Cameras;
+
     using UnityEngine;
 
     using CameraType = Enums.CameraType;

--- a/Exiled.API/Features/Cassie.cs
+++ b/Exiled.API/Features/Cassie.cs
@@ -14,7 +14,9 @@ namespace Exiled.API.Features
     using MEC;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles;
+
     using PlayerStatsSystem;
 
     using Respawning;
@@ -153,7 +155,7 @@ namespace Exiled.API.Features
             else if (info.BaseIs(out CustomFirearmHandler firearmDamageHandler) && firearmDamageHandler.Attacker is Player attacker)
                 result += " CONTAINEDSUCCESSFULLY " + ConvertTeam(attacker.Role.Team, attacker.UnitName);
 
-                // result += "To be changed";
+            // result += "To be changed";
             else
                 result += " SUCCESSFULLY TERMINATED . TERMINATION CAUSE UNSPECIFIED";
 

--- a/Exiled.API/Features/DamageHandlers/CustomDamageHandler.cs
+++ b/Exiled.API/Features/DamageHandlers/CustomDamageHandler.cs
@@ -8,10 +8,15 @@
 namespace Exiled.API.Features.DamageHandlers
 {
     using CustomPlayerEffects;
+
     using Enums;
+
     using Exiled.API.Extensions;
+
     using Items;
+
     using PlayerStatsSystem;
+
     using UnityEngine;
 
     using BaseFirearmHandler = PlayerStatsSystem.FirearmDamageHandler;

--- a/Exiled.API/Features/DamageHandlers/DamageHandlerBase.cs
+++ b/Exiled.API/Features/DamageHandlers/DamageHandlerBase.cs
@@ -13,8 +13,11 @@ namespace Exiled.API.Features.DamageHandlers
     using System.Linq;
 
     using Enums;
+
     using Extensions;
+
     using PlayerRoles.PlayableScps.Scp939;
+
     using PlayerStatsSystem;
 
     using BaseHandler = PlayerStatsSystem.DamageHandlerBase;

--- a/Exiled.API/Features/DamageHandlers/FirearmDamageHandler.cs
+++ b/Exiled.API/Features/DamageHandlers/FirearmDamageHandler.cs
@@ -8,7 +8,9 @@
 namespace Exiled.API.Features.DamageHandlers
 {
     using Enums;
+
     using Extensions;
+
     using Items;
 
     using PlayerStatsSystem;

--- a/Exiled.API/Features/DamageHandlers/GenericDamageHandler.cs
+++ b/Exiled.API/Features/DamageHandlers/GenericDamageHandler.cs
@@ -8,10 +8,14 @@
 namespace Exiled.API.Features.DamageHandlers
 {
     using Enums;
+
     using Footprinting;
+
     using Items;
+
     using PlayerRoles.PlayableScps.Scp096;
     using PlayerRoles.PlayableScps.Scp939;
+
     using PlayerStatsSystem;
 
     /// <summary>

--- a/Exiled.API/Features/DamageHandlers/ScpDamageHandler.cs
+++ b/Exiled.API/Features/DamageHandlers/ScpDamageHandler.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features.DamageHandlers
 {
     using Enums;
+
     using Extensions;
 
     using PlayerStatsSystem;

--- a/Exiled.API/Features/Door.cs
+++ b/Exiled.API/Features/Door.cs
@@ -12,6 +12,7 @@ namespace Exiled.API.Features
     using System.Linq;
 
     using Enums;
+
     using Extensions;
 
     using Interactables.Interobjects;
@@ -93,7 +94,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a value indicating whether or not the door is currently moving.
         /// </summary>
-        public bool IsMoving => ExactState is not(0 or 1);
+        public bool IsMoving => ExactState is not (0 or 1);
 
         /// <summary>
         /// Gets a value indicating the precise state of the door, from <c>0-1</c>. A value of <c>0</c> indicates the door is fully closed, while a value of <c>1</c> indicates the door is fully open. Values in-between represent the door's animation progress.

--- a/Exiled.API/Features/Door.cs
+++ b/Exiled.API/Features/Door.cs
@@ -94,7 +94,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a value indicating whether or not the door is currently moving.
         /// </summary>
-        public bool IsMoving => ExactState is not (0 or 1);
+        public bool IsMoving => ExactState is not(0 or 1);
 
         /// <summary>
         /// Gets a value indicating the precise state of the door, from <c>0-1</c>. A value of <c>0</c> indicates the door is fully closed, while a value of <c>1</c> indicates the door is fully open. Values in-between represent the door's animation progress.

--- a/Exiled.API/Features/Intercom.cs
+++ b/Exiled.API/Features/Intercom.cs
@@ -8,7 +8,9 @@
 namespace Exiled.API.Features
 {
     using Mirror;
+
     using PlayerRoles.Voice;
+
     using UnityEngine;
 
     using GameIntercom = PlayerRoles.Voice.Intercom;

--- a/Exiled.API/Features/Items/Armor.cs
+++ b/Exiled.API/Features/Items/Armor.cs
@@ -12,7 +12,9 @@ namespace Exiled.API.Features.Items
     using System.Linq;
 
     using InventorySystem.Items.Armor;
+
     using PlayerRoles;
+
     using Structs;
 
     /// <summary>

--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -8,11 +8,14 @@
 namespace Exiled.API.Features.Items
 {
     using Enums;
+
     using Exiled.API.Features.Pickups;
     using Exiled.API.Features.Pickups.Projectiles;
+
     using InventorySystem.Items;
     using InventorySystem.Items.Pickups;
     using InventorySystem.Items.ThrowableProjectiles;
+
     using UnityEngine;
 
     using Object = UnityEngine.Object;

--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -116,7 +116,11 @@ namespace Exiled.API.Features.Items
 #if DEBUG
             Log.Debug($"Spawning active grenade: {FuseTime}");
 #endif
-            ExplosionGrenadeProjectile grenade = (ExplosionGrenadeProjectile)Pickup.Get(Object.Instantiate(Projectile.Base, position, Quaternion.identity));
+            ItemPickupBase ipb = Object.Instantiate(Projectile.Base, position, Quaternion.identity);
+
+            ipb.Info = new PickupSyncInfo(Type, position, Quaternion.identity, Weight, ItemSerialGenerator.GenerateNext());
+
+            ExplosionGrenadeProjectile grenade = (ExplosionGrenadeProjectile)Pickup.Get(ipb);
 
             grenade.Base.gameObject.SetActive(true);
 
@@ -128,8 +132,6 @@ namespace Exiled.API.Features.Items
             grenade.FuseTime = FuseTime;
 
             grenade.PreviousOwner = owner ?? Server.Host;
-
-            grenade.Info = new PickupSyncInfo(grenade.Type, position, Quaternion.identity, Weight, ItemSerialGenerator.GenerateNext());
 
             grenade.Spawn();
 

--- a/Exiled.API/Features/Items/Firearm.cs
+++ b/Exiled.API/Features/Items/Firearm.cs
@@ -12,16 +12,21 @@ namespace Exiled.API.Features.Items
     using System.Linq;
 
     using CameraShaking;
+
     using Enums;
+
     using Exiled.API.Features.Pickups;
     using Exiled.API.Structs;
+
     using Extensions;
+
     using InventorySystem.Items;
     using InventorySystem.Items.Firearms;
     using InventorySystem.Items.Firearms.Attachments;
     using InventorySystem.Items.Firearms.Attachments.Components;
     using InventorySystem.Items.Firearms.BasicMessages;
     using InventorySystem.Items.Firearms.Modules;
+
     using UnityEngine;
 
     using BaseFirearm = InventorySystem.Items.Firearms.Firearm;

--- a/Exiled.API/Features/Items/Firearm.cs
+++ b/Exiled.API/Features/Items/Firearm.cs
@@ -26,6 +26,7 @@ namespace Exiled.API.Features.Items
     using InventorySystem.Items.Firearms.Attachments.Components;
     using InventorySystem.Items.Firearms.BasicMessages;
     using InventorySystem.Items.Firearms.Modules;
+    using InventorySystem.Items.Pickups;
 
     using UnityEngine;
 
@@ -566,10 +567,13 @@ namespace Exiled.API.Features.Items
         /// <returns>The created <see cref="Pickup"/>.</returns>
         public override Pickup CreatePickup(Vector3 position, Quaternion rotation = default, bool spawn = true)
         {
-            FirearmPickup pickup = (FirearmPickup)Pickup.Get(Object.Instantiate(Base.PickupDropModel, position, rotation));
+            ItemPickupBase ipb = Object.Instantiate(Base.PickupDropModel, position, rotation);
 
-            pickup.Info = new(Type, position, rotation, pickup.Weight, ItemSerialGenerator.GenerateNext());
-            pickup.Scale = Scale;
+            ipb.Info = new(Type, position, rotation, Weight, ItemSerialGenerator.GenerateNext());
+            ipb.gameObject.transform.localScale = Scale;
+
+            FirearmPickup pickup = Pickup.Get(ipb).As<FirearmPickup>();
+
             pickup.Status = Base.Status;
 
             if (spawn)

--- a/Exiled.API/Features/Items/FlashGrenade.cs
+++ b/Exiled.API/Features/Items/FlashGrenade.cs
@@ -96,7 +96,11 @@ namespace Exiled.API.Features.Items
 #if DEBUG
             Log.Debug($"Spawning active grenade: {FuseTime}");
 #endif
-            FlashbangProjectile grenade = (FlashbangProjectile)Pickup.Get(Object.Instantiate(Projectile.Base, position, Quaternion.identity));
+            ItemPickupBase ipb = Object.Instantiate(Projectile.Base, position, Quaternion.identity);
+
+            ipb.Info = new PickupSyncInfo(Type, position, Quaternion.identity, Weight, ItemSerialGenerator.GenerateNext());
+
+            FlashbangProjectile grenade = (FlashbangProjectile)Pickup.Get(ipb);
 
             grenade.Base.gameObject.SetActive(true);
 
@@ -106,8 +110,6 @@ namespace Exiled.API.Features.Items
             grenade.FuseTime = FuseTime;
 
             grenade.PreviousOwner = owner ?? Server.Host;
-
-            grenade.Info = new PickupSyncInfo(grenade.Type, position, Quaternion.identity, Weight, ItemSerialGenerator.GenerateNext());
 
             grenade.Spawn();
 

--- a/Exiled.API/Features/Items/Item.cs
+++ b/Exiled.API/Features/Items/Item.cs
@@ -12,6 +12,7 @@ namespace Exiled.API.Features.Items
 
     using Exiled.API.Features.Core;
     using Exiled.API.Features.Pickups;
+
     using InventorySystem.Items;
     using InventorySystem.Items.Armor;
     using InventorySystem.Items.Firearms.Ammo;
@@ -24,6 +25,7 @@ namespace Exiled.API.Features.Items
     using InventorySystem.Items.Usables.Scp1576;
     using InventorySystem.Items.Usables.Scp244;
     using InventorySystem.Items.Usables.Scp330;
+
     using UnityEngine;
 
     using BaseConsumable = InventorySystem.Items.Usables.Consumable;

--- a/Exiled.API/Features/Items/Item.cs
+++ b/Exiled.API/Features/Items/Item.cs
@@ -19,6 +19,7 @@ namespace Exiled.API.Features.Items
     using InventorySystem.Items.Flashlight;
     using InventorySystem.Items.Keycards;
     using InventorySystem.Items.MicroHID;
+    using InventorySystem.Items.Pickups;
     using InventorySystem.Items.Radio;
     using InventorySystem.Items.ThrowableProjectiles;
     using InventorySystem.Items.Usables;
@@ -278,10 +279,12 @@ namespace Exiled.API.Features.Items
         /// <returns>The created <see cref="Pickup"/>.</returns>
         public virtual Pickup CreatePickup(Vector3 position, Quaternion rotation = default, bool spawn = true)
         {
-            Pickup pickup = Pickup.Get(Object.Instantiate(Base.PickupDropModel, position, rotation));
+            ItemPickupBase ipb = Object.Instantiate(Base.PickupDropModel, position, rotation);
 
-            pickup.Info = new(Type, position, rotation, Weight, ItemSerialGenerator.GenerateNext());
-            pickup.Scale = Scale;
+            ipb.Info = new(Type, position, rotation, Weight, ItemSerialGenerator.GenerateNext());
+            ipb.gameObject.transform.localScale = Scale;
+
+            Pickup pickup = Pickup.Get(ipb);
 
             if (spawn)
                 pickup.Spawn();

--- a/Exiled.API/Features/Items/Radio.cs
+++ b/Exiled.API/Features/Items/Radio.cs
@@ -8,7 +8,9 @@
 namespace Exiled.API.Features.Items
 {
     using Enums;
+
     using InventorySystem.Items.Radio;
+
     using Structs;
 
     /// <summary>

--- a/Exiled.API/Features/Items/Scp2176.cs
+++ b/Exiled.API/Features/Items/Scp2176.cs
@@ -67,15 +67,17 @@ namespace Exiled.API.Features.Items
 #if DEBUG
             Log.Debug($"Spawning active grenade: {FuseTime}");
 #endif
-            Scp2176Projectile grenade = (Scp2176Projectile)Pickup.Get(Object.Instantiate(Projectile.Base, position, Quaternion.identity));
+            ItemPickupBase ipb = Object.Instantiate(Projectile.Base, position, Quaternion.identity);
+
+            ipb.Info = new PickupSyncInfo(Type, position, Quaternion.identity, Weight, ItemSerialGenerator.GenerateNext());
+
+            Scp2176Projectile grenade = (Scp2176Projectile)Pickup.Get(ipb);
 
             grenade.Base.gameObject.SetActive(true);
 
             grenade.FuseTime = FuseTime;
 
             grenade.PreviousOwner = owner ?? Server.Host;
-
-            grenade.Info = new PickupSyncInfo(grenade.Type, position, Quaternion.identity, Weight, ItemSerialGenerator.GenerateNext());
 
             grenade.Spawn();
 

--- a/Exiled.API/Features/Items/Scp330.cs
+++ b/Exiled.API/Features/Items/Scp330.cs
@@ -183,14 +183,19 @@ namespace Exiled.API.Features.Items
 
             List<Scp330Pickup> pickups = new();
 
-            if ((count > 1) && !dropIndividual)
+            if (count > 1 && !dropIndividual)
             {
-                Scp330Pickup pickup = (Scp330Pickup)Pickup.Get(Object.Instantiate(Base.PickupDropModel, Owner.Position, default));
+                ItemPickupBase ipb = Object.Instantiate(Base.PickupDropModel, Owner.Position, default);
+
+                ipb.Info = new(Type, Owner.Position, default, Weight, ItemSerialGenerator.GenerateNext());
+
+                Scp330Pickup pickup = (Scp330Pickup)Pickup.Get(ipb);
+
                 if (exposedType is not CandyKindID.None)
                     pickup.ExposedCandy = exposedType;
                 for (int i = 0; i < count; i++)
                     pickup.Candies.Add(type);
-                pickup.Info = new(Type, Owner.Position, default, Weight, ItemSerialGenerator.GenerateNext());
+
                 pickup.Base.InfoReceived(default, pickup.Info);
                 pickup.Scale = Scale;
                 pickup.Spawn();
@@ -201,13 +206,16 @@ namespace Exiled.API.Features.Items
 
             for (int i = 0; i < count; i++)
             {
-                Scp330Pickup pickup = (Scp330Pickup)Pickup.Get(Object.Instantiate(Base.PickupDropModel, Owner.Position, default));
+                ItemPickupBase ipb = Object.Instantiate(Base.PickupDropModel, Owner.Position, default);
+
+                ipb.Info = new(Type, Owner.Position, default, Weight, ItemSerialGenerator.GenerateNext());
+
+                Scp330Pickup pickup = (Scp330Pickup)Pickup.Get(ipb);
 
                 if (exposedType is not CandyKindID.None)
                     pickup.ExposedCandy = exposedType;
 
                 pickup.Candies.Add(type);
-                pickup.Info = new PickupSyncInfo(Type, Owner.Position, default, Weight, ItemSerialGenerator.GenerateNext());
                 pickup.Base.InfoReceived(default, pickup.Info);
                 pickup.Scale = Scale;
                 pickup.Spawn();

--- a/Exiled.API/Features/Items/Scp330.cs
+++ b/Exiled.API/Features/Items/Scp330.cs
@@ -8,7 +8,6 @@
 namespace Exiled.API.Features.Items
 {
     using System.Collections.Generic;
-    using System.Linq;
 
     using Exiled.API.Features.Pickups;
 
@@ -190,7 +189,7 @@ namespace Exiled.API.Features.Items
                 if (exposedType is not CandyKindID.None)
                     pickup.ExposedCandy = exposedType;
                 for (int i = 0; i < count; i++)
-                pickup.Candies.Add(type);
+                    pickup.Candies.Add(type);
                 pickup.Info = new(Type, Owner.Position, default, Weight, ItemSerialGenerator.GenerateNext());
                 pickup.Base.InfoReceived(default, pickup.Info);
                 pickup.Scale = Scale;

--- a/Exiled.API/Features/Lift.cs
+++ b/Exiled.API/Features/Lift.cs
@@ -12,8 +12,10 @@ namespace Exiled.API.Features
     using System.Linq;
 
     using Exiled.API.Enums;
+
     using Interactables.Interobjects;
     using Interactables.Interobjects.DoorUtils;
+
     using UnityEngine;
 
     using static Interactables.Interobjects.ElevatorChamber;

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -13,22 +13,33 @@ namespace Exiled.API.Features
     using System.Linq;
 
     using Enums;
+
     using Exiled.API.Extensions;
     using Exiled.API.Features.Pickups;
     using Exiled.API.Features.Roles;
     using Exiled.API.Features.Toys;
+
     using Hazards;
+
     using InventorySystem.Items.Firearms.BasicMessages;
+
     using Items;
+
     using LightContainmentZoneDecontamination;
+
     using MapGeneration;
     using MapGeneration.Distributors;
+
     using Mirror;
+
     using PlayerRoles;
     using PlayerRoles.PlayableScps.Scp173;
     using PlayerRoles.PlayableScps.Scp939;
+
     using RelativePositioning;
+
     using UnityEngine;
+
     using Utils.Networking;
 
     using Object = UnityEngine.Object;

--- a/Exiled.API/Features/Pickups/GrenadePickup.cs
+++ b/Exiled.API/Features/Pickups/GrenadePickup.cs
@@ -9,6 +9,7 @@ namespace Exiled.API.Features.Pickups
 {
     using Exiled.API.Enums;
     using Exiled.API.Extensions;
+
     using InventorySystem.Items.ThrowableProjectiles;
 
     /// <summary>

--- a/Exiled.API/Features/Pickups/Pickup.cs
+++ b/Exiled.API/Features/Pickups/Pickup.cs
@@ -12,12 +12,15 @@ namespace Exiled.API.Features.Pickups
 
     using Exiled.API.Features.Core;
     using Exiled.API.Features.Pickups.Projectiles;
+
     using InventorySystem;
     using InventorySystem.Items;
     using InventorySystem.Items.Pickups;
     using InventorySystem.Items.ThrowableProjectiles;
     using InventorySystem.Items.Usables.Scp244;
+
     using Mirror;
+
     using UnityEngine;
 
     using BaseAmmoPickup = InventorySystem.Items.Firearms.Ammo.AmmoPickup;

--- a/Exiled.API/Features/Pickups/Pickup.cs
+++ b/Exiled.API/Features/Pickups/Pickup.cs
@@ -53,10 +53,6 @@ namespace Exiled.API.Features.Pickups
             if (pickupBase.Info.ItemId == ItemType.None)
                 return;
 
-            // prevent exploded grenades to added in dict
-            if (!PhysicsPredictionPickup.AllPickups.Contains(pickupBase))
-                return;
-
             BaseToPickup.Add(pickupBase, this);
         }
 

--- a/Exiled.API/Features/Pickups/Projectiles/EffectGrenadeProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/EffectGrenadeProjectile.cs
@@ -7,9 +7,6 @@
 
 namespace Exiled.API.Features.Pickups.Projectiles
 {
-    using Exiled.API.Enums;
-    using Exiled.API.Extensions;
-
     using InventorySystem.Items.ThrowableProjectiles;
 
     /// <summary>

--- a/Exiled.API/Features/Pickups/Projectiles/ExplosionGrenadeProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/ExplosionGrenadeProjectile.cs
@@ -10,7 +10,9 @@ namespace Exiled.API.Features.Pickups.Projectiles
     using Exiled.API.Enums;
 
     using InventorySystem.Items.ThrowableProjectiles;
+
     using PlayerRoles;
+
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.API/Features/Pickups/Projectiles/Projectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/Projectile.cs
@@ -11,6 +11,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
     using Exiled.API.Extensions;
 
     using InventorySystem.Items.ThrowableProjectiles;
+
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.API/Features/Pickups/Scp1576Pickup.cs
+++ b/Exiled.API/Features/Pickups/Scp1576Pickup.cs
@@ -7,10 +7,6 @@
 
 namespace Exiled.API.Features.Pickups
 {
-    using System.Collections.Generic;
-
-    using InventorySystem.Items.Usables.Scp1576;
-
     using BaseScp1576 = InventorySystem.Items.Usables.Scp1576.Scp1576Pickup;
 
     /// <summary>

--- a/Exiled.API/Features/Pickups/Scp244Pickup.cs
+++ b/Exiled.API/Features/Pickups/Scp244Pickup.cs
@@ -10,7 +10,9 @@ namespace Exiled.API.Features.Pickups
     using System;
 
     using Exiled.API.Features.DamageHandlers;
+
     using InventorySystem.Items.Usables.Scp244;
+
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -14,19 +14,29 @@ namespace Exiled.API.Features
     using System.Runtime.CompilerServices;
 
     using Core;
+
     using CustomPlayerEffects;
+
     using DamageHandlers;
+
     using Enums;
+
     using Exiled.API.Features.Core.Interfaces;
     using Exiled.API.Features.Items;
     using Exiled.API.Features.Pickups;
     using Exiled.API.Features.Roles;
     using Exiled.API.Structs;
+
     using Extensions;
+
     using Footprinting;
+
     using global::Scp914;
+
     using Hints;
+
     using Interactables.Interobjects;
+
     using InventorySystem;
     using InventorySystem.Disarming;
     using InventorySystem.Items;
@@ -36,12 +46,17 @@ namespace Exiled.API.Features
     using InventorySystem.Items.Firearms.BasicMessages;
     using InventorySystem.Items.Usables;
     using InventorySystem.Items.Usables.Scp330;
+
     using MapGeneration.Distributors;
+
     using MEC;
+
     using Mirror;
     using Mirror.LiteNetLib4Mirror;
+
     using NorthwoodLib;
     using NorthwoodLib.Pools;
+
     using PlayerRoles;
     using PlayerRoles.FirstPersonControl;
     using PlayerRoles.PlayableScps.Scp079;
@@ -50,11 +65,17 @@ namespace Exiled.API.Features
     using PlayerRoles.PlayableScps.Scp939;
     using PlayerRoles.Spectating;
     using PlayerRoles.Voice;
+
     using PlayerStatsSystem;
+
     using RemoteAdmin;
+
     using RoundRestarting;
+
     using UnityEngine;
+
     using Utils.Networking;
+
     using VoiceChat;
     using VoiceChat.Playbacks;
 

--- a/Exiled.API/Features/Plugin.cs
+++ b/Exiled.API/Features/Plugin.cs
@@ -15,7 +15,9 @@ namespace Exiled.API.Features
     using CommandSystem;
 
     using Enums;
+
     using Extensions;
+
     using Interfaces;
 
     using RemoteAdmin;

--- a/Exiled.API/Features/Ragdoll.cs
+++ b/Exiled.API/Features/Ragdoll.cs
@@ -14,13 +14,15 @@ namespace Exiled.API.Features
     using DeathAnimations;
 
     using Enums;
+
     using Exiled.API.Extensions;
-    using Interactables.Interobjects.DoorUtils;
-    using MapGeneration;
+
     using Mirror;
+
     using PlayerRoles;
     using PlayerRoles.PlayableScps.Scp049.Zombies;
     using PlayerRoles.Ragdolls;
+
     using PlayerStatsSystem;
 
     using UnityEngine;

--- a/Exiled.API/Features/Recontainer.cs
+++ b/Exiled.API/Features/Recontainer.cs
@@ -11,7 +11,9 @@ namespace Exiled.API.Features
     using System.Linq;
 
     using Enums;
+
     using PlayerRoles.PlayableScps.Scp079;
+
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.API/Features/Roles/FpcRole.cs
+++ b/Exiled.API/Features/Roles/FpcRole.cs
@@ -10,9 +10,10 @@ namespace Exiled.API.Features.Roles
     using System.Collections.Generic;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles;
     using PlayerRoles.FirstPersonControl;
-    using PlayerRoles.PlayableScps.HumeShield;
+
     using PlayerStatsSystem;
 
     /// <summary>

--- a/Exiled.API/Features/Roles/HumanRole.cs
+++ b/Exiled.API/Features/Roles/HumanRole.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features.Roles
 {
     using PlayerRoles;
+
     using Respawning;
 
     using HumanGameRole = PlayerRoles.HumanRole;

--- a/Exiled.API/Features/Roles/Role.cs
+++ b/Exiled.API/Features/Roles/Role.cs
@@ -8,7 +8,6 @@
 namespace Exiled.API.Features.Roles
 {
     using System;
-    using System.Diagnostics;
 
     using Enums;
 
@@ -16,8 +15,10 @@ namespace Exiled.API.Features.Roles
     using Exiled.API.Features.Spawn;
 
     using Extensions;
+
     using PlayerRoles;
     using PlayerRoles.PlayableScps.Scp049.Zombies;
+
     using UnityEngine;
 
     using HumanGameRole = PlayerRoles.HumanRole;

--- a/Exiled.API/Features/Roles/Scp0492Role.cs
+++ b/Exiled.API/Features/Roles/Scp0492Role.cs
@@ -11,7 +11,6 @@ namespace Exiled.API.Features.Roles
     using PlayerRoles.PlayableScps.HumeShield;
     using PlayerRoles.PlayableScps.Scp049;
     using PlayerRoles.PlayableScps.Scp049.Zombies;
-    using PlayerRoles.PlayableScps.Scp079;
     using PlayerRoles.PlayableScps.Subroutines;
 
     /// <summary>

--- a/Exiled.API/Features/Roles/Scp173Role.cs
+++ b/Exiled.API/Features/Roles/Scp173Role.cs
@@ -11,6 +11,7 @@ namespace Exiled.API.Features.Roles
     using System.Linq;
 
     using Mirror;
+
     using PlayerRoles;
     using PlayerRoles.PlayableScps.HumeShield;
     using PlayerRoles.PlayableScps.Scp173;

--- a/Exiled.API/Features/Roles/Scp939Role.cs
+++ b/Exiled.API/Features/Roles/Scp939Role.cs
@@ -14,6 +14,7 @@ namespace Exiled.API.Features.Roles
     using PlayerRoles.PlayableScps.Scp939;
     using PlayerRoles.PlayableScps.Scp939.Mimicry;
     using PlayerRoles.PlayableScps.Subroutines;
+
     using UnityEngine;
 
     using Scp939GameRole = PlayerRoles.PlayableScps.Scp939.Scp939Role;

--- a/Exiled.API/Features/Roles/SpectatorRole.cs
+++ b/Exiled.API/Features/Roles/SpectatorRole.cs
@@ -10,6 +10,7 @@ namespace Exiled.API.Features.Roles
     using System;
 
     using PlayerRoles;
+
     using UnityEngine;
 
     using SpectatorGameRole = PlayerRoles.Spectating.SpectatorRole;

--- a/Exiled.API/Features/Room.cs
+++ b/Exiled.API/Features/Room.cs
@@ -12,15 +12,20 @@ namespace Exiled.API.Features
     using System.Linq;
 
     using Enums;
+
     using Exiled.API.Extensions;
-    using Exiled.API.Features.Items;
     using Exiled.API.Features.Pickups;
 
     using Interactables.Interobjects.DoorUtils;
+
     using MapGeneration;
+
     using MEC;
+
     using Mirror;
+
     using PlayerRoles.PlayableScps.Scp079;
+
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.API/Features/Round.cs
+++ b/Exiled.API/Features/Round.cs
@@ -13,7 +13,9 @@ namespace Exiled.API.Features
     using Enums;
 
     using GameCore;
+
     using PlayerRoles;
+
     using RoundRestarting;
 
     /// <summary>

--- a/Exiled.API/Features/Server.cs
+++ b/Exiled.API/Features/Server.cs
@@ -12,13 +12,19 @@ namespace Exiled.API.Features
     using System.Reflection;
 
     using CustomPlayerEffects;
+
     using GameCore;
+
     using Interfaces;
-    using MapGeneration.Distributors;
+
     using MEC;
+
     using Mirror;
+
     using PlayerRoles.RoleAssign;
+
     using RoundRestarting;
+
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.API/Features/Spawn/DynamicSpawnPoint.cs
+++ b/Exiled.API/Features/Spawn/DynamicSpawnPoint.cs
@@ -10,6 +10,7 @@ namespace Exiled.API.Features.Spawn
     using System;
 
     using Exiled.API.Enums;
+
     using Extensions;
 
     using UnityEngine;

--- a/Exiled.API/Features/Spawn/RoleSpawnPoint.cs
+++ b/Exiled.API/Features/Spawn/RoleSpawnPoint.cs
@@ -10,7 +10,9 @@ namespace Exiled.API.Features.Spawn
     using System;
 
     using Extensions;
+
     using PlayerRoles;
+
     using UnityEngine;
 
     using YamlDotNet.Serialization;

--- a/Exiled.API/Features/Spawn/SpawnLocation.cs
+++ b/Exiled.API/Features/Spawn/SpawnLocation.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features.Spawn
 {
     using PlayerRoles;
+
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.API/Features/TeslaGate.cs
+++ b/Exiled.API/Features/TeslaGate.cs
@@ -12,8 +12,11 @@ namespace Exiled.API.Features
     using System.Linq;
 
     using Hazards;
+
     using MEC;
+
     using PlayerRoles;
+
     using UnityEngine;
 
     using BaseTeslaGate = global::TeslaGate;

--- a/Exiled.API/Features/Warhead.cs
+++ b/Exiled.API/Features/Warhead.cs
@@ -8,7 +8,9 @@
 namespace Exiled.API.Features
 {
     using Enums;
+
     using Mirror;
+
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.API/Features/Window.cs
+++ b/Exiled.API/Features/Window.cs
@@ -10,7 +10,9 @@ namespace Exiled.API.Features
     using System.Collections.Generic;
 
     using DamageHandlers;
+
     using Enums;
+
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.API/Interfaces/IPlugin.cs
+++ b/Exiled.API/Interfaces/IPlugin.cs
@@ -14,6 +14,7 @@ namespace Exiled.API.Interfaces
     using CommandSystem;
 
     using Enums;
+
     using Features;
 
     /// <summary>

--- a/Exiled.API/Structs/ArmorAmmoLimit.cs
+++ b/Exiled.API/Structs/ArmorAmmoLimit.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Structs
 {
     using Enums;
+
     using Extensions;
 
     using InventorySystem.Items.Armor;

--- a/Exiled.API/Structs/AttachmentIdentifier.cs
+++ b/Exiled.API/Structs/AttachmentIdentifier.cs
@@ -12,6 +12,7 @@ namespace Exiled.API.Structs
     using System.Linq;
 
     using Exiled.API.Enums;
+
     using InventorySystem.Items.Firearms.Attachments;
     using InventorySystem.Items.Firearms.Attachments.Components;
 

--- a/Exiled.CustomItems/API/EventArgs/OwnerChangingRoleEventArgs.cs
+++ b/Exiled.CustomItems/API/EventArgs/OwnerChangingRoleEventArgs.cs
@@ -12,6 +12,7 @@ namespace Exiled.CustomItems.API.EventArgs
     using Exiled.Events.EventArgs.Player;
 
     using InventorySystem.Items;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.CustomItems/API/EventArgs/OwnerEscapingEventArgs.cs
+++ b/Exiled.CustomItems/API/EventArgs/OwnerEscapingEventArgs.cs
@@ -11,6 +11,7 @@ namespace Exiled.CustomItems.API.EventArgs
     using Exiled.API.Features.Items;
     using Exiled.CustomItems.API.Features;
     using Exiled.Events.EventArgs.Player;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.CustomItems/API/Features/CustomGrenade.cs
+++ b/Exiled.CustomItems/API/Features/CustomGrenade.cs
@@ -9,10 +9,8 @@ namespace Exiled.CustomItems.API.Features
 {
     using System;
 
-    using Exiled.API.Enums;
     using Exiled.API.Extensions;
     using Exiled.API.Features;
-    using Exiled.API.Features.Items;
     using Exiled.API.Features.Pickups.Projectiles;
     using Exiled.Events.EventArgs.Map;
     using Exiled.Events.EventArgs.Player;

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -21,7 +21,6 @@ namespace Exiled.CustomItems.API.Features
     using Exiled.API.Features.Spawn;
     using Exiled.API.Interfaces;
     using Exiled.CustomItems.API.EventArgs;
-    using Exiled.Events.EventArgs;
     using Exiled.Events.EventArgs.Player;
     using Exiled.Events.EventArgs.Scp914;
     using Exiled.Loader;
@@ -34,7 +33,9 @@ namespace Exiled.CustomItems.API.Features
     using MEC;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles;
+
     using UnityEngine;
 
     using YamlDotNet.Serialization;

--- a/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -15,15 +15,14 @@ namespace Exiled.CustomItems.API.Features
     using Exiled.API.Features.DamageHandlers;
     using Exiled.API.Features.Items;
     using Exiled.API.Features.Pickups;
-    using Exiled.Events.EventArgs;
     using Exiled.Events.EventArgs.Player;
 
     using InventorySystem.Items.Firearms.Attachments;
     using InventorySystem.Items.Firearms.Attachments.Components;
     using InventorySystem.Items.Firearms.BasicMessages;
 
-    using MEC;
     using PlayerRoles;
+
     using UnityEngine;
 
     using Firearm = Exiled.API.Features.Items.Firearm;

--- a/Exiled.CustomItems/Events/PlayerHandler.cs
+++ b/Exiled.CustomItems/Events/PlayerHandler.cs
@@ -11,6 +11,7 @@ namespace Exiled.CustomItems.Events
     using Exiled.API.Features;
     using Exiled.CustomItems.API.Features;
     using Exiled.Events.EventArgs.Player;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -27,7 +27,9 @@ namespace Exiled.CustomRoles.API.Features
     using Mirror;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles;
+
     using UnityEngine;
 
     using YamlDotNet.Serialization;

--- a/Exiled.Events/Commands/Config/Merge.cs
+++ b/Exiled.Events/Commands/Config/Merge.cs
@@ -14,7 +14,9 @@ namespace Exiled.Events.Commands.Config
     using API.Enums;
     using API.Features;
     using API.Interfaces;
+
     using CommandSystem;
+
     using Loader;
 
     /// <summary>

--- a/Exiled.Events/Commands/Config/Split.cs
+++ b/Exiled.Events/Commands/Config/Split.cs
@@ -14,7 +14,9 @@ namespace Exiled.Events.Commands.Config
     using API.Enums;
     using API.Features;
     using API.Interfaces;
+
     using CommandSystem;
+
     using Loader;
 
     /// <summary>

--- a/Exiled.Events/Commands/Reload/Configs.cs
+++ b/Exiled.Events/Commands/Reload/Configs.cs
@@ -10,8 +10,11 @@ namespace Exiled.Events.Commands.Reload
     using System;
 
     using API.Interfaces;
+
     using CommandSystem;
+
     using Exiled.Permissions.Extensions;
+
     using Loader;
 
     /// <summary>

--- a/Exiled.Events/Commands/Reload/Permissions.cs
+++ b/Exiled.Events/Commands/Reload/Permissions.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.Commands.Reload
     using System;
 
     using CommandSystem;
+
     using Exiled.Events.Handlers;
     using Exiled.Permissions.Extensions;
 

--- a/Exiled.Events/Commands/Reload/Plugins.cs
+++ b/Exiled.Events/Commands/Reload/Plugins.cs
@@ -10,8 +10,10 @@ namespace Exiled.Events.Commands.Reload
     using System;
 
     using CommandSystem;
+
     using Exiled.Events.Handlers;
     using Exiled.Permissions.Extensions;
+
     using Loader;
 
     /// <summary>

--- a/Exiled.Events/Commands/Reload/RemoteAdmin.cs
+++ b/Exiled.Events/Commands/Reload/RemoteAdmin.cs
@@ -10,7 +10,9 @@ namespace Exiled.Events.Commands.Reload
     using System;
 
     using CommandSystem;
+
     using Exiled.Permissions.Extensions;
+
     using Loader;
 
     /// <summary>

--- a/Exiled.Events/Commands/Reload/Translations.cs
+++ b/Exiled.Events/Commands/Reload/Translations.cs
@@ -10,8 +10,11 @@ namespace Exiled.Events.Commands.Reload
     using System;
 
     using API.Interfaces;
+
     using CommandSystem;
+
     using Exiled.Permissions.Extensions;
+
     using Loader;
 
     /// <summary>

--- a/Exiled.Events/Commands/Show/Plugins.cs
+++ b/Exiled.Events/Commands/Show/Plugins.cs
@@ -13,9 +13,13 @@ namespace Exiled.Events.Commands.Show
     using System.Text;
 
     using API.Interfaces;
+
     using CommandSystem;
+
     using Exiled.Permissions.Extensions;
+
     using NorthwoodLib.Pools;
+
     using RemoteAdmin;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Item/ChangingAttachmentsEventArgs.cs
+++ b/Exiled.Events/EventArgs/Item/ChangingAttachmentsEventArgs.cs
@@ -13,8 +13,11 @@ namespace Exiled.Events.EventArgs.Item
     using API.Features;
     using API.Features.Items;
     using API.Structs;
+
     using Exiled.API.Extensions;
+
     using Interfaces;
+
     using InventorySystem.Items.Firearms.Attachments;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Item/ReceivingPreferenceEventArgs.cs
+++ b/Exiled.Events/EventArgs/Item/ReceivingPreferenceEventArgs.cs
@@ -12,8 +12,10 @@ namespace Exiled.Events.EventArgs.Item
 
     using API.Features;
     using API.Structs;
+
     using Exiled.API.Enums;
     using Exiled.API.Extensions;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Map/AnnouncingDecontaminationEventArgs.cs
+++ b/Exiled.Events/EventArgs/Map/AnnouncingDecontaminationEventArgs.cs
@@ -7,10 +7,7 @@
 
 namespace Exiled.Events.EventArgs.Map
 {
-    using Exiled.API.Enums;
     using Exiled.Events.EventArgs.Interfaces;
-
-    using LightContainmentZoneDecontamination;
 
     /// <summary>
     ///     Contains all information before C.A.S.S.I.E announces light containment zone decontamination.

--- a/Exiled.Events/EventArgs/Map/AnnouncingScpTerminationEventArgs.cs
+++ b/Exiled.Events/EventArgs/Map/AnnouncingScpTerminationEventArgs.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.EventArgs.Map
     using API.Features;
     using API.Features.DamageHandlers;
     using API.Features.Roles;
+
     using Interfaces;
 
     using CustomAttackerHandler = API.Features.DamageHandlers.AttackerDamageHandler;

--- a/Exiled.Events/EventArgs/Map/GeneratorActivatedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Map/GeneratorActivatedEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Map
 {
     using API.Features;
+
     using Interfaces;
 
     using MapGeneration.Distributors;

--- a/Exiled.Events/EventArgs/Map/PlacingBloodEventArgs.cs
+++ b/Exiled.Events/EventArgs/Map/PlacingBloodEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Map
 {
     using API.Features;
+
     using Interfaces;
 
     using UnityEngine;

--- a/Exiled.Events/EventArgs/Map/PlacingBulletHole.cs
+++ b/Exiled.Events/EventArgs/Map/PlacingBulletHole.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Map
 {
     using API.Features;
+
     using Interfaces;
 
     using UnityEngine;

--- a/Exiled.Events/EventArgs/Map/SpawningItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/Map/SpawningItemEventArgs.cs
@@ -10,7 +10,9 @@ namespace Exiled.Events.EventArgs.Map
     using Exiled.API.Features;
     using Exiled.API.Features.Pickups;
     using Exiled.Events.EventArgs.Interfaces;
+
     using Interactables.Interobjects.DoorUtils;
+
     using InventorySystem.Items.Pickups;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/ActivatingGeneratorEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ActivatingGeneratorEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     using MapGeneration.Distributors;

--- a/Exiled.Events/EventArgs/Player/ActivatingWarheadPanelEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ActivatingWarheadPanelEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/ActivatingWorkstationEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ActivatingWorkstationEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     using InventorySystem.Items.Firearms.Attachments;

--- a/Exiled.Events/EventArgs/Player/AimingDownSightEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/AimingDownSightEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/BannedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/BannedEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/ChangingGroupEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ChangingGroupEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/ChangingItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ChangingItemEventArgs.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.EventArgs.Player
 
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     using InventorySystem.Items;

--- a/Exiled.Events/EventArgs/Player/ChangingMicroHIDStateEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ChangingMicroHIDStateEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     using InventorySystem.Items.MicroHID;

--- a/Exiled.Events/EventArgs/Player/ChangingMoveStateEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ChangingMoveStateEventArgs.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
+
     using PlayerRoles.FirstPersonControl;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/ChangingRadioPresetEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ChangingRadioPresetEventArgs.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Exiled.API.Enums;
+
     using Interfaces;
 
     using static InventorySystem.Items.Radio.RadioMessages;

--- a/Exiled.Events/EventArgs/Player/ChangingRoleEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ChangingRoleEventArgs.cs
@@ -11,9 +11,11 @@ namespace Exiled.Events.EventArgs.Player
 
     using API.Enums;
     using API.Features;
+
     using Interfaces;
 
     using InventorySystem.Configs;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/ChangingSpectatedPlayerEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ChangingSpectatedPlayerEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/DamagingShootingTargetEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DamagingShootingTargetEventArgs.cs
@@ -12,6 +12,7 @@ namespace Exiled.Events.EventArgs.Player
     using API.Features;
     using API.Features.Items;
     using API.Features.Toys;
+
     using Interfaces;
 
     using PlayerStatsSystem;

--- a/Exiled.Events/EventArgs/Player/DamagingWindowEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DamagingWindowEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
     using API.Features.DamageHandlers;
+
     using Interfaces;
 
     using AttackerDamageHandler = PlayerStatsSystem.AttackerDamageHandler;

--- a/Exiled.Events/EventArgs/Player/DeactivatingWorkstationEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DeactivatingWorkstationEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     using InventorySystem.Items.Firearms.Attachments;

--- a/Exiled.Events/EventArgs/Player/DestroyingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DestroyingEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/DiedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DiedEventArgs.cs
@@ -9,7 +9,9 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
     using API.Features.DamageHandlers;
+
     using Interfaces;
+
     using PlayerRoles;
 
     using CustomAttackerHandler = API.Features.DamageHandlers.AttackerDamageHandler;

--- a/Exiled.Events/EventArgs/Player/DroppingAmmoEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DroppingAmmoEventArgs.cs
@@ -9,7 +9,9 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Enums;
     using API.Features;
+
     using Interfaces;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/DroppingItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DroppingItemEventArgs.cs
@@ -9,9 +9,11 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     using InventorySystem.Items;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/DroppingNothingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DroppingNothingEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/DryfiringWeaponEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DryfiringWeaponEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/DyingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DyingEventArgs.cs
@@ -13,6 +13,7 @@ namespace Exiled.Events.EventArgs.Player
     using API.Features;
     using API.Features.DamageHandlers;
     using API.Features.Items;
+
     using Interfaces;
 
     using CustomAttackerHandler = API.Features.DamageHandlers.AttackerDamageHandler;

--- a/Exiled.Events/EventArgs/Player/EnteringEnvironmentalHazardEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/EnteringEnvironmentalHazardEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using Hazards;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/EnteringKillerCollisionEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/EnteringKillerCollisionEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/EnteringPocketDimensionEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/EnteringPocketDimensionEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/EscapingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/EscapingEventArgs.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/EscapingPocketDimensionEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/EscapingPocketDimensionEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     using UnityEngine;

--- a/Exiled.Events/EventArgs/Player/ExitingEnvironmentalHazardEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ExitingEnvironmentalHazardEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using Hazards;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/FailingEscapePocketDimensionEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/FailingEscapePocketDimensionEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/FlippingCoinEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/FlippingCoinEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/HandcuffingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/HandcuffingEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/HurtingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/HurtingEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
     using API.Features.DamageHandlers;
+
     using Interfaces;
 
     using CustomAttackerHandler = API.Features.DamageHandlers.AttackerDamageHandler;

--- a/Exiled.Events/EventArgs/Player/InteractedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/InteractedEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/InteractingDoorEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/InteractingDoorEventArgs.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interactables.Interobjects.DoorUtils;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/InteractingElevatorEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/InteractingElevatorEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using Exiled.API.Features;
     using Exiled.Events.EventArgs.Interfaces;
+
     using Interactables.Interobjects;
 
     using Lift = API.Features.Lift;

--- a/Exiled.Events/EventArgs/Player/InteractingLockerEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/InteractingLockerEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     using MapGeneration.Distributors;

--- a/Exiled.Events/EventArgs/Player/InteractingShootingTargetEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/InteractingShootingTargetEventArgs.cs
@@ -14,6 +14,7 @@ namespace Exiled.Events.EventArgs.Player
     using API.Enums;
     using API.Features;
     using API.Features.Toys;
+
     using Interfaces;
 
     using UnityEngine;

--- a/Exiled.Events/EventArgs/Player/IntercomSpeakingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/IntercomSpeakingEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/IssuingMuteEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/IssuingMuteEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/JoinedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/JoinedEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/JumpingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/JumpingEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     using UnityEngine;

--- a/Exiled.Events/EventArgs/Player/KickedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/KickedEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/KickingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/KickingEventArgs.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.EventArgs.Player
     using System.Reflection;
 
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/LandingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/LandingEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/LocalReportingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/LocalReportingEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/MakingNoiseEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/MakingNoiseEventArgs.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
+
     using PlayerRoles.FirstPersonControl.Thirdperson;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/OpeningGeneratorEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/OpeningGeneratorEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     using MapGeneration.Distributors;

--- a/Exiled.Events/EventArgs/Player/PreAuthenticatingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/PreAuthenticatingEventArgs.cs
@@ -10,7 +10,9 @@ namespace Exiled.Events.EventArgs.Player
     using System;
 
     using Interfaces;
+
     using LiteNetLib;
+
     using PluginAPI.Events;
 
 #pragma warning disable SA1600 //TODO:

--- a/Exiled.Events/EventArgs/Player/ProcessingHotkeyEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ProcessingHotkeyEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Enums;
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/ReceivingEffectEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ReceivingEffectEventArgs.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using CustomPlayerEffects;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/ReloadingWeaponEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ReloadingWeaponEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/SearchingPickupEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/SearchingPickupEventArgs.cs
@@ -8,9 +8,9 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using Exiled.API.Features;
-    using Exiled.API.Features.Items;
     using Exiled.API.Features.Pickups;
     using Exiled.Events.EventArgs.Interfaces;
+
     using InventorySystem.Items.Pickups;
     using InventorySystem.Searching;
 

--- a/Exiled.Events/EventArgs/Player/ShootingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ShootingEventArgs.cs
@@ -8,10 +8,13 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     using InventorySystem.Items.Firearms.BasicMessages;
+
     using RelativePositioning;
+
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/ShotEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ShotEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     using UnityEngine;

--- a/Exiled.Events/EventArgs/Player/SpawnedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/SpawnedEventArgs.cs
@@ -8,8 +8,11 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Exiled.API.Features.Roles;
+
     using Interfaces;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/SpawningRagdollEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/SpawningRagdollEventArgs.cs
@@ -8,8 +8,11 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
+
     using PlayerRoles;
+
     using PlayerStatsSystem;
 
     using UnityEngine;

--- a/Exiled.Events/EventArgs/Player/StayingOnEnvironmentalHazardEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/StayingOnEnvironmentalHazardEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using Hazards;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/ThrowingItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ThrowingItemEventArgs.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.EventArgs.Player
     using API.Enums;
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     using InventorySystem.Items.ThrowableProjectiles;

--- a/Exiled.Events/EventArgs/Player/ThrowingRequestEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ThrowingRequestEventArgs.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Player
 {
-    using System;
-
     using Exiled.API.Enums;
     using Exiled.API.Features;
     using Exiled.API.Features.Items;

--- a/Exiled.Events/EventArgs/Player/TogglingFlashlightEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/TogglingFlashlightEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     using InventorySystem.Items.Flashlight;

--- a/Exiled.Events/EventArgs/Player/TogglingNoClipEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/TogglingNoClipEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/TogglingWeaponFlashlightEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/TogglingWeaponFlashlightEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/TransmittingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/TransmittingEventArgs.cs
@@ -9,7 +9,9 @@ namespace Exiled.Events.EventArgs.Player
 {
     using Exiled.API.Features;
     using Exiled.Events.EventArgs.Interfaces;
+
     using PlayerRoles.Voice;
+
     using VoiceChat;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/TriggeringTeslaEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/TriggeringTeslaEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/UnloadingWeaponEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/UnloadingWeaponEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/UnlockingGeneratorEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/UnlockingGeneratorEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     using MapGeneration.Distributors;

--- a/Exiled.Events/EventArgs/Player/UsedItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/UsedItemEventArgs.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.EventArgs.Player
 
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     using InventorySystem.Items.Usables;

--- a/Exiled.Events/EventArgs/Player/UsingItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/UsingItemEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     using InventorySystem.Items.Usables;

--- a/Exiled.Events/EventArgs/Player/UsingMicroHIDEnergyEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/UsingMicroHIDEnergyEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     using InventorySystem.Items.MicroHID;

--- a/Exiled.Events/EventArgs/Player/UsingRadioBatteryEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/UsingRadioBatteryEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     using InventorySystem.Items.Radio;

--- a/Exiled.Events/EventArgs/Player/VerifiedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/VerifiedEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Player
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/VoiceChattingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/VoiceChattingEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Player
 {
     using Exiled.API.Features;
     using Exiled.Events.EventArgs.Interfaces;
+
     using PlayerRoles.Voice;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp049/FinishingRecallEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp049/FinishingRecallEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Scp049
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp049/StartingRecallEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp049/StartingRecallEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Scp049
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp079/ChangingCameraEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp079/ChangingCameraEventArgs.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.EventArgs.Scp079
     using Exiled.API.Features;
     using Exiled.API.Features.Roles;
     using Exiled.Events.EventArgs.Interfaces;
+
     using PlayerRoles.PlayableScps.Scp079.Cameras;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp079/ChangingSpeakerStatusEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp079/ChangingSpeakerStatusEventArgs.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.EventArgs.Scp079
 {
     using API.Features;
+
     using Exiled.API.Features.Roles;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp079/ElevatorTeleportingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp079/ElevatorTeleportingEventArgs.cs
@@ -10,7 +10,9 @@ namespace Exiled.Events.EventArgs.Scp079
     using Exiled.API.Features;
     using Exiled.API.Features.Roles;
     using Exiled.Events.EventArgs.Interfaces;
+
     using Interactables.Interobjects;
+
     using MapGeneration;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp079/GainingExperienceEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp079/GainingExperienceEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Scp079
 {
     using Exiled.API.Features;
     using Exiled.Events.EventArgs.Interfaces;
+
     using PlayerRoles.PlayableScps.Scp079;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp079/GainingLevelEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp079/GainingLevelEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Scp079
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp079/PingingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp079/PingingEventArgs.cs
@@ -8,9 +8,13 @@
 namespace Exiled.Events.EventArgs.Scp079
 {
     using API.Features;
+
     using Exiled.API.Enums;
+
     using Interfaces;
+
     using RelativePositioning;
+
     using UnityEngine;
 
     /// <summary>
@@ -36,7 +40,7 @@ namespace Exiled.Events.EventArgs.Scp079
         /// <param name="isAllowed">
         ///     <inheritdoc cref="IsAllowed" />
         /// </param>
-        public PingingEventArgs(ReferenceHub hub, RelativePosition position, int powerCost, byte proccesorindex,  bool isAllowed = true)
+        public PingingEventArgs(ReferenceHub hub, RelativePosition position, int powerCost, byte proccesorindex, bool isAllowed = true)
         {
             Player = Player.Get(hub);
             Position = position.Position;

--- a/Exiled.Events/EventArgs/Scp079/RecontainedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp079/RecontainedEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Scp079
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp079/RoomBlackoutEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp079/RoomBlackoutEventArgs.cs
@@ -8,11 +8,9 @@
 namespace Exiled.Events.EventArgs.Scp079
 {
     using Exiled.API.Features;
-    using Exiled.API.Features.Roles;
     using Exiled.Events.EventArgs.Interfaces;
 
     using MapGeneration;
-    using PlayerRoles.PlayableScps.Scp079;
 
     /// <summary>
     ///     Contains all information before SCP-079 turns off the lights in a room.

--- a/Exiled.Events/EventArgs/Scp079/TriggeringDoorEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp079/TriggeringDoorEventArgs.cs
@@ -8,8 +8,11 @@
 namespace Exiled.Events.EventArgs.Scp079
 {
     using API.Features;
+
     using Exiled.API.Features.Roles;
+
     using Interactables.Interobjects.DoorUtils;
+
     using Player;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp079/ZoneBlackoutEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp079/ZoneBlackoutEventArgs.cs
@@ -11,9 +11,10 @@ namespace Exiled.Events.EventArgs.Scp079
     using Exiled.API.Extensions;
 
     using Exiled.API.Features;
-    using Exiled.API.Features.Roles;
     using Exiled.Events.EventArgs.Interfaces;
+
     using MapGeneration;
+
     using PlayerRoles.PlayableScps.Scp079;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp096/AddingTargetEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp096/AddingTargetEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Scp096
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp096/CalmingDownEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp096/CalmingDownEventArgs.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.EventArgs.Scp096
 {
     using API.Features;
+
     using Exiled.Events.EventArgs.Interfaces;
+
     using PlayerRoles.PlayableScps.Scp096;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp096/ChargingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp096/ChargingEventArgs.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.EventArgs.Scp096
 {
     using API.Features;
+
     using Interfaces;
+
     using PlayerRoles.PlayableScps.Scp096;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp096/EnragingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp096/EnragingEventArgs.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.EventArgs.Scp096
 {
     using API.Features;
+
     using Interfaces;
+
     using PlayerRoles.PlayableScps.Scp096;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp096/StartPryingGateEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp096/StartPryingGateEventArgs.cs
@@ -8,8 +8,11 @@
 namespace Exiled.Events.EventArgs.Scp096
 {
     using API.Features;
+
     using Interactables.Interobjects;
+
     using Interfaces;
+
     using PlayerRoles.PlayableScps.Scp096;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp096/TryingNotToCryEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp096/TryingNotToCryEventArgs.cs
@@ -10,8 +10,11 @@ namespace Exiled.Events.EventArgs.Scp096
     using System.Linq;
 
     using API.Features;
+
     using Interfaces;
+
     using PlayerRoles.PlayableScps.Scp096;
+
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp106/TeleportingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp106/TeleportingEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Scp106
 {
     using API.Features;
+
     using Interfaces;
 
     using UnityEngine;

--- a/Exiled.Events/EventArgs/Scp173/BlinkingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp173/BlinkingEventArgs.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.EventArgs.Scp173
     using System.Collections.Generic;
 
     using API.Features;
+
     using Interfaces;
 
     using UnityEngine;

--- a/Exiled.Events/EventArgs/Scp173/PlacingTantrumEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp173/PlacingTantrumEventArgs.cs
@@ -9,7 +9,9 @@ namespace Exiled.Events.EventArgs.Scp173
 {
     using Exiled.API.Features;
     using Exiled.Events.EventArgs.Interfaces;
+
     using Hazards;
+
     using PlayerRoles.PlayableScps.Scp173;
     using PlayerRoles.PlayableScps.Subroutines;
 

--- a/Exiled.Events/EventArgs/Scp173/UsingBreakneckSpeedsEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp173/UsingBreakneckSpeedsEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Scp173
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp244/UsingScp244EventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp244/UsingScp244EventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Scp244
 {
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     using InventorySystem.Items.Usables.Scp244;

--- a/Exiled.Events/EventArgs/Scp330/DroppingScp330EventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp330/DroppingScp330EventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Scp330
 {
     using API.Features;
     using API.Features.Items;
+
     using Interfaces;
 
     using InventorySystem.Items.Usables.Scp330;

--- a/Exiled.Events/EventArgs/Scp330/EatenScp330EventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp330/EatenScp330EventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Scp330
 {
     using API.Features;
+
     using Interfaces;
 
     using InventorySystem.Items.Usables.Scp330;

--- a/Exiled.Events/EventArgs/Scp330/EatingScp330EventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp330/EatingScp330EventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Scp330
 {
     using API.Features;
+
     using Interfaces;
 
     using InventorySystem.Items.Usables.Scp330;

--- a/Exiled.Events/EventArgs/Scp330/InteractingScp330EventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp330/InteractingScp330EventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Scp330
 {
     using API.Features;
+
     using Interfaces;
 
     using InventorySystem.Items.Usables.Scp330;

--- a/Exiled.Events/EventArgs/Scp914/ActivatingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp914/ActivatingEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Scp914
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp914/ChangingKnobSettingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp914/ChangingKnobSettingEventArgs.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.EventArgs.Scp914
 {
     using API.Features;
+
     using global::Scp914;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp914/UpgradingInventoryItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp914/UpgradingInventoryItemEventArgs.cs
@@ -9,8 +9,11 @@ namespace Exiled.Events.EventArgs.Scp914
 {
     using API.Features;
     using API.Features.Items;
+
     using global::Scp914;
+
     using Interfaces;
+
     using InventorySystem.Items;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp914/UpgradingPickupEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp914/UpgradingPickupEventArgs.cs
@@ -11,7 +11,9 @@ namespace Exiled.Events.EventArgs.Scp914
     using Exiled.Events.EventArgs.Interfaces;
 
     using global::Scp914;
+
     using InventorySystem.Items.Pickups;
+
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp914/UpgradingPlayerEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp914/UpgradingPlayerEventArgs.cs
@@ -8,8 +8,11 @@
 namespace Exiled.Events.EventArgs.Scp914
 {
     using API.Features;
+
     using global::Scp914;
+
     using Interfaces;
+
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Server/AddingUnitNameEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/AddingUnitNameEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Server
 {
     using Interfaces;
+
     using Respawning.NamingRules;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Server/EndingRoundEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/EndingRoundEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Server
 {
     using API.Enums;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Server/ReportingCheaterEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/ReportingCheaterEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Server
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Server/RespawningTeamEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/RespawningTeamEventArgs.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.EventArgs.Server
 
     using Exiled.API.Features;
     using Exiled.Events.EventArgs.Interfaces;
+
     using Respawning;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Server/RoundEndedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/RoundEndedEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Server
 {
     using API.Enums;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Warhead/ChangingLeverStatusEventArgs.cs
+++ b/Exiled.Events/EventArgs/Warhead/ChangingLeverStatusEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Warhead
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Warhead/StoppingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Warhead/StoppingEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Warhead
 {
     using API.Features;
+
     using Interfaces;
 
     /// <summary>

--- a/Exiled.Events/Events.cs
+++ b/Exiled.Events/Events.cs
@@ -14,12 +14,17 @@ namespace Exiled.Events
 
     using API.Enums;
     using API.Features;
+
     using EventArgs.Interfaces;
+
     using HarmonyLib;
+
     using PlayerRoles;
     using PlayerRoles.FirstPersonControl.Thirdperson;
     using PlayerRoles.Ragdolls;
+
     using PluginAPI.Events;
+
     using UnityEngine.SceneManagement;
 
     /// <summary>

--- a/Exiled.Events/Extensions/Event.cs
+++ b/Exiled.Events/Extensions/Event.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.Extensions
     using System;
 
     using API.Features;
+
     using EventArgs.Interfaces;
 
     /// <summary>

--- a/Exiled.Events/Handlers/Cassie.cs
+++ b/Exiled.Events/Handlers/Cassie.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Handlers
 {
     using Exiled.Events.EventArgs.Cassie;
+
     using Extensions;
 
     using static Events;

--- a/Exiled.Events/Handlers/Internal/MapGenerated.cs
+++ b/Exiled.Events/Handlers/Internal/MapGenerated.cs
@@ -14,16 +14,24 @@ namespace Exiled.Events.Handlers.Internal
     using API.Features;
     using API.Features.Items;
     using API.Structs;
+
     using Exiled.API.Enums;
     using Exiled.API.Extensions;
+
     using Interactables.Interobjects;
+
     using InventorySystem.Items.Firearms.Attachments;
     using InventorySystem.Items.Firearms.Attachments.Components;
+
     using MapGeneration;
     using MapGeneration.Distributors;
+
     using MEC;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp079.Cameras;
+
     using Utils.NonAllocLINQ;
 
     using Broadcast = Broadcast;

--- a/Exiled.Events/Handlers/Internal/RagdollList.cs
+++ b/Exiled.Events/Handlers/Internal/RagdollList.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Handlers.Internal
 {
     using Exiled.API.Features;
+
     using PlayerRoles.Ragdolls;
 
     /// <summary>

--- a/Exiled.Events/Handlers/Internal/Round.cs
+++ b/Exiled.Events/Handlers/Internal/Round.cs
@@ -12,7 +12,9 @@ namespace Exiled.Events.Handlers.Internal
     using Exiled.Events.EventArgs.Player;
     using Exiled.Loader;
     using Exiled.Loader.Features;
+
     using InventorySystem;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.Events/Handlers/Item.cs
+++ b/Exiled.Events/Handlers/Item.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Handlers
 {
     using Exiled.Events.EventArgs.Item;
+
     using Extensions;
 
     using static Events;

--- a/Exiled.Events/Handlers/Map.cs
+++ b/Exiled.Events/Handlers/Map.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Handlers
 {
     using Exiled.API.Features.Pickups;
     using Exiled.Events.EventArgs.Map;
+
     using Extensions;
 
     using MapGeneration.Distributors;

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -553,10 +553,10 @@ namespace Exiled.Events.Handlers
         public static void OnChangingRole(ChangingRoleEventArgs ev) => ChangingRole.InvokeSafely(ev);
 
         /// <summary>
-        /// Called after throwing a grenade.
+        /// Called before throwing a grenade.
         /// </summary>
         /// <param name="ev">The <see cref="ThrownItemEventArgs"/> instance.</param>
-        public static void OnThrownItem(ThrownItemEventArgs ev) => ThrownItem.InvokeSafely(ev);
+        public static void OnThrowingItem(ThrownItemEventArgs ev) => ThrownItem.InvokeSafely(ev);
 
         /// <summary>
         /// Called before receving a throwing request.

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -7,17 +7,13 @@
 
 namespace Exiled.Events.Handlers
 {
-    using API.Extensions;
-    using API.Features;
     using Exiled.Events.EventArgs.Player;
-    using Exiled.Events.EventArgs.Scp079;
+
     using Extensions;
-    using Interactables.Interobjects.DoorUtils;
-    using InventorySystem.Items.Radio;
-    using MapGeneration.Distributors;
+
     using PlayerRoles;
     using PlayerRoles.FirstPersonControl.Thirdperson;
-    using PlayerStatsSystem;
+
     using PluginAPI.Core.Attributes;
     using PluginAPI.Enums;
     using PluginAPI.Events;

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -553,10 +553,10 @@ namespace Exiled.Events.Handlers
         public static void OnChangingRole(ChangingRoleEventArgs ev) => ChangingRole.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before throwing a grenade.
+        /// Called after throwing a grenade.
         /// </summary>
         /// <param name="ev">The <see cref="ThrownItemEventArgs"/> instance.</param>
-        public static void OnThrowingItem(ThrownItemEventArgs ev) => ThrownItem.InvokeSafely(ev);
+        public static void OnThrownItem(ThrownItemEventArgs ev) => ThrownItem.InvokeSafely(ev);
 
         /// <summary>
         /// Called before receving a throwing request.

--- a/Exiled.Events/Handlers/Scp049.cs
+++ b/Exiled.Events/Handlers/Scp049.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Handlers
 {
     using Exiled.Events.EventArgs.Scp049;
+
     using Extensions;
 
     using static Events;

--- a/Exiled.Events/Handlers/Scp079.cs
+++ b/Exiled.Events/Handlers/Scp079.cs
@@ -8,7 +8,7 @@
 namespace Exiled.Events.Handlers
 {
     using Exiled.Events.EventArgs.Scp079;
-    using Exiled.Events.Patches.Events.Scp079;
+
     using Extensions;
 
     using static Events;

--- a/Exiled.Events/Handlers/Scp096.cs
+++ b/Exiled.Events/Handlers/Scp096.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Handlers
 {
     using Exiled.Events.EventArgs.Scp096;
+
     using Extensions;
 
     using static Events;

--- a/Exiled.Events/Handlers/Scp106.cs
+++ b/Exiled.Events/Handlers/Scp106.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Handlers
 {
     using Exiled.Events.EventArgs.Scp106;
+
     using Extensions;
 
     using static Events;

--- a/Exiled.Events/Handlers/Scp173.cs
+++ b/Exiled.Events/Handlers/Scp173.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Handlers
 {
     using Exiled.Events.EventArgs.Scp173;
+
     using Extensions;
 
     using static Events;

--- a/Exiled.Events/Handlers/Scp244.cs
+++ b/Exiled.Events/Handlers/Scp244.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Handlers
 {
     using Exiled.Events.EventArgs.Scp244;
+
     using Extensions;
 
     using static Events;

--- a/Exiled.Events/Handlers/Scp330.cs
+++ b/Exiled.Events/Handlers/Scp330.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Handlers
 {
     using Exiled.Events.EventArgs.Scp330;
+
     using Extensions;
 
     using static Events;

--- a/Exiled.Events/Handlers/Scp914.cs
+++ b/Exiled.Events/Handlers/Scp914.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Handlers
 {
     using Exiled.Events.EventArgs.Scp914;
+
     using Extensions;
 
     using static Events;

--- a/Exiled.Events/Handlers/Server.cs
+++ b/Exiled.Events/Handlers/Server.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Handlers
 {
     using Exiled.Events.EventArgs.Player;
     using Exiled.Events.EventArgs.Server;
+
     using Extensions;
 
     using static Events;

--- a/Exiled.Events/Handlers/Warhead.cs
+++ b/Exiled.Events/Handlers/Warhead.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.Handlers
 {
     using Exiled.Events.EventArgs.Warhead;
+
     using Extensions;
+
     using PluginAPI.Core.Attributes;
     using PluginAPI.Enums;
 

--- a/Exiled.Events/Patches/Events/Cassie/SendingCassieMessage.cs
+++ b/Exiled.Events/Patches/Events/Cassie/SendingCassieMessage.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Cassie
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Cassie;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Item/ChangingAmmo.cs
+++ b/Exiled.Events/Patches/Events/Item/ChangingAmmo.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Item
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Item;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Item/ChangingAttachments.cs
+++ b/Exiled.Events/Patches/Events/Item/ChangingAttachments.cs
@@ -12,6 +12,7 @@ namespace Exiled.Events.Patches.Events.Item
 
     using API.Features;
     using API.Features.Items;
+
     using Exiled.Events.EventArgs.Item;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Item/KeycardInteracting.cs
+++ b/Exiled.Events/Patches/Events/Item/KeycardInteracting.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Item
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events;
     using Exiled.Events.EventArgs.Item;
 

--- a/Exiled.Events/Patches/Events/Item/ReceivingPreference.cs
+++ b/Exiled.Events/Patches/Events/Item/ReceivingPreference.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Item
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Item;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Map/AnnouncingDecontamination.cs
+++ b/Exiled.Events/Patches/Events/Map/AnnouncingDecontamination.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Map
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Map;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Map/AnnouncingNtfEntrance.cs
+++ b/Exiled.Events/Patches/Events/Map/AnnouncingNtfEntrance.cs
@@ -12,6 +12,7 @@ namespace Exiled.Events.Patches.Events.Map
     using System.Text.RegularExpressions;
 
     using Exiled.Events.EventArgs.Map;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Map/AnnouncingScpTermination.cs
+++ b/Exiled.Events/Patches/Events/Map/AnnouncingScpTermination.cs
@@ -10,7 +10,6 @@ namespace Exiled.Events.Patches.Events.Map
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
-    using API.Features.Roles;
     using Exiled.API.Features.DamageHandlers;
     using Exiled.Events.EventArgs.Map;
     using Exiled.Events.Handlers;
@@ -18,7 +17,6 @@ namespace Exiled.Events.Patches.Events.Map
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
-    using PlayerRoles;
 
     using static HarmonyLib.AccessTools;
 

--- a/Exiled.Events/Patches/Events/Map/BreakingScp2176.cs
+++ b/Exiled.Events/Patches/Events/Map/BreakingScp2176.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Map
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Map;
 
     using Footprinting;
@@ -20,7 +21,6 @@ namespace Exiled.Events.Patches.Events.Map
     using InventorySystem.Items.ThrowableProjectiles;
 
     using NorthwoodLib.Pools;
-    using UnityEngine;
 
     using static HarmonyLib.AccessTools;
 

--- a/Exiled.Events/Patches/Events/Map/ChangingIntoGrenade.cs
+++ b/Exiled.Events/Patches/Events/Map/ChangingIntoGrenade.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Map
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Map;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Map/Decontaminating.cs
+++ b/Exiled.Events/Patches/Events/Map/Decontaminating.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Map
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Map;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Map/ExplodingFragGrenade.cs
+++ b/Exiled.Events/Patches/Events/Map/ExplodingFragGrenade.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Map
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Map;
 
     using Footprinting;

--- a/Exiled.Events/Patches/Events/Map/GeneratorActivated.cs
+++ b/Exiled.Events/Patches/Events/Map/GeneratorActivated.cs
@@ -12,6 +12,7 @@ namespace Exiled.Events.Patches.Events.Map
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Map;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Map/PlacingBlood.cs
+++ b/Exiled.Events/Patches/Events/Map/PlacingBlood.cs
@@ -11,9 +11,13 @@ namespace Exiled.Events.Patches.Events.Map
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Map;
+
     using HarmonyLib;
+
     using InventorySystem.Items.Firearms.Modules;
+
     using NorthwoodLib.Pools;
+
     using UnityEngine;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Map/PlacingBulletHole.cs
+++ b/Exiled.Events/Patches/Events/Map/PlacingBulletHole.cs
@@ -17,6 +17,7 @@ namespace Exiled.Events.Patches.Events.Map
     using InventorySystem.Items.Firearms.Modules;
 
     using NorthwoodLib.Pools;
+
     using UnityEngine;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Map/SpawningItem.cs
+++ b/Exiled.Events/Patches/Events/Map/SpawningItem.cs
@@ -12,10 +12,13 @@ namespace Exiled.Events.Patches.Events.Map
 
     using Exiled.API.Features.Pickups;
     using Exiled.Events.EventArgs.Map;
+
     using Handlers;
 
     using HarmonyLib;
+
     using Interactables.Interobjects.DoorUtils;
+
     using MapGeneration.Distributors;
 
     using NorthwoodLib.Pools;

--- a/Exiled.Events/Patches/Events/Player/ActivatingWarheadPanel.cs
+++ b/Exiled.Events/Patches/Events/Player/ActivatingWarheadPanel.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/ActivatingWorkstation.cs
+++ b/Exiled.Events/Patches/Events/Player/ActivatingWorkstation.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/Banned.cs
+++ b/Exiled.Events/Patches/Events/Player/Banned.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/Banning.cs
+++ b/Exiled.Events/Patches/Events/Player/Banning.cs
@@ -11,7 +11,9 @@ namespace Exiled.Events.Patches.Events.Player
     using System;
 
     using API.Features;
+
     using CommandSystem;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/ChangingGroup.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingGroup.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/ChangingItem.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingItem.cs
@@ -12,6 +12,7 @@ namespace Exiled.Events.Patches.Events.Player
 
     using API.Features;
     using API.Features.Items;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/ChangingMicroHIDState.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingMicroHIDState.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/ChangingMoveState.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingMoveState.cs
@@ -8,7 +8,6 @@
 namespace Exiled.Events.Patches.Events.Player
 {
     using System.Collections.Generic;
-    using System.Reflection;
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Player;
@@ -17,6 +16,7 @@ namespace Exiled.Events.Patches.Events.Player
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.FirstPersonControl;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/ChangingRadioPreset.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRadioPreset.cs
@@ -14,8 +14,10 @@ namespace Exiled.Events.Patches.Events.Player
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;
+
     using InventorySystem.Items;
     using InventorySystem.Items.Radio;
+
     using NorthwoodLib.Pools;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -23,6 +23,7 @@ namespace Exiled.Events.Patches.Events.Player
     using InventorySystem.Items.Pickups;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/ChangingSpectatedPlayerPatch.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingSpectatedPlayerPatch.cs
@@ -11,8 +11,11 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Player;
+
     using HarmonyLib;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.Spectating;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/DamagingShootingTarget.cs
+++ b/Exiled.Events/Patches/Events/Player/DamagingShootingTarget.cs
@@ -13,6 +13,7 @@ namespace Exiled.Events.Patches.Events.Player
     using AdminToys;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/DamagingWindow.cs
+++ b/Exiled.Events/Patches/Events/Player/DamagingWindow.cs
@@ -11,10 +11,15 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features.DamageHandlers;
+
     using Exiled.Events.EventArgs.Player;
+
     using Handlers;
+
     using HarmonyLib;
+
     using NorthwoodLib.Pools;
+
     using UnityEngine;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/DeactivatingWorkstation.cs
+++ b/Exiled.Events/Patches/Events/Player/DeactivatingWorkstation.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Player;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/Destroying.cs
+++ b/Exiled.Events/Patches/Events/Player/Destroying.cs
@@ -14,6 +14,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Runtime.CompilerServices;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/DroppingAmmo.cs
+++ b/Exiled.Events/Patches/Events/Player/DroppingAmmo.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/DyingAndDied.cs
+++ b/Exiled.Events/Patches/Events/Player/DyingAndDied.cs
@@ -12,12 +12,15 @@ namespace Exiled.Events.Patches.Events.Player
 
     using API.Features;
     using API.Features.Roles;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles;
+
     using PlayerStatsSystem;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/EnteringPocketDimension.cs
+++ b/Exiled.Events/Patches/Events/Player/EnteringPocketDimension.cs
@@ -16,6 +16,7 @@ namespace Exiled.Events.Patches.Events.Player
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp106;
     using PlayerRoles.PlayableScps.Subroutines;
 

--- a/Exiled.Events/Patches/Events/Player/EnteringSinkholeEnvironmentalHazard.cs
+++ b/Exiled.Events/Patches/Events/Player/EnteringSinkholeEnvironmentalHazard.cs
@@ -13,8 +13,11 @@ namespace Exiled.Events.Patches.Events.Player
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;
+
     using Hazards;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/EnteringTantrumEnvironmentalHazard.cs
+++ b/Exiled.Events/Patches/Events/Player/EnteringTantrumEnvironmentalHazard.cs
@@ -13,7 +13,9 @@ namespace Exiled.Events.Patches.Events.Player
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;
+
     using Hazards;
+
     using NorthwoodLib.Pools;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/EscapingPocketDimension.cs
+++ b/Exiled.Events/Patches/Events/Player/EscapingPocketDimension.cs
@@ -16,8 +16,10 @@ namespace Exiled.Events.Patches.Events.Player
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.FirstPersonControl;
     using PlayerRoles.PlayableScps.Scp106;
+
     using UnityEngine;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/ExitingSinkholeEnvironmentalHazard.cs
+++ b/Exiled.Events/Patches/Events/Player/ExitingSinkholeEnvironmentalHazard.cs
@@ -13,7 +13,9 @@ namespace Exiled.Events.Patches.Events.Player
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;
+
     using Hazards;
+
     using NorthwoodLib.Pools;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/ExitingTantrumEnvironmentalHazard.cs
+++ b/Exiled.Events/Patches/Events/Player/ExitingTantrumEnvironmentalHazard.cs
@@ -13,7 +13,9 @@ namespace Exiled.Events.Patches.Events.Player
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;
+
     using Hazards;
+
     using NorthwoodLib.Pools;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/FailingEscapePocketDimension.cs
+++ b/Exiled.Events/Patches/Events/Player/FailingEscapePocketDimension.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/FirearmRequestReceived.cs
+++ b/Exiled.Events/Patches/Events/Player/FirearmRequestReceived.cs
@@ -11,12 +11,15 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Player;
+
     using Handlers;
 
     using HarmonyLib;
+
     using InventorySystem.Items.Firearms.BasicMessages;
 
     using NorthwoodLib.Pools;
+
     using PluginAPI.Enums;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/FlippingCoin.cs
+++ b/Exiled.Events/Patches/Events/Player/FlippingCoin.cs
@@ -11,9 +11,11 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;
+
     using InventorySystem.Items.Coin;
 
     using Mirror;

--- a/Exiled.Events/Patches/Events/Player/Interacted.cs
+++ b/Exiled.Events/Patches/Events/Player/Interacted.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/InteractingDoor.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingDoor.cs
@@ -20,6 +20,7 @@ namespace Exiled.Events.Patches.Events.Player
     using HarmonyLib;
 
     using Interactables.Interobjects.DoorUtils;
+
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.Events/Patches/Events/Player/InteractingElevator.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingElevator.cs
@@ -14,9 +14,13 @@ namespace Exiled.Events.Patches.Events.Player
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;
+
     using Interactables.Interobjects;
+
     using Mirror;
+
     using NorthwoodLib.Pools;
+
     using PluginAPI.Enums;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/InteractingGenerator.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingGenerator.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Player;
-    using Footprinting;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/InteractingLocker.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingLocker.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/InteractingShootingTarget.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingShootingTarget.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/IntercomSpeaking.cs
+++ b/Exiled.Events/Patches/Events/Player/IntercomSpeaking.cs
@@ -16,6 +16,7 @@ namespace Exiled.Events.Patches.Events.Player
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.Voice;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/IssuingMute.cs
+++ b/Exiled.Events/Patches/Events/Player/IssuingMute.cs
@@ -16,6 +16,7 @@ namespace Exiled.Events.Patches.Events.Player
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using VoiceChat;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/ItemDrop.cs
+++ b/Exiled.Events/Patches/Events/Player/ItemDrop.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Player;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/Jumping.cs
+++ b/Exiled.Events/Patches/Events/Player/Jumping.cs
@@ -16,7 +16,9 @@ namespace Exiled.Events.Patches.Events.Player
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.FirstPersonControl;
+
     using UnityEngine;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/Kicked.cs
+++ b/Exiled.Events/Patches/Events/Player/Kicked.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/Kicking.cs
+++ b/Exiled.Events/Patches/Events/Player/Kicking.cs
@@ -11,7 +11,9 @@ namespace Exiled.Events.Patches.Events.Player
     using System;
 
     using API.Features;
+
     using CommandSystem;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/Landing.cs
+++ b/Exiled.Events/Patches/Events/Player/Landing.cs
@@ -16,6 +16,7 @@ namespace Exiled.Events.Patches.Events.Player
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.FirstPersonControl.Thirdperson;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/PickingUpAmmo.cs
+++ b/Exiled.Events/Patches/Events/Player/PickingUpAmmo.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/PickingUpArmor.cs
+++ b/Exiled.Events/Patches/Events/Player/PickingUpArmor.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/PickingUpItem.cs
+++ b/Exiled.Events/Patches/Events/Player/PickingUpItem.cs
@@ -11,7 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
-    using API.Features.Items;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/ProcessDisarmMessage.cs
+++ b/Exiled.Events/Patches/Events/Player/ProcessDisarmMessage.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/ProcessingHotkey.cs
+++ b/Exiled.Events/Patches/Events/Player/ProcessingHotkey.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/ReservedSlotPatch.cs
+++ b/Exiled.Events/Patches/Events/Player/ReservedSlotPatch.cs
@@ -12,9 +12,13 @@ namespace Exiled.Events.Patches.Events.Player
 
     using Exiled.API.Enums;
     using Exiled.Events.EventArgs.Player;
+
     using Handlers;
+
     using HarmonyLib;
+
     using NorthwoodLib.Pools;
+
     using PluginAPI.Events;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/RevokingMute.cs
+++ b/Exiled.Events/Patches/Events/Player/RevokingMute.cs
@@ -16,6 +16,7 @@ namespace Exiled.Events.Patches.Events.Player
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using VoiceChat;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/SearchingPickupEvent.cs
+++ b/Exiled.Events/Patches/Events/Player/SearchingPickupEvent.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/Shooting.cs
+++ b/Exiled.Events/Patches/Events/Player/Shooting.cs
@@ -12,6 +12,7 @@ namespace Exiled.Events.Patches.Events.Player
 
     using API.Features;
     using API.Features.Items;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/Shot.cs
+++ b/Exiled.Events/Patches/Events/Player/Shot.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;
@@ -19,6 +20,7 @@ namespace Exiled.Events.Patches.Events.Player
     using InventorySystem.Items.Firearms.Modules;
 
     using NorthwoodLib.Pools;
+
     using UnityEngine;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/Spawning.cs
+++ b/Exiled.Events/Patches/Events/Player/Spawning.cs
@@ -23,6 +23,7 @@ namespace Exiled.Events.Patches.Events.Player
     using PlayerRoles.FirstPersonControl.Spawnpoints;
     using PlayerRoles.PlayableScps.Scp049;
     using PlayerRoles.PlayableScps.Subroutines;
+
     using UnityEngine;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/SpawningRagdoll.cs
+++ b/Exiled.Events/Patches/Events/Player/SpawningRagdoll.cs
@@ -11,21 +11,20 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Player;
+
     using Handlers;
 
     using HarmonyLib;
 
-    using Mirror;
-
     using NorthwoodLib.Pools;
+
     using PlayerRoles.Ragdolls;
+
     using PlayerStatsSystem;
 
     using UnityEngine;
 
     using static HarmonyLib.AccessTools;
-
-    using Map = API.Features.Map;
 
     /// <summary>
     ///     Patches <see cref="RagdollManager.ServerSpawnRagdoll(ReferenceHub, DamageHandlerBase)" />.

--- a/Exiled.Events/Patches/Events/Player/StayingOnEnvironmentalHazard.cs
+++ b/Exiled.Events/Patches/Events/Player/StayingOnEnvironmentalHazard.cs
@@ -13,7 +13,9 @@ namespace Exiled.Events.Patches.Events.Player
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;
+
     using Hazards;
+
     using NorthwoodLib.Pools;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/StayingOnSinkholeEnvironmentalHazard.cs
+++ b/Exiled.Events/Patches/Events/Player/StayingOnSinkholeEnvironmentalHazard.cs
@@ -11,7 +11,9 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using HarmonyLib;
+
     using Hazards;
+
     using NorthwoodLib.Pools;
 
     /// <summary>

--- a/Exiled.Events/Patches/Events/Player/StayingOnTantrumEnvironmentalHazard.cs
+++ b/Exiled.Events/Patches/Events/Player/StayingOnTantrumEnvironmentalHazard.cs
@@ -11,7 +11,9 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using HarmonyLib;
+
     using Hazards;
+
     using NorthwoodLib.Pools;
 
     /// <summary>

--- a/Exiled.Events/Patches/Events/Player/ThrowingRequest.cs
+++ b/Exiled.Events/Patches/Events/Player/ThrowingRequest.cs
@@ -11,7 +11,6 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using Exiled.API.Features;
-    using Exiled.API.Features.Items;
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/ThrownItem.cs
+++ b/Exiled.Events/Patches/Events/Player/ThrownItem.cs
@@ -57,7 +57,7 @@ namespace Exiled.Events.Patches.Events.Player
                 new(OpCodes.Newobj, GetDeclaredConstructors(typeof(ThrownItemEventArgs))[0]),
 
                 // Handlers.Player.OnThrowingItem(ev);
-                new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnThrowingItem))),
+                new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnThrownItem))),
             });
 
             newInstructions[newInstructions.Count - 1].labels.Add(returnLabel);

--- a/Exiled.Events/Patches/Events/Player/ThrownItem.cs
+++ b/Exiled.Events/Patches/Events/Player/ThrownItem.cs
@@ -57,7 +57,7 @@ namespace Exiled.Events.Patches.Events.Player
                 new(OpCodes.Newobj, GetDeclaredConstructors(typeof(ThrownItemEventArgs))[0]),
 
                 // Handlers.Player.OnThrowingItem(ev);
-                new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnThrownItem))),
+                new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnThrowingItem))),
             });
 
             newInstructions[newInstructions.Count - 1].labels.Add(returnLabel);

--- a/Exiled.Events/Patches/Events/Player/TogglingFlashlight.cs
+++ b/Exiled.Events/Patches/Events/Player/TogglingFlashlight.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/TogglingNoClip.cs
+++ b/Exiled.Events/Patches/Events/Player/TogglingNoClip.cs
@@ -16,6 +16,7 @@ namespace Exiled.Events.Patches.Events.Player
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.FirstPersonControl;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/Transmitting.cs
+++ b/Exiled.Events/Patches/Events/Player/Transmitting.cs
@@ -14,9 +14,13 @@ namespace Exiled.Events.Patches.Events.Player
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;
+
     using Mirror;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.Voice;
+
     using VoiceChat.Playbacks;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Player/UsedItem.cs
+++ b/Exiled.Events/Patches/Events/Player/UsedItem.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/UsingAndCancellingItemUse.cs
+++ b/Exiled.Events/Patches/Events/Player/UsingAndCancellingItemUse.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/UsingMicroHIDEnergy.cs
+++ b/Exiled.Events/Patches/Events/Player/UsingMicroHIDEnergy.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Player/UsingRadioBattery.cs
+++ b/Exiled.Events/Patches/Events/Player/UsingRadioBattery.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Scp049/FinishingRecall.cs
+++ b/Exiled.Events/Patches/Events/Scp049/FinishingRecall.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Scp049
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Scp049;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Scp049/StartingRecall.cs
+++ b/Exiled.Events/Patches/Events/Scp049/StartingRecall.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Scp049
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Scp049;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Scp079/ChangingCamera.cs
+++ b/Exiled.Events/Patches/Events/Scp079/ChangingCamera.cs
@@ -14,8 +14,11 @@ namespace Exiled.Events.Patches.Events.Scp079
     using Exiled.Events.Handlers;
 
     using HarmonyLib;
+
     using Mirror;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp079;
     using PlayerRoles.PlayableScps.Scp079.Cameras;
     using PlayerRoles.PlayableScps.Subroutines;

--- a/Exiled.Events/Patches/Events/Scp079/ChangingSpeakerStatusAndVoiceChatting.cs
+++ b/Exiled.Events/Patches/Events/Scp079/ChangingSpeakerStatusAndVoiceChatting.cs
@@ -17,6 +17,7 @@ namespace Exiled.Events.Patches.Events.Scp079
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles;
     using PlayerRoles.Voice;
 

--- a/Exiled.Events/Patches/Events/Scp079/ElevatorTeleporting.cs
+++ b/Exiled.Events/Patches/Events/Scp079/ElevatorTeleporting.cs
@@ -14,8 +14,11 @@ namespace Exiled.Events.Patches.Events.Scp079
     using Exiled.Events.Handlers;
 
     using HarmonyLib;
+
     using Mirror;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp079;
     using PlayerRoles.PlayableScps.Scp079.Cameras;
     using PlayerRoles.PlayableScps.Subroutines;

--- a/Exiled.Events/Patches/Events/Scp079/GainingExperience.cs
+++ b/Exiled.Events/Patches/Events/Scp079/GainingExperience.cs
@@ -16,6 +16,7 @@ namespace Exiled.Events.Patches.Events.Scp079
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp079;
     using PlayerRoles.PlayableScps.Subroutines;
 

--- a/Exiled.Events/Patches/Events/Scp079/GainingLevel.cs
+++ b/Exiled.Events/Patches/Events/Scp079/GainingLevel.cs
@@ -16,6 +16,7 @@ namespace Exiled.Events.Patches.Events.Scp079
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp079;
     using PlayerRoles.PlayableScps.Subroutines;
 

--- a/Exiled.Events/Patches/Events/Scp079/InteractingTesla.cs
+++ b/Exiled.Events/Patches/Events/Scp079/InteractingTesla.cs
@@ -14,8 +14,11 @@ namespace Exiled.Events.Patches.Events.Scp079
     using Exiled.Events.Handlers;
 
     using HarmonyLib;
+
     using Mirror;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp079;
     using PlayerRoles.PlayableScps.Subroutines;
 

--- a/Exiled.Events/Patches/Events/Scp079/LockingDown.cs
+++ b/Exiled.Events/Patches/Events/Scp079/LockingDown.cs
@@ -14,8 +14,11 @@ namespace Exiled.Events.Patches.Events.Scp079
     using Exiled.Events.Handlers;
 
     using HarmonyLib;
+
     using Mirror;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp079;
     using PlayerRoles.PlayableScps.Scp079.Cameras;
     using PlayerRoles.PlayableScps.Subroutines;

--- a/Exiled.Events/Patches/Events/Scp079/Pinging.cs
+++ b/Exiled.Events/Patches/Events/Scp079/Pinging.cs
@@ -8,16 +8,18 @@
 namespace Exiled.Events.Patches.Events.Scp079
 {
     using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection.Emit;
 
-    using Exiled.API.Features;
     using Exiled.Events.EventArgs.Scp079;
+
     using HarmonyLib;
+
     using Mirror;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp079.Pinging;
-    using PlayerRoles.PlayableScps.Subroutines;
+
     using RelativePositioning;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Scp079/RoomBlackout.cs
+++ b/Exiled.Events/Patches/Events/Scp079/RoomBlackout.cs
@@ -13,11 +13,10 @@ namespace Exiled.Events.Patches.Events.Scp079
     using Exiled.Events.EventArgs.Scp079;
 
     using HarmonyLib;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp079;
-    using PlayerRoles.PlayableScps.Scp079.Pinging;
-    using PlayerRoles.PlayableScps.Subroutines;
-    using RelativePositioning;
 
     using static HarmonyLib.AccessTools;
 

--- a/Exiled.Events/Patches/Events/Scp079/TriggeringDoor.cs
+++ b/Exiled.Events/Patches/Events/Scp079/TriggeringDoor.cs
@@ -14,8 +14,11 @@ namespace Exiled.Events.Patches.Events.Scp079
     using Exiled.Events.Handlers;
 
     using HarmonyLib;
+
     using Interactables.Interobjects.DoorUtils;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp079;
     using PlayerRoles.PlayableScps.Subroutines;
 

--- a/Exiled.Events/Patches/Events/Scp079/ZoneBlackout.cs
+++ b/Exiled.Events/Patches/Events/Scp079/ZoneBlackout.cs
@@ -11,8 +11,11 @@ namespace Exiled.Events.Patches.Events.Scp079
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Scp079;
+
     using HarmonyLib;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp079;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Scp096/AddingTarget.cs
+++ b/Exiled.Events/Patches/Events/Scp096/AddingTarget.cs
@@ -11,11 +11,13 @@ namespace Exiled.Events.Patches.Events.Scp096
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Scp096;
 
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp096;
     using PlayerRoles.PlayableScps.Subroutines;
 

--- a/Exiled.Events/Patches/Events/Scp096/CalmingDown.cs
+++ b/Exiled.Events/Patches/Events/Scp096/CalmingDown.cs
@@ -11,11 +11,13 @@ namespace Exiled.Events.Patches.Events.Scp096
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Scp096;
 
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp096;
     using PlayerRoles.PlayableScps.Subroutines;
 

--- a/Exiled.Events/Patches/Events/Scp096/Charging.cs
+++ b/Exiled.Events/Patches/Events/Scp096/Charging.cs
@@ -11,11 +11,15 @@ namespace Exiled.Events.Patches.Events.Scp096
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Scp096;
 
     using HarmonyLib;
+
     using Mirror;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp096;
     using PlayerRoles.PlayableScps.Subroutines;
 

--- a/Exiled.Events/Patches/Events/Scp096/Enraging.cs
+++ b/Exiled.Events/Patches/Events/Scp096/Enraging.cs
@@ -11,11 +11,13 @@ namespace Exiled.Events.Patches.Events.Scp096
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Scp096;
 
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp096;
     using PlayerRoles.PlayableScps.Subroutines;
 

--- a/Exiled.Events/Patches/Events/Scp096/StartPryingGate.cs
+++ b/Exiled.Events/Patches/Events/Scp096/StartPryingGate.cs
@@ -11,12 +11,17 @@ namespace Exiled.Events.Patches.Events.Scp096
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Scp096;
 
     using HarmonyLib;
+
     using Interactables.Interobjects.DoorUtils;
+
     using Mirror;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp096;
     using PlayerRoles.PlayableScps.Subroutines;
 

--- a/Exiled.Events/Patches/Events/Scp096/TryingNotToCry.cs
+++ b/Exiled.Events/Patches/Events/Scp096/TryingNotToCry.cs
@@ -11,10 +11,13 @@ namespace Exiled.Events.Patches.Events.Scp096
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Scp096;
 
     using HarmonyLib;
+
     using Mirror;
+
     using NorthwoodLib.Pools;
 
     using PlayerRoles.PlayableScps.Scp096;

--- a/Exiled.Events/Patches/Events/Scp106/Teleporting.cs
+++ b/Exiled.Events/Patches/Events/Scp106/Teleporting.cs
@@ -16,6 +16,7 @@ namespace Exiled.Events.Patches.Events.Scp106
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp106;
     using PlayerRoles.PlayableScps.Subroutines;
 

--- a/Exiled.Events/Patches/Events/Scp173/Blinking.cs
+++ b/Exiled.Events/Patches/Events/Scp173/Blinking.cs
@@ -17,8 +17,10 @@ namespace Exiled.Events.Patches.Events.Scp173
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp173;
     using PlayerRoles.PlayableScps.Subroutines;
+
     using UnityEngine;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Scp173/PlacingTantrum.cs
+++ b/Exiled.Events/Patches/Events/Scp173/PlacingTantrum.cs
@@ -17,8 +17,10 @@ namespace Exiled.Events.Patches.Events.Scp173
     using Mirror;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp173;
     using PlayerRoles.PlayableScps.Subroutines;
+
     using UnityEngine;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Scp173/UsingBreakneckSpeeds.cs
+++ b/Exiled.Events/Patches/Events/Scp173/UsingBreakneckSpeeds.cs
@@ -16,6 +16,7 @@ namespace Exiled.Events.Patches.Events.Scp173
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp173;
     using PlayerRoles.PlayableScps.Subroutines;
 

--- a/Exiled.Events/Patches/Events/Scp244/DamagingScp244.cs
+++ b/Exiled.Events/Patches/Events/Scp244/DamagingScp244.cs
@@ -11,7 +11,9 @@ namespace Exiled.Events.Patches.Events.Scp244
     using System.Reflection.Emit;
 
     using API.Features.DamageHandlers;
+
     using Exiled.Events.EventArgs.Scp244;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Scp244/UpdateScp244.cs
+++ b/Exiled.Events/Patches/Events/Scp244/UpdateScp244.cs
@@ -12,6 +12,7 @@ namespace Exiled.Events.Patches.Events.Scp244
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Scp244;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Scp244/UsingScp244.cs
+++ b/Exiled.Events/Patches/Events/Scp244/UsingScp244.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Scp244
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Scp244;
+
     using Handlers;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Scp330/DroppingCandy.cs
+++ b/Exiled.Events/Patches/Events/Scp330/DroppingCandy.cs
@@ -11,13 +11,16 @@ namespace Exiled.Events.Patches.Events.Scp330
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Scp330;
+
     using Handlers;
 
     using HarmonyLib;
 
     using InventorySystem.Items.Pickups;
     using InventorySystem.Items.Usables.Scp330;
+
     using Mirror;
+
     using NorthwoodLib.Pools;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Scp914/InteractingEvents.cs
+++ b/Exiled.Events/Patches/Events/Scp914/InteractingEvents.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Scp914
 {
 #pragma warning disable SA1313
     using API.Features;
+
     using Exiled.Events.EventArgs.Scp914;
 
     using global::Scp914;

--- a/Exiled.Events/Patches/Events/Scp914/UpgradingItem.cs
+++ b/Exiled.Events/Patches/Events/Scp914/UpgradingItem.cs
@@ -11,9 +11,13 @@ namespace Exiled.Events.Patches.Events.Scp914
     using System.Reflection.Emit;
 
     using Exiled.Events.EventArgs.Scp914;
+
     using global::Scp914;
+
     using Handlers;
+
     using HarmonyLib;
+
     using NorthwoodLib.Pools;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Scp914/UpgradingPlayer.cs
+++ b/Exiled.Events/Patches/Events/Scp914/UpgradingPlayer.cs
@@ -11,11 +11,13 @@ namespace Exiled.Events.Patches.Events.Scp914
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Scp914;
 
     using global::Scp914;
 
     using HarmonyLib;
+
     using NorthwoodLib.Pools;
 
     using UnityEngine;

--- a/Exiled.Events/Patches/Events/Server/AddingUnitName.cs
+++ b/Exiled.Events/Patches/Events/Server/AddingUnitName.cs
@@ -15,6 +15,7 @@ namespace Exiled.Events.Patches.Events.Server
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using Respawning;
     using Respawning.NamingRules;
 

--- a/Exiled.Events/Patches/Events/Server/Reporting.cs
+++ b/Exiled.Events/Patches/Events/Server/Reporting.cs
@@ -17,6 +17,7 @@ namespace Exiled.Events.Patches.Events.Server
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using UnityEngine;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Server/RestartingRound.cs
+++ b/Exiled.Events/Patches/Events/Server/RestartingRound.cs
@@ -12,8 +12,11 @@ namespace Exiled.Events.Patches.Events.Server
     using System.Reflection.Emit;
 
     using GameCore;
+
     using HarmonyLib;
+
     using NorthwoodLib.Pools;
+
     using RoundRestarting;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Events/Server/RoundEnd.cs
+++ b/Exiled.Events/Patches/Events/Server/RoundEnd.cs
@@ -22,9 +22,12 @@ namespace Exiled.Events.Patches.Events.Server
     using HarmonyLib;
 
     using MEC;
+
     using PlayerRoles;
+
     using PluginAPI.Enums;
     using PluginAPI.Events;
+
     using RoundRestarting;
 
     using UnityEngine;

--- a/Exiled.Events/Patches/Events/Warhead/ChangingLeverStatus.cs
+++ b/Exiled.Events/Patches/Events/Warhead/ChangingLeverStatus.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Warhead
     using System.Reflection.Emit;
 
     using API.Features;
+
     using Exiled.Events.EventArgs.Warhead;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Events/Warhead/StartingByCommand.cs
+++ b/Exiled.Events/Patches/Events/Warhead/StartingByCommand.cs
@@ -15,6 +15,7 @@ namespace Exiled.Events.Patches.Events.Warhead
     using CommandSystem;
     using CommandSystem.Commands.RemoteAdmin.ServerEvent;
     using CommandSystem.Commands.RemoteAdmin.Warhead;
+
     using Exiled.API.Features;
     using Exiled.Events.EventArgs.Warhead;
 

--- a/Exiled.Events/Patches/Fixes/GrenadePropertiesFix.cs
+++ b/Exiled.Events/Patches/Fixes/GrenadePropertiesFix.cs
@@ -11,7 +11,6 @@ namespace Exiled.Events.Patches.Fixes
     using System.Reflection.Emit;
 
     using Exiled.API.Features.Items;
-    using Exiled.API.Features.Pickups;
     using Exiled.API.Features.Pickups.Projectiles;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Fixes/KillPlayer.cs
+++ b/Exiled.Events/Patches/Fixes/KillPlayer.cs
@@ -11,8 +11,11 @@ namespace Exiled.Events.Patches.Fixes
 
     using API.Features;
     using API.Features.DamageHandlers;
+
     using EventArgs.Player;
+
     using HarmonyLib;
+
     using Mirror;
 
     using PlayerStatsSystem;

--- a/Exiled.Events/Patches/Fixes/RoleChangedPatch.cs
+++ b/Exiled.Events/Patches/Fixes/RoleChangedPatch.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Fixes
     using System.Reflection.Emit;
 
     using API.Features.Items;
+
     using EventArgs.Player;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Fixes/VoiceChatMutesClear.cs
+++ b/Exiled.Events/Patches/Fixes/VoiceChatMutesClear.cs
@@ -13,6 +13,7 @@ namespace Exiled.Events.Patches.Fixes
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using VoiceChat;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Generic/DestroyRecontainerInstance.cs
+++ b/Exiled.Events/Patches/Generic/DestroyRecontainerInstance.cs
@@ -15,6 +15,7 @@ namespace Exiled.Events.Patches.Generic
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp079;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Generic/GhostModePatch.cs
+++ b/Exiled.Events/Patches/Generic/GhostModePatch.cs
@@ -12,8 +12,11 @@ namespace Exiled.Events.Patches.Generic
 
     using Exiled.API.Features;
     using Exiled.API.Features.Roles;
+
     using HarmonyLib;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles.FirstPersonControl.NetworkMessages;
     using PlayerRoles.Visibility;
 

--- a/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
+++ b/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
@@ -22,7 +22,9 @@ namespace Exiled.Events.Patches.Generic
     using InventorySystem.Items.ThrowableProjectiles;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles;
+
     using PlayerStatsSystem;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Generic/InitRecontainerInstance.cs
+++ b/Exiled.Events/Patches/Generic/InitRecontainerInstance.cs
@@ -15,6 +15,7 @@ namespace Exiled.Events.Patches.Generic
     using HarmonyLib;
 
     using NorthwoodLib.Pools;
+
     using PlayerRoles.PlayableScps.Scp079;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Generic/InventoryControlPatch.cs
+++ b/Exiled.Events/Patches/Generic/InventoryControlPatch.cs
@@ -146,7 +146,7 @@ namespace Exiled.Events.Patches.Generic
             Log.Debug(
                 $"Inventory Info (before): {player.Nickname} - {player.Items.Count} ({player.Inventory.UserInventory.Items.Count})");
             foreach (Item item in player.Items)
-                    Log.Debug($"{item})");
+                Log.Debug($"{item})");
 #endif
             ItemBase itemBase = player.Inventory.UserInventory.Items[serial];
 
@@ -161,9 +161,9 @@ namespace Exiled.Events.Patches.Generic
                 Log.Debug($"Inventory Info (after): {player.Nickname} - {player.Items.Count} ({player.Inventory.UserInventory.Items.Count})");
 
                 foreach (Item item in player.Items)
-                        Log.Debug($"{item})");
+                    Log.Debug($"{item})");
 #endif
-                });
+            });
         }
     }
 }

--- a/Exiled.Events/Patches/Generic/ParseVisionInformation.cs
+++ b/Exiled.Events/Patches/Generic/ParseVisionInformation.cs
@@ -11,8 +11,11 @@ namespace Exiled.Events.Patches.Generic
     using System.Reflection.Emit;
 
     using Exiled.API.Features;
+
     using HarmonyLib;
+
     using NorthwoodLib.Pools;
+
     using PlayerRoles;
     using PlayerRoles.PlayableScps.Scp096;
 

--- a/Exiled.Events/Patches/Generic/PickupControlPatch.cs
+++ b/Exiled.Events/Patches/Generic/PickupControlPatch.cs
@@ -19,7 +19,9 @@ namespace Exiled.Events.Patches.Generic
     using InventorySystem;
     using InventorySystem.Items;
     using InventorySystem.Items.Pickups;
+
     using MapGeneration.Distributors;
+
     using NorthwoodLib.Pools;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Generic/PickupListRemove.cs
+++ b/Exiled.Events/Patches/Generic/PickupListRemove.cs
@@ -9,7 +9,6 @@ namespace Exiled.Events.Patches.Generic
 {
 #pragma warning disable SA1402
     using System.Collections.Generic;
-    using System.Reflection;
     using System.Reflection.Emit;
 
     using Exiled.API.Features.Pickups;
@@ -18,6 +17,7 @@ namespace Exiled.Events.Patches.Generic
 
     using InventorySystem.Items.Pickups;
     using InventorySystem.Items.ThrowableProjectiles;
+
     using NorthwoodLib.Pools;
 
     using static HarmonyLib.AccessTools;

--- a/Exiled.Events/Patches/Generic/PickupListRemove.cs
+++ b/Exiled.Events/Patches/Generic/PickupListRemove.cs
@@ -7,7 +7,9 @@
 
 namespace Exiled.Events.Patches.Generic
 {
+#pragma warning disable SA1402
     using System.Collections.Generic;
+    using System.Reflection;
     using System.Reflection.Emit;
 
     using Exiled.API.Features.Pickups;
@@ -15,15 +17,15 @@ namespace Exiled.Events.Patches.Generic
     using HarmonyLib;
 
     using InventorySystem.Items.Pickups;
-
+    using InventorySystem.Items.ThrowableProjectiles;
     using NorthwoodLib.Pools;
 
     using static HarmonyLib.AccessTools;
 
     /// <summary>
-    /// Patches <see cref="ItemPickupBase.DestroySelf"/>.
+    /// Patches <see cref="ItemPickupBase.OnDestroy"/>.
     /// </summary>
-    [HarmonyPatch(typeof(ItemPickupBase), nameof(ItemPickupBase.DestroySelf))]
+    [HarmonyPatch(typeof(ItemPickupBase), nameof(ItemPickupBase.OnDestroy))]
     internal static class PickupListRemove
     {
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
@@ -37,6 +39,76 @@ namespace Exiled.Events.Patches.Generic
                 new(OpCodes.Ldarg_0),
                 new(OpCodes.Callvirt, Method(typeof(Dictionary<ItemPickupBase, Pickup>), nameof(Dictionary<ItemPickupBase, Pickup>.Remove), new[] { typeof(ItemPickupBase) })),
                 new(OpCodes.Pop),
+            });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+
+    /// <summary>
+    /// Patches <see cref="EffectGrenade.OnDestroy"/> for fixing cringe NW code :).
+    /// </summary>
+    [HarmonyPatch(typeof(EffectGrenade), nameof(EffectGrenade.OnDestroy))]
+    internal static class EffectGrenadesListRemove
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            // remove first base::OnDestroy call
+            newInstructions.RemoveRange(0, 2);
+
+            int offset = 0;
+            int index = newInstructions.FindIndex(i => i.opcode == OpCodes.Ret) + offset;
+
+            CodeInstruction[] toInsert = new[]
+            {
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new(OpCodes.Call, Method(typeof(ItemPickupBase), nameof(ItemPickupBase.OnDestroy))),
+            };
+
+            // OnDestroy call if TargetTime == 0.0f
+            newInstructions.InsertRange(index, toInsert);
+
+            // OnDestroy call at the end
+            newInstructions.InsertRange(newInstructions.Count - 1, toInsert);
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+
+    /// <summary>
+    /// Patches <see cref="Scp2176Projectile.ServerFuseEnd"/> for fixing cringe NW code :).
+    /// </summary>
+    [HarmonyPatch(typeof(Scp2176Projectile), nameof(Scp2176Projectile.ServerFuseEnd))]
+    internal static class Scp2176ListRemove
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            int offset = -1;
+            int index = newInstructions.FindIndex(i => i.Calls(Method(typeof(Scp2176Projectile), nameof(Scp2176Projectile.ServerShatter)))) + offset;
+
+            offset = -1;
+            int index2 = newInstructions.FindIndex(i => i.Calls(Method(typeof(EffectGrenade), nameof(EffectGrenade.ServerFuseEnd)))) + offset;
+
+            newInstructions[index].MoveLabelsFrom(newInstructions[index2]);
+
+            // remove EffectGrenade::ServerFuseEnd at start
+            newInstructions.RemoveRange(index2, 2);
+
+            // insert EffectGrenade::ServerFuseEnd at the ends
+            newInstructions.InsertRange(newInstructions.Count - 1, new[]
+            {
+                new(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Call, Method(typeof(EffectGrenade), nameof(EffectGrenade.ServerFuseEnd))),
             });
 
             for (int z = 0; z < newInstructions.Count; z++)

--- a/Exiled.Events/Patches/Generic/Scp173BeingLooked.cs
+++ b/Exiled.Events/Patches/Generic/Scp173BeingLooked.cs
@@ -9,7 +9,9 @@ namespace Exiled.Events.Patches.Generic
 {
 #pragma warning disable SA1313
     using Exiled.API.Features;
+
     using HarmonyLib;
+
     using PlayerRoles;
     using PlayerRoles.PlayableScps.Scp173;
 

--- a/Exiled.Example/Events/MapHandler.cs
+++ b/Exiled.Example/Events/MapHandler.cs
@@ -20,7 +20,7 @@ namespace Exiled.Example.Events
         /// <inheritdoc cref="Exiled.Events.Handlers.Map.OnExplodingGrenade(ExplodingGrenadeEventArgs)"/>
         public void OnExplodingGrenade(ExplodingGrenadeEventArgs ev)
         {
-            Log.Info($"A grenade thrown by {ev.Player.Nickname} is exploding: {ev.Projectile.Base.name}\n[Targets]\n\n{string.Join("\n", ev.TargetsToAffect.Select(player => $"[{player.Nickname}]"))}");
+            Log.Info($"A grenade thrown by {ev.Player.Nickname} is exploding: {ev.Projectile.Type}\n[Targets]\n\n{string.Join("\n", ev.TargetsToAffect.Select(player => $"[{player.Nickname}]"))}");
         }
 
         /// <inheritdoc cref="Exiled.Events.Handlers.Map.OnGeneratorActivated(GeneratorActivatedEventArgs)"/>

--- a/Exiled.Example/Events/PlayerHandler.cs
+++ b/Exiled.Example/Events/PlayerHandler.cs
@@ -126,7 +126,7 @@ namespace Exiled.Example.Events
         /// <inheritdoc cref="Exiled.Events.Handlers.Player.Dying"/>
         public void OnDying(DyingEventArgs ev)
         {
-            Log.Info($"{ev.Player.Nickname} ({ev.Player.Role}) is getting killed by {ev.Attacker.Nickname} ({ev.Attacker.Role})!");
+            Log.Info($"{ev.Player.Nickname} ({ev.Player.Role}) is getting killed by {ev.Attacker?.Nickname ?? "None"} ({ev.Attacker?.Role?.ToString() ?? "None"})!");
         }
 
         /// <inheritdoc cref="Exiled.Events.Handlers.Player.PreAuthenticating"/>

--- a/Exiled.Example/Events/PlayerHandler.cs
+++ b/Exiled.Example/Events/PlayerHandler.cs
@@ -16,8 +16,11 @@ namespace Exiled.Example.Events
     using Exiled.Events.EventArgs.Player;
     using Exiled.Events.EventArgs.Scp106;
     using Exiled.Events.EventArgs.Scp914;
+
     using MEC;
+
     using PlayerRoles;
+
     using UnityEngine;
 
     using static Example;

--- a/Exiled.Installer/Program.cs
+++ b/Exiled.Installer/Program.cs
@@ -124,8 +124,8 @@ namespace Exiled.Installer
                 using HttpResponseMessage downloadResult = await httpClient.GetAsync(exiledAsset.BrowserDownloadUrl).ConfigureAwait(false);
                 using Stream downloadArchiveStream = await downloadResult.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
-                using GZipInputStream gzInputStream = new (downloadArchiveStream);
-                using TarInputStream tarInputStream = new (gzInputStream, null);
+                using GZipInputStream gzInputStream = new(downloadArchiveStream);
+                using TarInputStream tarInputStream = new(gzInputStream, null);
 
                 TarEntry entry;
                 while ((entry = tarInputStream.GetNextEntry()) is not null)
@@ -163,7 +163,7 @@ namespace Exiled.Installer
 
         private static string FormatRelease(Release r, bool includeAssets)
         {
-            StringBuilder builder = new (30);
+            StringBuilder builder = new(30);
             builder.AppendLine($"PRE: {r.Prerelease} | ID: {r.Id} | TAG: {r.TagName}");
             if (includeAssets)
             {

--- a/Exiled.Loader/Config.cs
+++ b/Exiled.Loader/Config.cs
@@ -12,6 +12,7 @@ namespace Exiled.Loader
 
     using API.Enums;
     using API.Interfaces;
+
     using Exiled.API.Features;
 
     /// <summary>

--- a/Exiled.Loader/ConfigManager.cs
+++ b/Exiled.Loader/ConfigManager.cs
@@ -15,7 +15,9 @@ namespace Exiled.Loader
     using API.Enums;
     using API.Extensions;
     using API.Interfaces;
+
     using Exiled.API.Features;
+
     using YamlDotNet.Core;
 
     /// <summary>

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -19,11 +19,15 @@ namespace Exiled.Loader
 
     using API.Enums;
     using API.Interfaces;
+
     using CommandSystem.Commands.Shared;
+
     using Exiled.API.Features;
+
     using Features;
     using Features.Configs;
     using Features.Configs.CustomConverters;
+
     using YamlDotNet.Serialization;
     using YamlDotNet.Serialization.NamingConventions;
     using YamlDotNet.Serialization.NodeDeserializers;

--- a/Exiled.Loader/TranslationManager.cs
+++ b/Exiled.Loader/TranslationManager.cs
@@ -15,7 +15,9 @@ namespace Exiled.Loader
     using API.Enums;
     using API.Extensions;
     using API.Interfaces;
+
     using Exiled.API.Features;
+
     using YamlDotNet.Core;
 
     /// <summary>

--- a/Exiled.Permissions/Config.cs
+++ b/Exiled.Permissions/Config.cs
@@ -11,6 +11,7 @@ namespace Exiled.Permissions
     using System.IO;
 
     using API.Interfaces;
+
     using Exiled.API.Features;
 
     /// <inheritdoc cref="IConfig"/>

--- a/Exiled.Permissions/Extensions/Permissions.cs
+++ b/Exiled.Permissions/Extensions/Permissions.cs
@@ -14,12 +14,18 @@ namespace Exiled.Permissions.Extensions
     using System.Text;
 
     using CommandSystem;
+
     using Exiled.API.Extensions;
     using Exiled.API.Features;
+
     using Features;
+
     using NorthwoodLib.Pools;
+
     using Properties;
+
     using RemoteAdmin;
+
     using YamlDotNet.Core;
     using YamlDotNet.Serialization;
     using YamlDotNet.Serialization.NamingConventions;

--- a/Exiled.Updater/Models/TaggedRelease.cs
+++ b/Exiled.Updater/Models/TaggedRelease.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Updater.Models
 {
     using Exiled.Updater.GHApi.Models;
+
     using SemanticVersioning;
 
     public readonly struct TaggedRelease


### PR DESCRIPTION
- Deleted `Visuals939` effect, because deleted in base game
- Fixed `MirrorExtensions::MessageTranslated` method
- Really last fix for phantom pickups (lets say thanks to base game system: the grenade gameObject is destroyed before explosion)