### PR TITLE
Spawning fixes

### DIFF
--- a/Exiled.API/Features/Badge.cs
+++ b/Exiled.API/Features/Badge.cs
@@ -77,7 +77,7 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="colorType">The <see cref="Misc.PlayerInfoColorTypes"/> to get the hex color code of.</param>
         /// <returns>The hex color code, including the <c>#</c>.</returns>
-        public static string GetHexColor(Misc.PlayerInfoColorTypes colorType) => Misc.AllowedColors.FirstOrDefault(option => option.Key == colorType).Value;
+        public static string GetHexColor(Misc.PlayerInfoColorTypes colorType) => Misc.AllowedColors[colorType];
 
         /// <summary>
         /// Returns the Badge in a human-readable format.

--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -63,15 +63,6 @@ namespace Exiled.Events.Patches.Events.Player
                     new(OpCodes.Stloc_S, player.LocalIndex),
                     new(OpCodes.Brfalse_S, continueLabel),
 
-                    // if (this.CurrentRole.RoleTypeId == newRole)
-                    //    return;
-                    new(OpCodes.Ldarg_0),
-                    new(OpCodes.Call, PropertyGetter(typeof(PlayerRoleManager), nameof(PlayerRoleManager.CurrentRole))),
-                    new(OpCodes.Callvirt, PropertyGetter(typeof(PlayerRoleBase), nameof(PlayerRoleBase.RoleTypeId))),
-                    new(OpCodes.Ldarg_1),
-                    new(OpCodes.Ceq),
-                    new(OpCodes.Brtrue_S, continueLabel),
-
                     // player
                     new(OpCodes.Ldloc_S, player.LocalIndex),
 

--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -134,7 +134,7 @@ namespace Exiled.Events.Patches.Events.Player
                     new(OpCodes.Call, PropertyGetter(typeof(PlayerRoleManager), nameof(PlayerRoleManager.CurrentRole))),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(PlayerRoleBase), nameof(PlayerRoleBase.RoleTypeId))),
 
-                    // ChangingRole.ChangeInventory(ev.Player, ev.Items, ev.Ammo, currentRole, newRole, reason);
+                    // ChangingRole.ChangeInventory(ev, oldRoleType);
                     new(OpCodes.Call, Method(typeof(ChangingRole), nameof(ChangeInventory))),
 
                     new CodeInstruction(OpCodes.Nop).WithLabels(continueLabel),
@@ -184,7 +184,7 @@ namespace Exiled.Events.Patches.Events.Player
             {
                 Inventory inventory = ev.Player.Inventory;
 
-                if ((RoleChangeReason)ev.Reason == RoleChangeReason.Escaped && prevRole != ev.NewRole)
+                if (ev.Reason == API.Enums.SpawnReason.Escaped)
                 {
                     List<ItemPickupBase> list = new();
                     if (inventory.TryGetBodyArmor(out BodyArmor bodyArmor))

--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -44,6 +44,7 @@ namespace Exiled.Events.Patches.Events.Player
             Label returnLabel = generator.DefineLabel();
             Label continueLabel = generator.DefineLabel();
             Label continueLabel1 = generator.DefineLabel();
+            Label continueLabel2 = generator.DefineLabel();
 
             LocalBuilder ev = generator.DeclareLocal(typeof(ChangingRoleEventArgs));
             LocalBuilder player = generator.DeclareLocal(typeof(API.Features.Player));
@@ -137,17 +138,18 @@ namespace Exiled.Events.Patches.Events.Player
                 });
 
             offset = 1;
-            index = newInstructions.FindIndex(i => i.Calls(Method(typeof(PlayerRoleManager.RoleChanged), nameof(PlayerRoleManager.RoleChanged)))) + offset;
+            index = newInstructions.FindIndex(i => i.Calls(Method(typeof(PlayerRoleManager.RoleChanged), nameof(PlayerRoleManager.RoleChanged.Invoke)))) + offset;
+
+            newInstructions[index].labels.Add(continueLabel2);
 
             newInstructions.InsertRange(
                 index,
                 new[]
                 {
-                    // if (ev.ShouldPreserveInventory)
-                    //    goto continueLabel;
-                    new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
-                    new(OpCodes.Callvirt, PropertyGetter(typeof(ChangingRoleEventArgs), nameof(ChangingRoleEventArgs.ShouldPreserveInventory))),
-                    new(OpCodes.Brtrue_S, returnLabel),
+                    // if (player == null)
+                    //     continue
+                    new CodeInstruction(OpCodes.Ldloc_S, player.LocalIndex),
+                    new(OpCodes.Brfalse_S, continueLabel2),
 
                     // ev
                     new(OpCodes.Ldloc_S, ev.LocalIndex),


### PR DESCRIPTION
- Removed cringe code in `Badge::GetHexColor`
- Properly fix for spawning items while escaping(before my fix items spawns on escape position, not on player spawn position💀)
- removed `if (oldRole == newRole)` checks, base game now support respawning as same role