### PR TITLE
Create IWrapper interface

### DIFF
--- a/Exiled.API/Features/Camera.cs
+++ b/Exiled.API/Features/Camera.cs
@@ -12,6 +12,7 @@ namespace Exiled.API.Features
     using System.Linq;
 
     using Enums;
+    using Exiled.API.Interfaces;
 
     using PlayerRoles.PlayableScps.Scp079.Cameras;
 
@@ -22,7 +23,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// The in-game Scp079Camera.
     /// </summary>
-    public class Camera
+    public class Camera : IWrapper<Scp079Camera>
     {
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="Scp079Camera"/>s and their corresponding <see cref="Camera"/>.

--- a/Exiled.API/Features/Door.cs
+++ b/Exiled.API/Features/Door.cs
@@ -12,7 +12,7 @@ namespace Exiled.API.Features
     using System.Linq;
 
     using Enums;
-
+    using Exiled.API.Interfaces;
     using Extensions;
 
     using Interactables.Interobjects;
@@ -29,7 +29,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// A wrapper class for <see cref="DoorVariant"/>.
     /// </summary>
-    public class Door
+    public class Door : IWrapper<DoorVariant>
     {
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="DoorVariant"/>s and their corresponding <see cref="Door"/>.

--- a/Exiled.API/Features/Generator.cs
+++ b/Exiled.API/Features/Generator.cs
@@ -11,6 +11,7 @@ namespace Exiled.API.Features
     using System.Linq;
 
     using Enums;
+    using Exiled.API.Interfaces;
 
     using MapGeneration.Distributors;
 
@@ -19,7 +20,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// Wrapper class for <see cref="Scp079Generator"/>.
     /// </summary>
-    public class Generator
+    public class Generator : IWrapper<Scp079Generator>
     {
         /// <summary>
         /// A <see cref="List{T}"/> of <see cref="Generator"/> on the map.

--- a/Exiled.API/Features/Items/Ammo.cs
+++ b/Exiled.API/Features/Items/Ammo.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features.Items
 {
     using Enums;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items;
     using InventorySystem.Items.Firearms.Ammo;
@@ -15,7 +16,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for <see cref="AmmoItem"/>.
     /// </summary>
-    public class Ammo : Item
+    public class Ammo : Item, IWrapper<AmmoItem>
     {
         /// <summary>
         /// Gets the absolute maximum amount of ammo that may be held at one time, if ammo is forcefully given to the player (regardless of worn armor or server configuration).

--- a/Exiled.API/Features/Items/Armor.cs
+++ b/Exiled.API/Features/Items/Armor.cs
@@ -11,6 +11,8 @@ namespace Exiled.API.Features.Items
     using System.Collections.Generic;
     using System.Linq;
 
+    using Exiled.API.Interfaces;
+
     using InventorySystem.Items;
     using InventorySystem.Items.Armor;
 
@@ -21,7 +23,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for <see cref="BodyArmor"/>.
     /// </summary>
-    public class Armor : Item
+    public class Armor : Item, IWrapper<BodyArmor>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Armor"/> class.

--- a/Exiled.API/Features/Items/Consumable.cs
+++ b/Exiled.API/Features/Items/Consumable.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Items
 {
+    using Exiled.API.Interfaces;
+
     using InventorySystem.Items;
 
     using BaseConsumable = InventorySystem.Items.Usables.Consumable;
@@ -14,7 +16,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for <see cref="BaseConsumable"/>.
     /// </summary>
-    public class Consumable : Usable
+    public class Consumable : Usable, IWrapper<BaseConsumable>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Consumable"/> class.

--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -11,6 +11,7 @@ namespace Exiled.API.Features.Items
 
     using Exiled.API.Features.Pickups;
     using Exiled.API.Features.Pickups.Projectiles;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items;
     using InventorySystem.Items.Pickups;
@@ -23,7 +24,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for <see cref="ExplosionGrenade"/>.
     /// </summary>
-    public class ExplosiveGrenade : Throwable
+    public class ExplosiveGrenade : Throwable, IWrapper<ThrowableItem>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ExplosiveGrenade"/> class.

--- a/Exiled.API/Features/Items/Firearm.cs
+++ b/Exiled.API/Features/Items/Firearm.cs
@@ -16,6 +16,7 @@ namespace Exiled.API.Features.Items
     using Enums;
 
     using Exiled.API.Features.Pickups;
+    using Exiled.API.Interfaces;
     using Exiled.API.Structs;
 
     using Extensions;
@@ -37,7 +38,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for <see cref="InventorySystem.Items.Firearms.Firearm"/>.
     /// </summary>
-    public class Firearm : Item
+    public class Firearm : Item, IWrapper<BaseFirearm>
     {
         /// <summary>
         /// A <see cref="List{T}"/> of <see cref="Firearm"/> which contains all the existing firearms based on all the <see cref="FirearmType"/>s.

--- a/Exiled.API/Features/Items/FlashGrenade.cs
+++ b/Exiled.API/Features/Items/FlashGrenade.cs
@@ -10,6 +10,7 @@ namespace Exiled.API.Features.Items
     using Exiled.API.Enums;
     using Exiled.API.Features.Pickups;
     using Exiled.API.Features.Pickups.Projectiles;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items;
     using InventorySystem.Items.Pickups;
@@ -22,7 +23,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for <see cref="FlashbangGrenade"/>.
     /// </summary>
-    public class FlashGrenade : Throwable
+    public class FlashGrenade : Throwable, IWrapper<ThrowableItem>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FlashGrenade"/> class.

--- a/Exiled.API/Features/Items/Flashlight.cs
+++ b/Exiled.API/Features/Items/Flashlight.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Items
 {
+    using Exiled.API.Interfaces;
+
     using InventorySystem.Items;
     using InventorySystem.Items.Flashlight;
 
@@ -15,7 +17,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapped class for <see cref="FlashlightItem"/>.
     /// </summary>
-    public class Flashlight : Item
+    public class Flashlight : Item, IWrapper<FlashlightItem>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Flashlight"/> class.

--- a/Exiled.API/Features/Items/Item.cs
+++ b/Exiled.API/Features/Items/Item.cs
@@ -12,6 +12,7 @@ namespace Exiled.API.Features.Items
 
     using Exiled.API.Features.Core;
     using Exiled.API.Features.Pickups;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items;
     using InventorySystem.Items.Armor;
@@ -36,7 +37,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for <see cref="ItemBase"/>.
     /// </summary>
-    public class Item : TypeCastObject<Item>
+    public class Item : TypeCastObject<Item>, IWrapper<ItemBase>
     {
         /// <summary>
         /// A dictionary of all <see cref="ItemBase"/>'s that have been converted into <see cref="Item"/>.

--- a/Exiled.API/Features/Items/Jailbird.cs
+++ b/Exiled.API/Features/Items/Jailbird.cs
@@ -7,13 +7,15 @@
 
 namespace Exiled.API.Features.Items
 {
+    using Exiled.API.Interfaces;
+
     using InventorySystem.Items.Jailbird;
     using UnityEngine;
 
     /// <summary>
     /// A wrapped class for <see cref="JailbirdItem"/>.
     /// </summary>
-    public class Jailbird : Item
+    public class Jailbird : Item, IWrapper<JailbirdItem>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Jailbird"/> class.

--- a/Exiled.API/Features/Items/Keycard.cs
+++ b/Exiled.API/Features/Items/Keycard.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features.Items
 {
     using Exiled.API.Enums;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items;
     using InventorySystem.Items.Keycards;
@@ -15,7 +16,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for <see cref="KeycardItem"/>.
     /// </summary>
-    public class Keycard : Item
+    public class Keycard : Item, IWrapper<KeycardItem>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Keycard"/> class.

--- a/Exiled.API/Features/Items/MicroHid.cs
+++ b/Exiled.API/Features/Items/MicroHid.cs
@@ -7,13 +7,15 @@
 
 namespace Exiled.API.Features.Items
 {
+    using Exiled.API.Interfaces;
+
     using InventorySystem.Items;
     using InventorySystem.Items.MicroHID;
 
     /// <summary>
     /// A wrapper class for <see cref="MicroHIDItem"/>.
     /// </summary>
-    public class MicroHid : Item
+    public class MicroHid : Item, IWrapper<MicroHIDItem>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MicroHid"/> class.

--- a/Exiled.API/Features/Items/Radio.cs
+++ b/Exiled.API/Features/Items/Radio.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features.Items
 {
     using Enums;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items;
     using InventorySystem.Items.Radio;
@@ -17,7 +18,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for <see cref="RadioItem"/>.
     /// </summary>
-    public class Radio : Item
+    public class Radio : Item, IWrapper<RadioItem>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Radio"/> class.

--- a/Exiled.API/Features/Items/Scp1576.cs
+++ b/Exiled.API/Features/Items/Scp1576.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Items
 {
+    using Exiled.API.Interfaces;
+
     using InventorySystem.Items;
     using InventorySystem.Items.Usables;
     using InventorySystem.Items.Usables.Scp1576;
@@ -14,7 +16,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for <see cref="Scp1576Item"/>.
     /// </summary>
-    public class Scp1576 : Usable
+    public class Scp1576 : Usable, IWrapper<Scp1576Item>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp1576"/> class.

--- a/Exiled.API/Features/Items/Scp2176.cs
+++ b/Exiled.API/Features/Items/Scp2176.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features.Items
 {
     using Exiled.API.Features.Pickups;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items;
     using InventorySystem.Items.Pickups;
@@ -20,7 +21,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for <see cref="Scp2176Projectile"/>.
     /// </summary>
-    public class Scp2176 : Throwable
+    public class Scp2176 : Throwable, IWrapper<ThrowableItem>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp2176"/> class.

--- a/Exiled.API/Features/Items/Scp244.cs
+++ b/Exiled.API/Features/Items/Scp244.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features.Items
 {
     using Exiled.API.Features.Pickups;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items;
     using InventorySystem.Items.Usables.Scp244;
@@ -17,7 +18,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for SCP-244.
     /// </summary>
-    public class Scp244 : Usable
+    public class Scp244 : Usable, IWrapper<Scp244Item>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp244"/> class.

--- a/Exiled.API/Features/Items/Scp330.cs
+++ b/Exiled.API/Features/Items/Scp330.cs
@@ -10,6 +10,7 @@ namespace Exiled.API.Features.Items
     using System.Collections.Generic;
 
     using Exiled.API.Features.Pickups;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items;
     using InventorySystem.Items.Pickups;
@@ -44,7 +45,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for SCP-330 bags.
     /// </summary>
-    public partial class Scp330 : Usable
+    public partial class Scp330 : Usable, IWrapper<Scp330Bag>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp330"/> class.

--- a/Exiled.API/Features/Items/Throwable.cs
+++ b/Exiled.API/Features/Items/Throwable.cs
@@ -9,6 +9,7 @@ namespace Exiled.API.Features.Items
 {
     using Exiled.API.Features.Pickups;
     using Exiled.API.Features.Pickups.Projectiles;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items;
     using InventorySystem.Items.ThrowableProjectiles;
@@ -18,7 +19,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for throwable items.
     /// </summary>
-    public class Throwable : Item
+    public class Throwable : Item, IWrapper<ThrowableItem>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Throwable"/> class.

--- a/Exiled.API/Features/Items/Usable.cs
+++ b/Exiled.API/Features/Items/Usable.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features.Items
 {
     using Exiled.API.Features.Pickups;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items;
     using InventorySystem.Items.Usables;
@@ -17,7 +18,7 @@ namespace Exiled.API.Features.Items
     /// <summary>
     /// A wrapper class for <see cref="UsableItem"/>.
     /// </summary>
-    public class Usable : Item
+    public class Usable : Item, IWrapper<UsableItem>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Usable"/> class.

--- a/Exiled.API/Features/Lift.cs
+++ b/Exiled.API/Features/Lift.cs
@@ -12,9 +12,9 @@ namespace Exiled.API.Features
     using System.Linq;
 
     using Exiled.API.Enums;
+    using Exiled.API.Features.Pools;
     using Exiled.API.Interfaces;
 
-    using Exiled.API.Features.Pools;
     using Interactables.Interobjects;
     using Interactables.Interobjects.DoorUtils;
 

--- a/Exiled.API/Features/Lift.cs
+++ b/Exiled.API/Features/Lift.cs
@@ -12,6 +12,7 @@ namespace Exiled.API.Features
     using System.Linq;
 
     using Exiled.API.Enums;
+    using Exiled.API.Interfaces;
 
     using Interactables.Interobjects;
     using Interactables.Interobjects.DoorUtils;
@@ -24,7 +25,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// The in-game lift.
     /// </summary>
-    public class Lift
+    public class Lift : IWrapper<ElevatorChamber>
     {
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="ElevatorChamber"/>s and their corresponding <see cref="Lift"/>.

--- a/Exiled.API/Features/Pickups/AmmoPickup.cs
+++ b/Exiled.API/Features/Pickups/AmmoPickup.cs
@@ -9,13 +9,14 @@ namespace Exiled.API.Features.Pickups
 {
     using Exiled.API.Enums;
     using Exiled.API.Extensions;
+    using Exiled.API.Interfaces;
 
     using BaseAmmo = InventorySystem.Items.Firearms.Ammo.AmmoPickup;
 
     /// <summary>
     /// A wrapper class for an Ammo pickup.
     /// </summary>
-    public class AmmoPickup : Pickup
+    public class AmmoPickup : Pickup, IWrapper<BaseAmmo>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AmmoPickup"/> class.

--- a/Exiled.API/Features/Pickups/BodyArmorPickup.cs
+++ b/Exiled.API/Features/Pickups/BodyArmorPickup.cs
@@ -7,12 +7,14 @@
 
 namespace Exiled.API.Features.Pickups
 {
+    using Exiled.API.Interfaces;
+
     using BaseBodyArmor = InventorySystem.Items.Armor.BodyArmorPickup;
 
     /// <summary>
     /// A wrapper class for a Body Armor pickup.
     /// </summary>
-    public class BodyArmorPickup : Pickup
+    public class BodyArmorPickup : Pickup, IWrapper<BaseBodyArmor>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BodyArmorPickup"/> class.

--- a/Exiled.API/Features/Pickups/FirearmPickup.cs
+++ b/Exiled.API/Features/Pickups/FirearmPickup.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Pickups
 {
+    using Exiled.API.Interfaces;
+
     using InventorySystem.Items.Firearms;
 
     using BaseFirearm = InventorySystem.Items.Firearms.FirearmPickup;
@@ -14,7 +16,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for a Firearm pickup.
     /// </summary>
-    public class FirearmPickup : Pickup
+    public class FirearmPickup : Pickup, IWrapper<BaseFirearm>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FirearmPickup"/> class.

--- a/Exiled.API/Features/Pickups/GrenadePickup.cs
+++ b/Exiled.API/Features/Pickups/GrenadePickup.cs
@@ -9,13 +9,14 @@ namespace Exiled.API.Features.Pickups
 {
     using Exiled.API.Enums;
     using Exiled.API.Extensions;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items.ThrowableProjectiles;
 
     /// <summary>
     /// A wrapper class for a grenade pickup.
     /// </summary>
-    public class GrenadePickup : Pickup
+    public class GrenadePickup : Pickup, IWrapper<TimedGrenadePickup>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrenadePickup"/> class.

--- a/Exiled.API/Features/Pickups/JailbirdPickup.cs
+++ b/Exiled.API/Features/Pickups/JailbirdPickup.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Pickups
 {
+    using Exiled.API.Interfaces;
+
     using InventorySystem.Items.Jailbird;
     using UnityEngine;
 
@@ -15,7 +17,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for a jailbird pickup.
     /// </summary>
-    public class JailbirdPickup : Pickup
+    public class JailbirdPickup : Pickup, IWrapper<BaseJailbirdPickup>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JailbirdPickup"/> class.

--- a/Exiled.API/Features/Pickups/KeycardPickup.cs
+++ b/Exiled.API/Features/Pickups/KeycardPickup.cs
@@ -7,12 +7,14 @@
 
 namespace Exiled.API.Features.Pickups
 {
+    using Exiled.API.Interfaces;
+
     using BaseKeycard = InventorySystem.Items.Keycards.KeycardPickup;
 
     /// <summary>
     /// A wrapper class for a Keycard pickup.
     /// </summary>
-    public class KeycardPickup : Pickup
+    public class KeycardPickup : Pickup, IWrapper<BaseKeycard>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="KeycardPickup"/> class.

--- a/Exiled.API/Features/Pickups/MicroHIDPickup.cs
+++ b/Exiled.API/Features/Pickups/MicroHIDPickup.cs
@@ -7,12 +7,14 @@
 
 namespace Exiled.API.Features.Pickups
 {
+    using Exiled.API.Interfaces;
+
     using BaseMicroHID = InventorySystem.Items.MicroHID.MicroHIDPickup;
 
     /// <summary>
     /// A wrapper class for a MicroHID pickup.
     /// </summary>
-    public class MicroHIDPickup : Pickup
+    public class MicroHIDPickup : Pickup, IWrapper<BaseMicroHID>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MicroHIDPickup"/> class.

--- a/Exiled.API/Features/Pickups/Pickup.cs
+++ b/Exiled.API/Features/Pickups/Pickup.cs
@@ -12,6 +12,7 @@ namespace Exiled.API.Features.Pickups
 
     using Exiled.API.Features.Core;
     using Exiled.API.Features.Pickups.Projectiles;
+    using Exiled.API.Interfaces;
 
     using InventorySystem;
     using InventorySystem.Items;
@@ -37,7 +38,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for <see cref="ItemPickupBase"/>.
     /// </summary>
-    public class Pickup : TypeCastObject<Pickup>
+    public class Pickup : TypeCastObject<Pickup>, IWrapper<ItemPickupBase>
     {
         /// <summary>
         /// A dictionary of all <see cref="ItemBase"/>'s that have been converted into <see cref="Items.Item"/>.

--- a/Exiled.API/Features/Pickups/Projectiles/EffectGrenadeProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/EffectGrenadeProjectile.cs
@@ -7,12 +7,14 @@
 
 namespace Exiled.API.Features.Pickups.Projectiles
 {
+    using Exiled.API.Interfaces;
+
     using InventorySystem.Items.ThrowableProjectiles;
 
     /// <summary>
     /// A wrapper class for EffectGrenade.
     /// </summary>
-    public class EffectGrenadeProjectile : TimeGrenadeProjectile
+    public class EffectGrenadeProjectile : TimeGrenadeProjectile, IWrapper<EffectGrenade>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EffectGrenadeProjectile"/> class.

--- a/Exiled.API/Features/Pickups/Projectiles/ExplosionGrenadeProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/ExplosionGrenadeProjectile.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features.Pickups.Projectiles
 {
     using Exiled.API.Enums;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items.ThrowableProjectiles;
 
@@ -18,7 +19,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
     /// <summary>
     /// A wrapper class for ExplosionGrenade.
     /// </summary>
-    public class ExplosionGrenadeProjectile : EffectGrenadeProjectile
+    public class ExplosionGrenadeProjectile : EffectGrenadeProjectile, IWrapper<ExplosionGrenade>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ExplosionGrenadeProjectile"/> class.

--- a/Exiled.API/Features/Pickups/Projectiles/FlashbangProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/FlashbangProjectile.cs
@@ -8,13 +8,14 @@
 namespace Exiled.API.Features.Pickups.Projectiles
 {
     using Exiled.API.Enums;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items.ThrowableProjectiles;
 
     /// <summary>
     /// A wrapper class for FlashbangGrenade.
     /// </summary>
-    public class FlashbangProjectile : EffectGrenadeProjectile
+    public class FlashbangProjectile : EffectGrenadeProjectile, IWrapper<FlashbangGrenade>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FlashbangProjectile"/> class.

--- a/Exiled.API/Features/Pickups/Projectiles/Projectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/Projectile.cs
@@ -9,6 +9,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
 {
     using Exiled.API.Enums;
     using Exiled.API.Extensions;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items.ThrowableProjectiles;
 
@@ -17,7 +18,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
     /// <summary>
     /// A wrapper class for Projectile.
     /// </summary>
-    public class Projectile : Pickup
+    public class Projectile : Pickup, IWrapper<ThrownProjectile>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Projectile"/> class.

--- a/Exiled.API/Features/Pickups/Projectiles/Scp018Projectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/Scp018Projectile.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Pickups.Projectiles
 {
+    using Exiled.API.Interfaces;
+
     using InventorySystem.Items.ThrowableProjectiles;
 
     using BaseScp018Projectile = InventorySystem.Items.ThrowableProjectiles.Scp018Projectile;
@@ -14,7 +16,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
     /// <summary>
     /// A wrapper class for Scp018Projectile.
     /// </summary>
-    public class Scp018Projectile : ExplosionGrenadeProjectile
+    public class Scp018Projectile : ExplosionGrenadeProjectile, IWrapper<BaseScp018Projectile>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp018Projectile"/> class.

--- a/Exiled.API/Features/Pickups/Projectiles/Scp2176Projectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/Scp2176Projectile.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features.Pickups.Projectiles
 {
+    using Exiled.API.Interfaces;
+
     using InventorySystem.Items.ThrowableProjectiles;
 
     using BaseScp2176Projectile = InventorySystem.Items.ThrowableProjectiles.Scp2176Projectile;
@@ -14,7 +16,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
     /// <summary>
     /// A wrapper class for an SCP-2176 Projectile.
     /// </summary>
-    public class Scp2176Projectile : EffectGrenadeProjectile
+    public class Scp2176Projectile : EffectGrenadeProjectile, IWrapper<BaseScp2176Projectile>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp2176Projectile"/> class.

--- a/Exiled.API/Features/Pickups/Projectiles/TimeGrenadeProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/TimeGrenadeProjectile.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features.Pickups.Projectiles
 {
     using Exiled.API.Enums;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items.ThrowableProjectiles;
 
@@ -16,7 +17,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
     /// <summary>
     /// A wrapper class for TimeGrenade.
     /// </summary>
-    public class TimeGrenadeProjectile : Projectile
+    public class TimeGrenadeProjectile : Projectile, IWrapper<TimeGrenade>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeGrenadeProjectile"/> class.

--- a/Exiled.API/Features/Pickups/RadioPickup.cs
+++ b/Exiled.API/Features/Pickups/RadioPickup.cs
@@ -8,13 +8,14 @@
 namespace Exiled.API.Features.Pickups
 {
     using Exiled.API.Enums;
+    using Exiled.API.Interfaces;
 
     using BaseRadio = InventorySystem.Items.Radio.RadioPickup;
 
     /// <summary>
     /// A wrapper class for a Radio pickup.
     /// </summary>
-    public class RadioPickup : Pickup
+    public class RadioPickup : Pickup, IWrapper<BaseRadio>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RadioPickup"/> class.

--- a/Exiled.API/Features/Pickups/Scp1576Pickup.cs
+++ b/Exiled.API/Features/Pickups/Scp1576Pickup.cs
@@ -7,12 +7,14 @@
 
 namespace Exiled.API.Features.Pickups
 {
+    using Exiled.API.Interfaces;
+
     using BaseScp1576 = InventorySystem.Items.Usables.Scp1576.Scp1576Pickup;
 
     /// <summary>
     /// A wrapper class for dropped SCP-330 bags.
     /// </summary>
-    public class Scp1576Pickup : Pickup
+    public class Scp1576Pickup : Pickup, IWrapper<BaseScp1576>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp1576Pickup"/> class.

--- a/Exiled.API/Features/Pickups/Scp244Pickup.cs
+++ b/Exiled.API/Features/Pickups/Scp244Pickup.cs
@@ -10,6 +10,7 @@ namespace Exiled.API.Features.Pickups
     using System;
 
     using Exiled.API.Features.DamageHandlers;
+    using Exiled.API.Interfaces;
 
     using InventorySystem.Items.Usables.Scp244;
 
@@ -18,7 +19,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for a SCP-244 pickup.
     /// </summary>
-    public class Scp244Pickup : Pickup
+    public class Scp244Pickup : Pickup, IWrapper<Scp244DeployablePickup>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp244Pickup"/> class.

--- a/Exiled.API/Features/Pickups/Scp330Pickup.cs
+++ b/Exiled.API/Features/Pickups/Scp330Pickup.cs
@@ -9,6 +9,8 @@ namespace Exiled.API.Features.Pickups
 {
     using System.Collections.Generic;
 
+    using Exiled.API.Interfaces;
+
     using InventorySystem.Items.Usables.Scp330;
 
     using BaseScp330 = InventorySystem.Items.Usables.Scp330.Scp330Pickup;
@@ -16,7 +18,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for dropped SCP-330 bags.
     /// </summary>
-    public class Scp330Pickup : Pickup
+    public class Scp330Pickup : Pickup, IWrapper<BaseScp330>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp330Pickup"/> class.

--- a/Exiled.API/Features/Ragdoll.cs
+++ b/Exiled.API/Features/Ragdoll.cs
@@ -16,6 +16,7 @@ namespace Exiled.API.Features
     using Enums;
 
     using Exiled.API.Extensions;
+    using Exiled.API.Interfaces;
 
     using Mirror;
 
@@ -32,7 +33,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// A set of tools to handle the ragdolls more easily.
     /// </summary>
-    public class Ragdoll
+    public class Ragdoll : IWrapper<BasicRagdoll>
     {
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="BasicRagdoll"/>s and their corresponding <see cref="Ragdoll"/>.

--- a/Exiled.API/Features/Roles/Role.cs
+++ b/Exiled.API/Features/Roles/Role.cs
@@ -13,7 +13,7 @@ namespace Exiled.API.Features.Roles
 
     using Exiled.API.Features.Core;
     using Exiled.API.Features.Spawn;
-
+    using Exiled.API.Interfaces;
     using Extensions;
 
     using PlayerRoles;
@@ -34,7 +34,7 @@ namespace Exiled.API.Features.Roles
     /// <summary>
     /// Defines the class for role-related classes.
     /// </summary>
-    public abstract class Role : TypeCastObject<Role>
+    public abstract class Role : TypeCastObject<Role>, IWrapper<PlayerRoleBase>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Role"/> class.

--- a/Exiled.API/Features/TeslaGate.cs
+++ b/Exiled.API/Features/TeslaGate.cs
@@ -11,6 +11,8 @@ namespace Exiled.API.Features
     using System.Collections.Generic;
     using System.Linq;
 
+    using Exiled.API.Interfaces;
+
     using Hazards;
 
     using MEC;
@@ -24,7 +26,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// The in-game tesla gate.
     /// </summary>
-    public class TeslaGate
+    public class TeslaGate : IWrapper<BaseTeslaGate>
     {
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="BaseTeslaGate"/>s and their corresponding <see cref="TeslaGate"/>.

--- a/Exiled.API/Features/Toys/Light.cs
+++ b/Exiled.API/Features/Toys/Light.cs
@@ -12,13 +12,14 @@ namespace Exiled.API.Features.Toys
     using AdminToys;
 
     using Enums;
+    using Exiled.API.Interfaces;
 
     using UnityEngine;
 
     /// <summary>
     /// A wrapper class for <see cref="LightSourceToy"/>.
     /// </summary>
-    public class Light : AdminToy
+    public class Light : AdminToy, IWrapper<LightSourceToy>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Light"/> class.

--- a/Exiled.API/Features/Toys/Primitive.cs
+++ b/Exiled.API/Features/Toys/Primitive.cs
@@ -13,6 +13,7 @@ namespace Exiled.API.Features.Toys
     using AdminToys;
 
     using Enums;
+    using Exiled.API.Interfaces;
 
     using UnityEngine;
 
@@ -21,7 +22,7 @@ namespace Exiled.API.Features.Toys
     /// <summary>
     /// A wrapper class for <see cref="PrimitiveObjectToy"/>.
     /// </summary>
-    public class Primitive : AdminToy
+    public class Primitive : AdminToy, IWrapper<PrimitiveObjectToy>
     {
         private bool collidable = true;
 

--- a/Exiled.API/Features/Toys/ShootingTargetToy.cs
+++ b/Exiled.API/Features/Toys/ShootingTargetToy.cs
@@ -12,6 +12,7 @@ namespace Exiled.API.Features.Toys
     using System.Linq;
 
     using Enums;
+    using Exiled.API.Interfaces;
 
     using Mirror;
 
@@ -25,7 +26,7 @@ namespace Exiled.API.Features.Toys
     /// <summary>
     /// A wrapper class for <see cref="ShootingTarget"/>.
     /// </summary>
-    public class ShootingTargetToy : AdminToy
+    public class ShootingTargetToy : AdminToy, IWrapper<ShootingTarget>
     {
         private static readonly Dictionary<string, ShootingTargetType> TypeLookup = new()
         {

--- a/Exiled.API/Features/Window.cs
+++ b/Exiled.API/Features/Window.cs
@@ -12,13 +12,14 @@ namespace Exiled.API.Features
     using DamageHandlers;
 
     using Enums;
+    using Exiled.API.Interfaces;
 
     using UnityEngine;
 
     /// <summary>
     /// A wrapper class for <see cref="BreakableWindow"/>.
     /// </summary>
-    public class Window
+    public class Window : IWrapper<BreakableWindow>
     {
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="BreakableWindow"/>s and their corresponding <see cref="Window"/>.

--- a/Exiled.API/Interfaces/IWrapper.cs
+++ b/Exiled.API/Interfaces/IWrapper.cs
@@ -1,0 +1,24 @@
+// -----------------------------------------------------------------------
+// <copyright file="IWrapper.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Interfaces
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// Defines the contract for classes that wrap a base-game object.
+    /// </summary>
+    /// <typeparam name="T">The base-game class that is being wrapped.</typeparam>
+    public interface IWrapper<T>
+        where T : MonoBehaviour
+    {
+        /// <summary>
+        /// Gets the base <typeparamref name="T"/> that this class is wrapping.
+        /// </summary>
+        public T Base { get; }
+    }
+}


### PR DESCRIPTION
Introduce a new interface: `IWrapper`. This interface is used on all wrapper classes that use a `Base` property (figuring out how to support this for `Player`). The goal is to force wrapper classes to all use a similar Base naming scheme, while also providing inherited docs (since all wrapper classes use very similar docs for the `Base` property). I will also be using this in part 2 of the pool API coming later...