### PR TITLE
Convert pools to use basegame pools

### DIFF
--- a/Exiled.API/Features/Pools/HashSetPool.cs
+++ b/Exiled.API/Features/Pools/HashSetPool.cs
@@ -26,20 +26,17 @@ namespace Exiled.API.Features.Pools
         public static HashSetPool<T> Pool { get; } = new();
 
         /// <inheritdoc/>
-        public HashSet<T> Get()
-            => BasePools.HashSetPool<T>.Shared.Rent();
+        public HashSet<T> Get() => BasePools.HashSetPool<T>.Shared.Rent();
 
         /// <summary>
         /// Retrieves a stored object of type <see cref="HashSet{T}"/>, or creates it if it does not exist. The hashset will be filled with all the provided <paramref name="items"/>.
         /// </summary>
         /// <param name="items">The items to fill the hashset with.</param>
         /// <returns>The stored object, or a new object, of type <see cref="HashSet{T}"/>.</returns>
-        public HashSet<T> Get(IEnumerable<T> items)
-            => BasePools.HashSetPool<T>.Shared.Rent(items);
+        public HashSet<T> Get(IEnumerable<T> items) => BasePools.HashSetPool<T>.Shared.Rent(items);
 
         /// <inheritdoc/>
-        public void Return(HashSet<T> obj)
-            => BasePools.HashSetPool<T>.Shared.Return(obj);
+        public void Return(HashSet<T> obj) => BasePools.HashSetPool<T>.Shared.Return(obj);
 
         /// <summary>
         /// Returns the <see cref="HashSet{T}"/> to the pool and returns its contents as an array.

--- a/Exiled.API/Features/Pools/HashSetPool.cs
+++ b/Exiled.API/Features/Pools/HashSetPool.cs
@@ -7,9 +7,10 @@
 
 namespace Exiled.API.Features.Pools
 {
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
+
+    using BasePools = NorthwoodLib.Pools;
 
     /// <summary>
     /// Defines a system used to store and retrieve <see cref="HashSet{T}"/> objects.
@@ -19,8 +20,6 @@ namespace Exiled.API.Features.Pools
     /// <seealso cref="ListPool{T}"/>
     public class HashSetPool<T> : IPool<HashSet<T>>
     {
-        private readonly ConcurrentQueue<HashSet<T>> pool = new();
-
         /// <summary>
         /// Gets a <see cref="HashSetPool{T}"/> that stores hash sets.
         /// </summary>
@@ -28,12 +27,7 @@ namespace Exiled.API.Features.Pools
 
         /// <inheritdoc/>
         public HashSet<T> Get()
-        {
-            if (pool.TryDequeue(out HashSet<T> set))
-                return set;
-
-            return new();
-        }
+            => BasePools.HashSetPool<T>.Shared.Rent();
 
         /// <summary>
         /// Retrieves a stored object of type <see cref="HashSet{T}"/>, or creates it if it does not exist. The hashset will be filled with all the provided <paramref name="items"/>.
@@ -41,23 +35,11 @@ namespace Exiled.API.Features.Pools
         /// <param name="items">The items to fill the hashset with.</param>
         /// <returns>The stored object, or a new object, of type <see cref="HashSet{T}"/>.</returns>
         public HashSet<T> Get(IEnumerable<T> items)
-        {
-            if (pool.TryDequeue(out HashSet<T> set))
-            {
-                foreach (T item in items)
-                    set.Add(item);
-                return set;
-            }
-
-            return new(items);
-        }
+            => BasePools.HashSetPool<T>.Shared.Rent(items);
 
         /// <inheritdoc/>
         public void Return(HashSet<T> obj)
-        {
-            obj.Clear();
-            pool.Enqueue(obj);
-        }
+            => BasePools.HashSetPool<T>.Shared.Return(obj);
 
         /// <summary>
         /// Returns the <see cref="HashSet{T}"/> to the pool and returns its contents as an array.

--- a/Exiled.API/Features/Pools/ListPool.cs
+++ b/Exiled.API/Features/Pools/ListPool.cs
@@ -25,28 +25,24 @@ namespace Exiled.API.Features.Pools
         public static ListPool<T> Pool { get; } = new();
 
         /// <inheritdoc/>
-        public List<T> Get()
-            => BasePools.ListPool<T>.Shared.Rent();
+        public List<T> Get() => BasePools.ListPool<T>.Shared.Rent();
 
         /// <summary>
         /// Retrieves a stored object of type <see cref="List{T}"/>, or creates it if it does not exist. The capacity of the list will be equal to or greater than <paramref name="capacity"/>.
         /// </summary>
         /// <param name="capacity">The capacity of content in the <see cref="List{T}"/>.</param>
         /// <returns>The stored object, or a new object, of type <see cref="List{T}"/>.</returns>
-        public List<T> Get(int capacity)
-            => BasePools.ListPool<T>.Shared.Rent(capacity);
+        public List<T> Get(int capacity) => BasePools.ListPool<T>.Shared.Rent(capacity);
 
         /// <summary>
         /// Retrieves a stored object of type <see cref="List{T}"/>, or creates it if it does not exist. The list will be filled with all the provided <paramref name="items"/>.
         /// </summary>
         /// <param name="items">The items to fill the list with.</param>
         /// <returns>The stored object, or a new object, of type <see cref="List{T}"/>.</returns>
-        public List<T> Get(IEnumerable<T> items)
-            => BasePools.ListPool<T>.Shared.Rent(items);
+        public List<T> Get(IEnumerable<T> items) => BasePools.ListPool<T>.Shared.Rent(items);
 
         /// <inheritdoc/>
-        public void Return(List<T> obj)
-            => BasePools.ListPool<T>.Shared.Return(obj);
+        public void Return(List<T> obj) => BasePools.ListPool<T>.Shared.Return(obj);
 
         /// <summary>
         /// Returns the <see cref="List{T}"/> to the pool and returns its contents as an array.

--- a/Exiled.API/Features/Pools/ListPool.cs
+++ b/Exiled.API/Features/Pools/ListPool.cs
@@ -7,8 +7,9 @@
 
 namespace Exiled.API.Features.Pools
 {
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
+
+    using BasePools = NorthwoodLib.Pools;
 
     /// <summary>
     /// Defines a system used to store and retrieve <see cref="List{T}"/> objects.
@@ -18,8 +19,6 @@ namespace Exiled.API.Features.Pools
     /// <seealso cref="HashSetPool{T}"/>
     public class ListPool<T> : IPool<List<T>>
     {
-        private readonly ConcurrentQueue<List<T>> pool = new();
-
         /// <summary>
         /// Gets a <see cref="ListPool{T}"/> that stores lists.
         /// </summary>
@@ -27,12 +26,7 @@ namespace Exiled.API.Features.Pools
 
         /// <inheritdoc/>
         public List<T> Get()
-        {
-            if (pool.TryDequeue(out List<T> list))
-                return list;
-
-            return new();
-        }
+            => BasePools.ListPool<T>.Shared.Rent();
 
         /// <summary>
         /// Retrieves a stored object of type <see cref="List{T}"/>, or creates it if it does not exist. The capacity of the list will be equal to or greater than <paramref name="capacity"/>.
@@ -40,15 +34,7 @@ namespace Exiled.API.Features.Pools
         /// <param name="capacity">The capacity of content in the <see cref="List{T}"/>.</param>
         /// <returns>The stored object, or a new object, of type <see cref="List{T}"/>.</returns>
         public List<T> Get(int capacity)
-        {
-            if (pool.TryDequeue(out List<T> list))
-            {
-                list.EnsureCapacity(capacity);
-                return list;
-            }
-
-            return new(capacity);
-        }
+            => BasePools.ListPool<T>.Shared.Rent(capacity);
 
         /// <summary>
         /// Retrieves a stored object of type <see cref="List{T}"/>, or creates it if it does not exist. The list will be filled with all the provided <paramref name="items"/>.
@@ -56,22 +42,11 @@ namespace Exiled.API.Features.Pools
         /// <param name="items">The items to fill the list with.</param>
         /// <returns>The stored object, or a new object, of type <see cref="List{T}"/>.</returns>
         public List<T> Get(IEnumerable<T> items)
-        {
-            if (pool.TryDequeue(out List<T> list))
-            {
-                list.AddRange(items);
-                return list;
-            }
-
-            return new(items);
-        }
+            => BasePools.ListPool<T>.Shared.Rent(items);
 
         /// <inheritdoc/>
         public void Return(List<T> obj)
-        {
-            obj.Clear();
-            pool.Enqueue(obj);
-        }
+            => BasePools.ListPool<T>.Shared.Return(obj);
 
         /// <summary>
         /// Returns the <see cref="List{T}"/> to the pool and returns its contents as an array.

--- a/Exiled.API/Features/Pools/StringBuilderPool.cs
+++ b/Exiled.API/Features/Pools/StringBuilderPool.cs
@@ -22,20 +22,17 @@ namespace Exiled.API.Features.Pools
         public static StringBuilderPool Pool { get; } = new();
 
         /// <inheritdoc/>
-        public StringBuilder Get()
-            => BasePools.StringBuilderPool.Shared.Rent();
+        public StringBuilder Get() => BasePools.StringBuilderPool.Shared.Rent();
 
         /// <summary>
         /// Retrieves a stored object of type <see cref="StringBuilder"/>, or creates it if it does not exist. The capacity of the StringBuilder will be equal to or greater than <paramref name="capacity"/>.
         /// </summary>
         /// <param name="capacity">The capacity of content in the <see cref="StringBuilder"/>.</param>
         /// <returns>The stored object, or a new object, of type <see cref="StringBuilder"/>.</returns>
-        public StringBuilder Get(int capacity)
-            => BasePools.StringBuilderPool.Shared.Rent(capacity);
+        public StringBuilder Get(int capacity) => BasePools.StringBuilderPool.Shared.Rent(capacity);
 
         /// <inheritdoc/>
-        public void Return(StringBuilder obj)
-            => BasePools.StringBuilderPool.Shared.Return(obj);
+        public void Return(StringBuilder obj) => BasePools.StringBuilderPool.Shared.Return(obj);
 
         /// <summary>
         /// Returns the contents of the <see cref="StringBuilder"/> and returns it to the pool.

--- a/Exiled.API/Features/Pools/StringBuilderPool.cs
+++ b/Exiled.API/Features/Pools/StringBuilderPool.cs
@@ -7,16 +7,15 @@
 
 namespace Exiled.API.Features.Pools
 {
-    using System.Collections.Concurrent;
     using System.Text;
+
+    using BasePools = NorthwoodLib.Pools;
 
     /// <summary>
     /// Defines a system used to store and retrieve <see cref="StringBuilder"/> objects.
     /// </summary>
     public class StringBuilderPool : IPool<StringBuilder>
     {
-        private readonly ConcurrentQueue<StringBuilder> pool = new();
-
         /// <summary>
         /// Gets a <see cref="StringBuilderPool"/> that stores <see cref="StringBuilder"/>.
         /// </summary>
@@ -24,12 +23,7 @@ namespace Exiled.API.Features.Pools
 
         /// <inheritdoc/>
         public StringBuilder Get()
-        {
-            if (pool.TryDequeue(out StringBuilder sb))
-                return sb;
-
-            return new();
-        }
+            => BasePools.StringBuilderPool.Shared.Rent();
 
         /// <summary>
         /// Retrieves a stored object of type <see cref="StringBuilder"/>, or creates it if it does not exist. The capacity of the StringBuilder will be equal to or greater than <paramref name="capacity"/>.
@@ -37,22 +31,11 @@ namespace Exiled.API.Features.Pools
         /// <param name="capacity">The capacity of content in the <see cref="StringBuilder"/>.</param>
         /// <returns>The stored object, or a new object, of type <see cref="StringBuilder"/>.</returns>
         public StringBuilder Get(int capacity)
-        {
-            if (pool.TryDequeue(out StringBuilder sb))
-            {
-                sb.EnsureCapacity(capacity);
-                return sb;
-            }
-
-            return new(capacity);
-        }
+            => BasePools.StringBuilderPool.Shared.Rent(capacity);
 
         /// <inheritdoc/>
         public void Return(StringBuilder obj)
-        {
-            obj.Clear();
-            pool.Enqueue(obj);
-        }
+            => BasePools.StringBuilderPool.Shared.Return(obj);
 
         /// <summary>
         /// Returns the contents of the <see cref="StringBuilder"/> and returns it to the pool.


### PR DESCRIPTION
Convert pools to use basegame pools under the hood. Keep all of our API while using northwood pools so that there's only one pool internally.