### PR TITLE
Less spam

### DIFF
--- a/Exiled.CustomRoles/API/Features/Parsers/AggregateExpectationTypeResolver.cs
+++ b/Exiled.CustomRoles/API/Features/Parsers/AggregateExpectationTypeResolver.cs
@@ -45,7 +45,8 @@ namespace Exiled.CustomRoles.API.Features.Parsers
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Error loading types for {assembly.FullName}\n{e}");
+                    Log.Error($"Error loading types for {assembly.FullName}. It can be ignored if it's not using Exiled.CustomRoles.");
+                    Log.Debug(e);
                 }
             }
         }


### PR DESCRIPTION
CustomRoles tends to throw ``System.Reflection.ReflectionTypeLoadException`` on certain DLLs like MySql.Data. It results in big spam on the console, and it's just annoying when it prints errors for DLLs that doesn't rely on it at all. 