### PR TITLE
WorldSpace Interfaces

### DIFF
--- a/Exiled.API/Features/Camera.cs
+++ b/Exiled.API/Features/Camera.cs
@@ -23,7 +23,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// The in-game Scp079Camera.
     /// </summary>
-    public class Camera : IWrapper<Scp079Camera>
+    public class Camera : IWrapper<Scp079Camera>, IPosition // Todo: Convert to IWorldSpace (Rotation Vector3 -> Quaternion)
     {
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="Scp079Camera"/>s and their corresponding <see cref="Camera"/>.

--- a/Exiled.API/Features/Core/EActor.cs
+++ b/Exiled.API/Features/Core/EActor.cs
@@ -13,6 +13,7 @@ namespace Exiled.API.Features.Core
 
     using Exiled.API.Features.Core.Interfaces;
     using Exiled.API.Features.Pools;
+    using Exiled.API.Interfaces;
     using MEC;
 
     using UnityEngine;
@@ -20,7 +21,7 @@ namespace Exiled.API.Features.Core
     /// <summary>
     /// Actor is the base class for a <see cref="EObject"/> that can be placed or spawned in-game.
     /// </summary>
-    public abstract class EActor : EObject, IEntity
+    public abstract class EActor : EObject, IEntity, IWorldSpace
     {
         /// <summary>
         /// The default fixed tick rate.

--- a/Exiled.API/Features/Door.cs
+++ b/Exiled.API/Features/Door.cs
@@ -28,7 +28,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// A wrapper class for <see cref="DoorVariant"/>.
     /// </summary>
-    public class Door : IWrapper<DoorVariant>
+    public class Door : IWrapper<DoorVariant>, IWorldSpace
     {
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="DoorVariant"/>s and their corresponding <see cref="Door"/>.

--- a/Exiled.API/Features/Generator.cs
+++ b/Exiled.API/Features/Generator.cs
@@ -20,7 +20,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// Wrapper class for <see cref="Scp079Generator"/>.
     /// </summary>
-    public class Generator : IWrapper<Scp079Generator>
+    public class Generator : IWrapper<Scp079Generator>, IWorldSpace
     {
         /// <summary>
         /// A <see cref="List{T}"/> of <see cref="Generator"/> on the map.

--- a/Exiled.API/Features/Lift.cs
+++ b/Exiled.API/Features/Lift.cs
@@ -26,7 +26,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// The in-game lift.
     /// </summary>
-    public class Lift : IWrapper<ElevatorChamber>
+    public class Lift : IWrapper<ElevatorChamber>, IWorldSpace
     {
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="ElevatorChamber"/>s and their corresponding <see cref="Lift"/>.

--- a/Exiled.API/Features/Pickups/AmmoPickup.cs
+++ b/Exiled.API/Features/Pickups/AmmoPickup.cs
@@ -16,7 +16,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for an Ammo pickup.
     /// </summary>
-    public class AmmoPickup : Pickup, IWrapper<BaseAmmo>
+    public class AmmoPickup : Pickup, IWrapper<BaseAmmo>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AmmoPickup"/> class.

--- a/Exiled.API/Features/Pickups/BodyArmorPickup.cs
+++ b/Exiled.API/Features/Pickups/BodyArmorPickup.cs
@@ -14,7 +14,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for a Body Armor pickup.
     /// </summary>
-    public class BodyArmorPickup : Pickup, IWrapper<BaseBodyArmor>
+    public class BodyArmorPickup : Pickup, IWrapper<BaseBodyArmor>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BodyArmorPickup"/> class.

--- a/Exiled.API/Features/Pickups/FirearmPickup.cs
+++ b/Exiled.API/Features/Pickups/FirearmPickup.cs
@@ -16,7 +16,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for a Firearm pickup.
     /// </summary>
-    public class FirearmPickup : Pickup, IWrapper<BaseFirearm>
+    public class FirearmPickup : Pickup, IWrapper<BaseFirearm>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FirearmPickup"/> class.

--- a/Exiled.API/Features/Pickups/GrenadePickup.cs
+++ b/Exiled.API/Features/Pickups/GrenadePickup.cs
@@ -16,7 +16,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for a grenade pickup.
     /// </summary>
-    public class GrenadePickup : Pickup, IWrapper<TimedGrenadePickup>
+    public class GrenadePickup : Pickup, IWrapper<TimedGrenadePickup>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrenadePickup"/> class.

--- a/Exiled.API/Features/Pickups/JailbirdPickup.cs
+++ b/Exiled.API/Features/Pickups/JailbirdPickup.cs
@@ -17,7 +17,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for a jailbird pickup.
     /// </summary>
-    public class JailbirdPickup : Pickup, IWrapper<BaseJailbirdPickup>
+    public class JailbirdPickup : Pickup, IWrapper<BaseJailbirdPickup>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JailbirdPickup"/> class.

--- a/Exiled.API/Features/Pickups/KeycardPickup.cs
+++ b/Exiled.API/Features/Pickups/KeycardPickup.cs
@@ -14,7 +14,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for a Keycard pickup.
     /// </summary>
-    public class KeycardPickup : Pickup, IWrapper<BaseKeycard>
+    public class KeycardPickup : Pickup, IWrapper<BaseKeycard>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="KeycardPickup"/> class.

--- a/Exiled.API/Features/Pickups/MicroHIDPickup.cs
+++ b/Exiled.API/Features/Pickups/MicroHIDPickup.cs
@@ -14,7 +14,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for a MicroHID pickup.
     /// </summary>
-    public class MicroHIDPickup : Pickup, IWrapper<BaseMicroHID>
+    public class MicroHIDPickup : Pickup, IWrapper<BaseMicroHID>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MicroHIDPickup"/> class.

--- a/Exiled.API/Features/Pickups/Pickup.cs
+++ b/Exiled.API/Features/Pickups/Pickup.cs
@@ -38,7 +38,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for <see cref="ItemPickupBase"/>.
     /// </summary>
-    public class Pickup : TypeCastObject<Pickup>, IWrapper<ItemPickupBase>
+    public class Pickup : TypeCastObject<Pickup>, IWrapper<ItemPickupBase>, IWorldSpace
     {
         /// <summary>
         /// A dictionary of all <see cref="ItemBase"/>'s that have been converted into <see cref="Items.Item"/>.

--- a/Exiled.API/Features/Pickups/Projectiles/EffectGrenadeProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/EffectGrenadeProjectile.cs
@@ -14,7 +14,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
     /// <summary>
     /// A wrapper class for EffectGrenade.
     /// </summary>
-    public class EffectGrenadeProjectile : TimeGrenadeProjectile, IWrapper<EffectGrenade>
+    public class EffectGrenadeProjectile : TimeGrenadeProjectile, IWrapper<EffectGrenade>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EffectGrenadeProjectile"/> class.

--- a/Exiled.API/Features/Pickups/Projectiles/ExplosionGrenadeProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/ExplosionGrenadeProjectile.cs
@@ -19,7 +19,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
     /// <summary>
     /// A wrapper class for ExplosionGrenade.
     /// </summary>
-    public class ExplosionGrenadeProjectile : EffectGrenadeProjectile, IWrapper<ExplosionGrenade>
+    public class ExplosionGrenadeProjectile : EffectGrenadeProjectile, IWrapper<ExplosionGrenade>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ExplosionGrenadeProjectile"/> class.

--- a/Exiled.API/Features/Pickups/Projectiles/FlashbangProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/FlashbangProjectile.cs
@@ -15,7 +15,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
     /// <summary>
     /// A wrapper class for FlashbangGrenade.
     /// </summary>
-    public class FlashbangProjectile : EffectGrenadeProjectile, IWrapper<FlashbangGrenade>
+    public class FlashbangProjectile : EffectGrenadeProjectile, IWrapper<FlashbangGrenade>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FlashbangProjectile"/> class.

--- a/Exiled.API/Features/Pickups/Projectiles/Projectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/Projectile.cs
@@ -18,7 +18,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
     /// <summary>
     /// A wrapper class for Projectile.
     /// </summary>
-    public class Projectile : Pickup, IWrapper<ThrownProjectile>
+    public class Projectile : Pickup, IWrapper<ThrownProjectile>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Projectile"/> class.

--- a/Exiled.API/Features/Pickups/Projectiles/Scp018Projectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/Scp018Projectile.cs
@@ -16,7 +16,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
     /// <summary>
     /// A wrapper class for Scp018Projectile.
     /// </summary>
-    public class Scp018Projectile : ExplosionGrenadeProjectile, IWrapper<BaseScp018Projectile>
+    public class Scp018Projectile : ExplosionGrenadeProjectile, IWrapper<BaseScp018Projectile>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp018Projectile"/> class.

--- a/Exiled.API/Features/Pickups/Projectiles/Scp2176Projectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/Scp2176Projectile.cs
@@ -16,7 +16,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
     /// <summary>
     /// A wrapper class for an SCP-2176 Projectile.
     /// </summary>
-    public class Scp2176Projectile : EffectGrenadeProjectile, IWrapper<BaseScp2176Projectile>
+    public class Scp2176Projectile : EffectGrenadeProjectile, IWrapper<BaseScp2176Projectile>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp2176Projectile"/> class.

--- a/Exiled.API/Features/Pickups/Projectiles/TimeGrenadeProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/TimeGrenadeProjectile.cs
@@ -17,7 +17,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
     /// <summary>
     /// A wrapper class for TimeGrenade.
     /// </summary>
-    public class TimeGrenadeProjectile : Projectile, IWrapper<TimeGrenade>
+    public class TimeGrenadeProjectile : Projectile, IWrapper<TimeGrenade>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeGrenadeProjectile"/> class.

--- a/Exiled.API/Features/Pickups/RadioPickup.cs
+++ b/Exiled.API/Features/Pickups/RadioPickup.cs
@@ -15,7 +15,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for a Radio pickup.
     /// </summary>
-    public class RadioPickup : Pickup, IWrapper<BaseRadio>
+    public class RadioPickup : Pickup, IWrapper<BaseRadio>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RadioPickup"/> class.

--- a/Exiled.API/Features/Pickups/Scp1576Pickup.cs
+++ b/Exiled.API/Features/Pickups/Scp1576Pickup.cs
@@ -14,7 +14,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for dropped SCP-330 bags.
     /// </summary>
-    public class Scp1576Pickup : Pickup, IWrapper<BaseScp1576>
+    public class Scp1576Pickup : Pickup, IWrapper<BaseScp1576>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp1576Pickup"/> class.

--- a/Exiled.API/Features/Pickups/Scp244Pickup.cs
+++ b/Exiled.API/Features/Pickups/Scp244Pickup.cs
@@ -19,7 +19,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for a SCP-244 pickup.
     /// </summary>
-    public class Scp244Pickup : Pickup, IWrapper<Scp244DeployablePickup>
+    public class Scp244Pickup : Pickup, IWrapper<Scp244DeployablePickup>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp244Pickup"/> class.

--- a/Exiled.API/Features/Pickups/Scp330Pickup.cs
+++ b/Exiled.API/Features/Pickups/Scp330Pickup.cs
@@ -18,7 +18,7 @@ namespace Exiled.API.Features.Pickups
     /// <summary>
     /// A wrapper class for dropped SCP-330 bags.
     /// </summary>
-    public class Scp330Pickup : Pickup, IWrapper<BaseScp330>
+    public class Scp330Pickup : Pickup, IWrapper<BaseScp330>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Scp330Pickup"/> class.

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -2888,11 +2888,15 @@ namespace Exiled.API.Features
         {
             switch (obj)
             {
-                case Camera camera:
-                    Teleport(camera.Position + Vector3.down);
+                case TeslaGate teslaGate:
+                    Teleport(
+                        teslaGate.Position + Vector3.up +
+                        (teslaGate.Room.Transform.rotation == new Quaternion(0f, 0f, 0f, 1f)
+                            ? new Vector3(3, 0, 0)
+                            : new Vector3(0, 0, 3)));
                     break;
-                case Door door:
-                    Teleport(door.Position + Vector3.up);
+                case IWorldSpace worldspaceObject:
+                    Teleport(worldspaceObject.Position + Vector3.up);
                     break;
                 case DoorType doorType:
                     Teleport(Door.Get(doorType).Position + Vector3.up);
@@ -2912,16 +2916,6 @@ namespace Exiled.API.Features
                 case ElevatorType elevatorType:
                     Teleport(Lift.Get(elevatorType).Position + Vector3.up);
                     break;
-                case Room room:
-                    Teleport(room.Position + Vector3.up);
-                    break;
-                case TeslaGate teslaGate:
-                    Teleport(
-                        teslaGate.Position + Vector3.up +
-                        (teslaGate.Room.Transform.rotation == new Quaternion(0f, 0f, 0f, 1f)
-                            ? new Vector3(3, 0, 0)
-                            : new Vector3(0, 0, 3)));
-                    break;
                 case Scp914Controller scp914:
                     Teleport(scp914._knobTransform.position + Vector3.up);
                     break;
@@ -2934,32 +2928,14 @@ namespace Exiled.API.Features
                     else
                         Log.Warn($"{nameof(Teleport)}: {Assembly.GetCallingAssembly().GetName().Name}: Invalid role teleport (role is missing Owner).");
                     break;
-                case Pickup pickup:
-                    Teleport(pickup.Position + Vector3.up);
-                    break;
-                case Ragdoll ragdoll:
-                    Teleport(ragdoll.Position + Vector3.up);
-                    break;
                 case Locker locker:
                     Teleport(locker.transform.position + Vector3.up);
                     break;
                 case LockerChamber chamber:
                     Teleport(chamber._spawnpoint.position + Vector3.up);
                     break;
-                case Generator generator:
-                    Teleport(generator.Position + Vector3.up);
-                    break;
-                case Window window:
-                    Teleport(window.Position + Vector3.up);
-                    break;
-                case Toys.AdminToy toy:
-                    Teleport(toy.Position + Vector3.up);
-                    break;
                 case ElevatorChamber elevator:
                     Teleport(elevator.transform.position + Vector3.up);
-                    break;
-                case EActor ea:
-                    Teleport(ea.Position + Vector3.up);
                     break;
                 case Item item:
                     if (item.Owner is not null)

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -26,6 +26,7 @@ namespace Exiled.API.Features
     using Exiled.API.Features.Pickups;
     using Exiled.API.Features.Pools;
     using Exiled.API.Features.Roles;
+    using Exiled.API.Interfaces;
     using Exiled.API.Structs;
 
     using Extensions;
@@ -91,7 +92,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// Represents the in-game player, by encapsulating a <see cref="global::ReferenceHub"/>.
     /// </summary>
-    public class Player : IEntity
+    public class Player : IEntity, IPosition // Todo: Convert to IWorldSpace (Rotation Vector3 -> Quaternion)
     {
 #pragma warning disable SA1401
         /// <summary>

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -2895,17 +2895,14 @@ namespace Exiled.API.Features
                             ? new Vector3(3, 0, 0)
                             : new Vector3(0, 0, 3)));
                     break;
-                case IWorldSpace worldspaceObject:
-                    Teleport(worldspaceObject.Position + Vector3.up);
+                case IPosition positionObject:
+                    Teleport(positionObject.Position + Vector3.up);
                     break;
                 case DoorType doorType:
                     Teleport(Door.Get(doorType).Position + Vector3.up);
                     break;
                 case SpawnLocationType sp:
                     Teleport(sp.GetPosition());
-                    break;
-                case Spawn.SpawnPoint sp:
-                    Teleport(sp.Position);
                     break;
                 case RoomType roomType:
                     Teleport(Room.Get(roomType).Position + Vector3.up);
@@ -2918,9 +2915,6 @@ namespace Exiled.API.Features
                     break;
                 case Scp914Controller scp914:
                     Teleport(scp914._knobTransform.position + Vector3.up);
-                    break;
-                case Player player:
-                    Teleport(player.Position);
                     break;
                 case Role role:
                     if (role.Owner is not null)

--- a/Exiled.API/Features/Ragdoll.cs
+++ b/Exiled.API/Features/Ragdoll.cs
@@ -33,7 +33,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// A set of tools to handle the ragdolls more easily.
     /// </summary>
-    public class Ragdoll : IWrapper<BasicRagdoll>
+    public class Ragdoll : IWrapper<BasicRagdoll>, IWorldSpace
     {
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="BasicRagdoll"/>s and their corresponding <see cref="Ragdoll"/>.

--- a/Exiled.API/Features/Room.cs
+++ b/Exiled.API/Features/Room.cs
@@ -15,7 +15,7 @@ namespace Exiled.API.Features
 
     using Exiled.API.Extensions;
     using Exiled.API.Features.Pickups;
-
+    using Exiled.API.Interfaces;
     using Interactables.Interobjects.DoorUtils;
 
     using MapGeneration;
@@ -31,7 +31,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// The in-game room.
     /// </summary>
-    public class Room : MonoBehaviour
+    public class Room : MonoBehaviour, IWorldSpace
     {
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="RoomIdentifier"/>s and their corresponding <see cref="Room"/>.
@@ -62,6 +62,11 @@ namespace Exiled.API.Features
         /// Gets the <see cref="Room"/> position.
         /// </summary>
         public Vector3 Position => transform.position;
+
+        /// <summary>
+        /// Gets the <see cref="Room"/> rotation.
+        /// </summary>
+        public Quaternion Rotation => transform.rotation;
 
         /// <summary>
         /// Gets the <see cref="ZoneType"/> in which the room is located.

--- a/Exiled.API/Features/Spawn/SpawnLocation.cs
+++ b/Exiled.API/Features/Spawn/SpawnLocation.cs
@@ -7,6 +7,7 @@
 
 namespace Exiled.API.Features.Spawn
 {
+    using Exiled.API.Interfaces;
     using PlayerRoles;
 
     using UnityEngine;
@@ -14,7 +15,7 @@ namespace Exiled.API.Features.Spawn
     /// <summary>
     /// Represents a spawn location for a <see cref="Roles.Role"/>.
     /// </summary>
-    public class SpawnLocation
+    public class SpawnLocation : IPosition
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpawnLocation"/> class.

--- a/Exiled.API/Features/Spawn/SpawnPoint.cs
+++ b/Exiled.API/Features/Spawn/SpawnPoint.cs
@@ -7,12 +7,13 @@
 
 namespace Exiled.API.Features.Spawn
 {
+    using Exiled.API.Interfaces;
     using UnityEngine;
 
     /// <summary>
     /// Defines item spawn properties.
     /// </summary>
-    public abstract class SpawnPoint
+    public abstract class SpawnPoint : IPosition
     {
         /// <summary>
         /// Gets or sets this spawn point name.

--- a/Exiled.API/Features/TeslaGate.cs
+++ b/Exiled.API/Features/TeslaGate.cs
@@ -26,7 +26,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// The in-game tesla gate.
     /// </summary>
-    public class TeslaGate : IWrapper<BaseTeslaGate>
+    public class TeslaGate : IWrapper<BaseTeslaGate>, IWorldSpace
     {
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="BaseTeslaGate"/>s and their corresponding <see cref="TeslaGate"/>.

--- a/Exiled.API/Features/Toys/AdminToy.cs
+++ b/Exiled.API/Features/Toys/AdminToy.cs
@@ -12,7 +12,7 @@ namespace Exiled.API.Features.Toys
     using AdminToys;
 
     using Enums;
-
+    using Exiled.API.Interfaces;
     using Mirror;
 
     using UnityEngine;
@@ -20,7 +20,7 @@ namespace Exiled.API.Features.Toys
     /// <summary>
     /// A wrapper class for <see cref="AdminToys.AdminToyBase"/>.
     /// </summary>
-    public abstract class AdminToy
+    public abstract class AdminToy : IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdminToy"/> class.

--- a/Exiled.API/Features/Toys/Light.cs
+++ b/Exiled.API/Features/Toys/Light.cs
@@ -19,7 +19,7 @@ namespace Exiled.API.Features.Toys
     /// <summary>
     /// A wrapper class for <see cref="LightSourceToy"/>.
     /// </summary>
-    public class Light : AdminToy, IWrapper<LightSourceToy>
+    public class Light : AdminToy, IWrapper<LightSourceToy>, IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Light"/> class.

--- a/Exiled.API/Features/Toys/Primitive.cs
+++ b/Exiled.API/Features/Toys/Primitive.cs
@@ -22,7 +22,7 @@ namespace Exiled.API.Features.Toys
     /// <summary>
     /// A wrapper class for <see cref="PrimitiveObjectToy"/>.
     /// </summary>
-    public class Primitive : AdminToy, IWrapper<PrimitiveObjectToy>
+    public class Primitive : AdminToy, IWrapper<PrimitiveObjectToy>, IWorldSpace
     {
         private bool collidable = true;
 

--- a/Exiled.API/Features/Toys/ShootingTargetToy.cs
+++ b/Exiled.API/Features/Toys/ShootingTargetToy.cs
@@ -26,7 +26,7 @@ namespace Exiled.API.Features.Toys
     /// <summary>
     /// A wrapper class for <see cref="ShootingTarget"/>.
     /// </summary>
-    public class ShootingTargetToy : AdminToy, IWrapper<ShootingTarget>
+    public class ShootingTargetToy : AdminToy, IWrapper<ShootingTarget>, IWorldSpace
     {
         private static readonly Dictionary<string, ShootingTargetType> TypeLookup = new()
         {

--- a/Exiled.API/Features/Window.cs
+++ b/Exiled.API/Features/Window.cs
@@ -19,7 +19,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// A wrapper class for <see cref="BreakableWindow"/>.
     /// </summary>
-    public class Window : IWrapper<BreakableWindow>
+    public class Window : IWrapper<BreakableWindow>, IWorldSpace
     {
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="BreakableWindow"/>s and their corresponding <see cref="Window"/>.

--- a/Exiled.API/Interfaces/IPosition.cs
+++ b/Exiled.API/Interfaces/IPosition.cs
@@ -1,0 +1,22 @@
+// -----------------------------------------------------------------------
+// <copyright file="IPosition.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Interfaces
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// Represents an object with a <see cref="Vector3"/> position.
+    /// </summary>
+    public interface IPosition
+    {
+        /// <summary>
+        /// Gets the position of this object.
+        /// </summary>
+        public Vector3 Position { get; }
+    }
+}

--- a/Exiled.API/Interfaces/IRotation.cs
+++ b/Exiled.API/Interfaces/IRotation.cs
@@ -1,0 +1,22 @@
+// -----------------------------------------------------------------------
+// <copyright file="IRotation.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Interfaces
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// Represents an object with a <see cref="Quaternion"/> rotation.
+    /// </summary>
+    public interface IRotation
+    {
+        /// <summary>
+        /// Gets the rotation of this object.
+        /// </summary>
+        public Quaternion Rotation { get; }
+    }
+}

--- a/Exiled.API/Interfaces/IWorldSpace.cs
+++ b/Exiled.API/Interfaces/IWorldSpace.cs
@@ -1,0 +1,18 @@
+// -----------------------------------------------------------------------
+// <copyright file="IWorldSpace.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Interfaces
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// Represents an object with a <see cref="Vector3"/> position and a <see cref="Quaternion"/> rotation.
+    /// </summary>
+    public interface IWorldSpace : IPosition, IRotation
+    {
+    }
+}


### PR DESCRIPTION
Introduces three new interfaces: `IPosition`, `IRotation`, and `IWorldSpace`. The first two interfaces are exactly as they sound: They define either a Vector3 position or a Quaternion rotation. The third is a combination of the two, representing a 3D-space object that has a position and a rotation. I added these interfaces to every class we have that is able to inherit them, without any breaking changes. This way, we can shorten methods like `Player.Teleport(object)` from using every single object to using an interface.