### PR TITLE
Temporarily disable dict pool

### DIFF
--- a/Exiled.API/Features/Pools/DictionaryPool.cs
+++ b/Exiled.API/Features/Pools/DictionaryPool.cs
@@ -33,8 +33,8 @@ namespace Exiled.API.Features.Pools
         /// <returns>The <see cref="Dictionary{TKey, TValue}"/>.</returns>
         public Dictionary<TKey, TValue> Get()
         {
-            if (pool.TryDequeue(out Dictionary<TKey, TValue> result))
-                return result;
+            /*if (pool.TryDequeue(out Dictionary<TKey, TValue> result))
+                return result;*/
 
             return new();
         }
@@ -46,8 +46,8 @@ namespace Exiled.API.Features.Pools
         /// <returns>The <see cref="Dictionary{TKey, TValue}"/>.</returns>
         public Dictionary<TKey, TValue> Get(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
         {
-            if (!pool.TryDequeue(out Dictionary<TKey, TValue> dict))
-                dict = new();
+            // if (!pool.TryDequeue(out Dictionary<TKey, TValue> dict))
+            Dictionary<TKey, TValue> dict = new();
 
             foreach (KeyValuePair<TKey, TValue> pair in pairs)
                 dict.Add(pair.Key, pair.Value);
@@ -61,8 +61,8 @@ namespace Exiled.API.Features.Pools
         /// <param name="obj">The <see cref="Dictionary{TKey, TValue}"/> to return.</param>
         public void Return(Dictionary<TKey, TValue> obj)
         {
-            obj.Clear();
-            pool.Enqueue(obj);
+            // obj.Clear();
+            // pool.Enqueue(obj);
         }
 
         /// <summary>


### PR DESCRIPTION
I believe the returned dictionary may always be the same, resulting in some broken cases with players. If someone wants to fix I'd be more than happy to add that, I just don't know how to fix atm :)