### PR TITLE
Fix Spamming Ability

### DIFF
--- a/Exiled.Events/Patches/Events/Scp049/SendingCall.cs
+++ b/Exiled.Events/Patches/Events/Scp049/SendingCall.cs
@@ -59,10 +59,10 @@ namespace Exiled.Events.Patches.Events.Scp049
             Player player = Player.Get(callAbility.Owner);
             float duration = Scp049CallAbility.EffectDuration;
 
-            var ev = new SendingCallEventArgs(player, duration);
+            var ev = new SendingCallEventArgs(player, duration, callAbility._serverTriggered || !callAbility.Cooldown.IsReady);
             Handlers.Scp049.OnSendingCall(ev);
 
-            if (!ev.IsAllowed || callAbility._serverTriggered || !callAbility.Cooldown.IsReady)
+            if (!ev.IsAllowed)
                 return;
             callAbility.Duration.Trigger(ev.Duration);
             callAbility._serverTriggered = true;

--- a/Exiled.Events/Patches/Events/Scp049/SendingCall.cs
+++ b/Exiled.Events/Patches/Events/Scp049/SendingCall.cs
@@ -62,7 +62,7 @@ namespace Exiled.Events.Patches.Events.Scp049
             var ev = new SendingCallEventArgs(player, duration);
             Handlers.Scp049.OnSendingCall(ev);
 
-            if (!ev.IsAllowed)
+            if (!ev.IsAllowed || callAbility._serverTriggered || !callAbility.Cooldown.IsReady)
                 return;
             callAbility.Duration.Trigger(ev.Duration);
             callAbility._serverTriggered = true;


### PR DESCRIPTION
Someone found a issue with the Call event args (049) that can be spammed to give zombies infinite shield lmao