### PR TITLE
CustomItems and CustomRoles fix

### DIFF
--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -808,6 +808,8 @@ namespace Exiled.CustomItems.API.Features
             typeLookupTable.Add(GetType(), this);
             stringLookupTable.Add(Name, this);
             idLookupTable.Add(Id, this);
+            
+            SubscribeEvents();
         }
 
         /// <summary>

--- a/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -43,7 +43,7 @@ namespace Exiled.CustomRoles.API.Features
 
         private static Dictionary<string, CustomRole?> stringLookupTable = new();
 
-        private static Dictionary<int, CustomRole?> idLookupTable = new();
+        private static Dictionary<uint, CustomRole?> idLookupTable = new();
 
         /// <summary>
         /// Gets a list of all registered custom roles.
@@ -171,12 +171,16 @@ namespace Exiled.CustomRoles.API.Features
         /// </summary>
         /// <param name="id">The ID of the role to get.</param>
         /// <returns>The role, or <see langword="null"/> if it doesn't exist.</returns>
+        [Obsolete("Use Get(uint) instead", false)]
         public static CustomRole? Get(int id)
         {
-            if (!idLookupTable.ContainsKey(id))
-                idLookupTable.Add(id, Registered?.FirstOrDefault(r => r.Id == id));
-            return idLookupTable[id];
+            if (!idLookupTable.ContainsKey((uint)id))
+                idLookupTable.Add((uint)id, Registered?.FirstOrDefault(r => r.Id == id));
+            return idLookupTable[(uint)id];
         }
+
+        /// <inheritdoc cref="Get(int)"/>
+        public static CustomRole? Get(uint id) => Get(id);
 
         /// <summary>
         /// Gets a <see cref="CustomRole"/> by type.
@@ -208,12 +212,16 @@ namespace Exiled.CustomRoles.API.Features
         /// <param name="id">The ID of the role to get.</param>
         /// <param name="customRole">The custom role.</param>
         /// <returns>True if the role exists.</returns>
+        [Obsolete("Use TryGet(uint) instead", false)]
         public static bool TryGet(int id, out CustomRole? customRole)
         {
             customRole = Get(id);
 
             return customRole is not null;
         }
+
+        /// <inheritdoc cref="TryGet(int,out Exiled.CustomRoles.API.Features.CustomRole?)"/>
+        public static bool TryGet(uint id, out CustomRole? customRole) => TryGet(id, out customRole);
 
         /// <summary>
         /// Tries to get a <see cref="CustomRole"/> by name.
@@ -227,7 +235,7 @@ namespace Exiled.CustomRoles.API.Features
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentNullException(nameof(name));
 
-            customRole = int.TryParse(name, out int id) ? Get(id) : Get(name);
+            customRole = uint.TryParse(name, out uint id) ? Get(id) : Get(name);
 
             return customRole is not null;
         }
@@ -461,12 +469,24 @@ namespace Exiled.CustomRoles.API.Features
         /// <summary>
         /// Initializes this role manager.
         /// </summary>
-        public virtual void Init() => SubscribeEvents();
+        public virtual void Init()
+        {
+            idLookupTable.Add(Id, this);
+            typeLookupTable.Add(GetType(), this);
+            stringLookupTable.Add(Name, this);
+            SubscribeEvents();
+        }
 
         /// <summary>
         /// Destroys this role manager.
         /// </summary>
-        public virtual void Destroy() => UnsubscribeEvents();
+        public virtual void Destroy()
+        {
+            idLookupTable.Remove(Id);
+            typeLookupTable.Remove(GetType());
+            stringLookupTable.Remove(Name);
+            UnsubscribeEvents();
+        }
 
         /// <summary>
         /// Handles setup of the role, including spawn location, inventory and registering event handlers and add FF rules.
@@ -511,6 +531,12 @@ namespace Exiled.CustomRoles.API.Features
             player.Health = MaxHealth;
             player.MaxHealth = MaxHealth;
             player.Scale = Scale;
+
+            Vector3 position = GetSpawnPosition();
+            if (position != Vector3.zero)
+            {
+                player.Position = position;
+            }
 
             Log.Debug($"{Name}: Setting player info");
             player.CustomInfo = CustomInfo;


### PR DESCRIPTION
**CustomItems**:
Fixing events not being registered for custom items.
Fix for https://discord.com/channels/656673194693885975/1088086256900120679.

**CustomRoles**:
Fixing player position not changed if custom role has own spawn point.
Changed Init and Destroy methods (support of lookup tables like in CustomItems).
Changed Get and TryGet methods from int to uint (Id is uint).

Tested