### PR TITLE
Config command

### DIFF
--- a/Exiled.API/Features/Paths.cs
+++ b/Exiled.API/Features/Paths.cs
@@ -9,6 +9,7 @@ namespace Exiled.API.Features
 {
     using System;
     using System.IO;
+    using System.Linq;
 
     /// <summary>
     /// A set of useful paths.
@@ -105,7 +106,7 @@ namespace Exiled.API.Features
             Dependencies = Path.Combine(Plugins, "dependencies");
             Configs = Path.Combine(Exiled, "Configs");
             IndividualConfigs = Path.Combine(Configs, "Plugins");
-            LoaderConfig = Path.Combine(Configs, "loader.yml");
+            LoaderConfig = PluginAPI.Loader.AssemblyLoader.InstalledPlugins.FirstOrDefault(x => x.PluginName == "Exiled Loader")?.MainConfigPath;
             Config = Path.Combine(Configs, $"{Server.Port}-config.yml");
             BackupConfig = Path.Combine(Configs, $"{Server.Port}-config.yml.old");
             IndividualTranslations = Path.Combine(Configs, "Translations");

--- a/Exiled.Events/Commands/Config/Merge.cs
+++ b/Exiled.Events/Commands/Config/Merge.cs
@@ -49,7 +49,6 @@ namespace Exiled.Events.Commands.Config
             SortedDictionary<string, IConfig> configs = ConfigManager.LoadSorted(ConfigManager.Read());
             LoaderPlugin.Config.ConfigType = ConfigType.Default;
             bool haveBeenSaved = ConfigManager.Save(configs);
-            File.WriteAllText(Paths.LoaderConfig, Loader.Serializer.Serialize(LoaderPlugin.Config));
             PluginAPI.Loader.AssemblyLoader.InstalledPlugins.FirstOrDefault(x => x.PluginName == "Exiled Loader")?.SaveConfig(new LoaderPlugin(), nameof(LoaderPlugin.Config));
 
             response = $"Configs have been merged successfully! Feel free to remove the directory in the following path:\n\"{Paths.IndividualConfigs}\"";

--- a/Exiled.Events/Commands/Config/Merge.cs
+++ b/Exiled.Events/Commands/Config/Merge.cs
@@ -10,13 +10,12 @@ namespace Exiled.Events.Commands.Config
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
 
     using API.Enums;
     using API.Features;
     using API.Interfaces;
-
     using CommandSystem;
-
     using Loader;
 
     /// <summary>
@@ -51,6 +50,7 @@ namespace Exiled.Events.Commands.Config
             LoaderPlugin.Config.ConfigType = ConfigType.Default;
             bool haveBeenSaved = ConfigManager.Save(configs);
             File.WriteAllText(Paths.LoaderConfig, Loader.Serializer.Serialize(LoaderPlugin.Config));
+            PluginAPI.Loader.AssemblyLoader.InstalledPlugins.FirstOrDefault(x => x.PluginName == "Exiled Loader")?.SaveConfig(new LoaderPlugin(), nameof(LoaderPlugin.Config));
 
             response = $"Configs have been merged successfully! Feel free to remove the directory in the following path:\n\"{Paths.IndividualConfigs}\"";
             return haveBeenSaved;

--- a/Exiled.Events/Commands/Config/Split.cs
+++ b/Exiled.Events/Commands/Config/Split.cs
@@ -49,7 +49,6 @@ namespace Exiled.Events.Commands.Config
             SortedDictionary<string, IConfig> configs = ConfigManager.LoadSorted(ConfigManager.Read());
             LoaderPlugin.Config.ConfigType = ConfigType.Separated;
             bool haveBeenSaved = ConfigManager.Save(configs);
-            File.WriteAllText(Paths.LoaderConfig, Loader.Serializer.Serialize(LoaderPlugin.Config));
             PluginAPI.Loader.AssemblyLoader.InstalledPlugins.FirstOrDefault(x => x.PluginName == "Exiled Loader")?.SaveConfig(new LoaderPlugin(), nameof(LoaderPlugin.Config));
 
             response = $"Configs have been merged successfully! Feel free to remove the file in the following path:\n\"{Paths.Config}\"";

--- a/Exiled.Events/Commands/Config/Split.cs
+++ b/Exiled.Events/Commands/Config/Split.cs
@@ -10,13 +10,12 @@ namespace Exiled.Events.Commands.Config
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
 
     using API.Enums;
     using API.Features;
     using API.Interfaces;
-
     using CommandSystem;
-
     using Loader;
 
     /// <summary>
@@ -51,6 +50,7 @@ namespace Exiled.Events.Commands.Config
             LoaderPlugin.Config.ConfigType = ConfigType.Separated;
             bool haveBeenSaved = ConfigManager.Save(configs);
             File.WriteAllText(Paths.LoaderConfig, Loader.Serializer.Serialize(LoaderPlugin.Config));
+            PluginAPI.Loader.AssemblyLoader.InstalledPlugins.FirstOrDefault(x => x.PluginName == "Exiled Loader")?.SaveConfig(new LoaderPlugin(), nameof(LoaderPlugin.Config));
 
             response = $"Configs have been merged successfully! Feel free to remove the file in the following path:\n\"{Paths.Config}\"";
             return haveBeenSaved;


### PR DESCRIPTION
Now when you use `econfig` command it'll save new value into loader config in NWAPI.
Also updated Paths so now it has actual information about loader config destination.

For #1762