### PR TITLE
`Map.StartDecontamination` does not work with `disable_decontamination` true

### DIFF
--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -204,11 +204,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Starts the light containment zone decontamination process.
         /// </summary>
-        public static void StartDecontamination()
-        {
-            DecontaminationController.Singleton.FinishDecontamination();
-            DecontaminationController.Singleton.NetworkRoundStartTime = -1f;
-        }
+        public static void StartDecontamination() => DecontaminationController.Singleton.ForceDecontamination();
 
         /// <summary>
         /// Turns off all lights in the facility.


### PR DESCRIPTION
When `disable_decontamination` is true, you cant force decontamination. The fix replaces methods which ignore this.
Tested