### PR TITLE
Better ExiledLoading

### DIFF
--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -364,8 +364,16 @@ namespace Exiled.Loader
                 Thread.Sleep(5000);
             }
 
+            Log.Info($"Loading EXILED Version: {Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion}");
+
             if (dependencies?.Length > 0)
                 Dependencies.AddRange(dependencies);
+
+            Paths.Reload(LoaderPlugin.Config.ExiledDirectoryPath);
+            Directory.CreateDirectory(Paths.Exiled);
+            Directory.CreateDirectory(Paths.Configs);
+            Directory.CreateDirectory(Paths.Plugins);
+            Directory.CreateDirectory(Paths.Dependencies);
 
             LoadDependencies();
             LoadPlugins();

--- a/Exiled.Loader/LoaderPlugin.cs
+++ b/Exiled.Loader/LoaderPlugin.cs
@@ -73,7 +73,7 @@ namespace Exiled.Loader
 
                 if (!File.Exists(Path.Combine(dependenciesPath, "Exiled.API.dll")))
                 {
-                    ServerConsole.AddLog($"[Exiled.Bootstrap] Exiled.API.dll was not found, Exiled won't be loaded!", ConsoleColor.DarkRed);
+                    ServerConsole.AddLog($"[Exiled.Loader] Exiled.API.dll was not found, Exiled won't be loaded!", ConsoleColor.DarkRed);
                     return;
                 }
 
@@ -84,7 +84,7 @@ namespace Exiled.Loader
             }
             catch (Exception exception)
             {
-                ServerConsole.AddLog($"[Exiled.Bootstrap] Exiled loading error: {exception}", ConsoleColor.DarkRed);
+                ServerConsole.AddLog($"[Exiled.Loader] Exiled loading error: {exception}", ConsoleColor.DarkRed);
             }
         }
     }

--- a/Exiled.Loader/LoaderPlugin.cs
+++ b/Exiled.Loader/LoaderPlugin.cs
@@ -36,7 +36,7 @@ namespace Exiled.Loader
         {
             if (!Config.IsEnabled)
             {
-                ServerConsole.AddLog("EXILED is disabled on this server via config.", ConsoleColor.Red);
+                ServerConsole.AddLog("EXILED is disabled on this server via config.", ConsoleColor.DarkRed);
                 return;
             }
 
@@ -59,10 +59,12 @@ namespace Exiled.Loader
             {
                 ServerConsole.AddLog("[Exiled.Loader] Exiled is loading...", ConsoleColor.DarkRed);
 
-                string rootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "EXILED");
+                string rootPath = Path.Combine(Config.ExiledDirectoryPath, "EXILED");
 
                 if (Environment.CurrentDirectory.Contains("testing", StringComparison.OrdinalIgnoreCase))
-                    rootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "EXILED-Testing");
+                    rootPath = Path.Combine(Config.ExiledDirectoryPath, "EXILED-Testing");
+
+                ServerConsole.AddLog($"[Exiled.Loader] Exiled root path set to: {rootPath}", ConsoleColor.Cyan);
 
                 string dependenciesPath = Path.Combine(rootPath, "Plugins", "dependencies");
 


### PR DESCRIPTION
- why is better ?
 - because Exiled.API don't need to be In NW Dependency 
 
 
 (for testing make sure to verify than config is not reset or overwrited and if config is loaded correctly)