### PR TITLE
Reverted back to original method of finding player by int as new meth…

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1251,7 +1251,23 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="id">The player id.</param>
         /// <returns>Returns the player found or <see langword="null"/> if not found.</returns>
-        public static Player Get(int id) => ReferenceHub.HubByPlayerIds.TryGetValue(id, out ReferenceHub referenceHub) ? Get(referenceHub) : null;
+        public static Player Get(int id)
+        {
+            if (IdsCache.TryGetValue(id, out Player player) && player?.ReferenceHub is not null)
+                return player;
+
+            foreach (Player playerFound in Dictionary.Values)
+            {
+                if (playerFound.Id != id)
+                    continue;
+
+                IdsCache[id] = playerFound;
+
+                return playerFound;
+            }
+
+            return null;
+        }
 
         /// <summary>
         /// Gets the <see cref="Player"/> by identifier.


### PR DESCRIPTION
Reverted back to original method of finding player by int as new method uses basegame needs players to "Request Data" before trying to find by player ID