### PR TITLE
Sl Update

### DIFF
--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -119,7 +119,6 @@ namespace Exiled.API.Features.Items
             ItemPickupBase ipb = Object.Instantiate(Projectile.Base, position, Quaternion.identity);
 
             ipb.Info = new PickupSyncInfo(Type, Weight, ItemSerialGenerator.GenerateNext());
-            ipb.Position = Owner.Position;
 
             ExplosionGrenadeProjectile grenade = (ExplosionGrenadeProjectile)Pickup.Get(ipb);
 

--- a/Exiled.API/Features/Items/Firearm.cs
+++ b/Exiled.API/Features/Items/Firearm.cs
@@ -571,8 +571,6 @@ namespace Exiled.API.Features.Items
             ItemPickupBase ipb = Object.Instantiate(Base.PickupDropModel, position, rotation);
 
             ipb.Info = new(Type, Weight, ItemSerialGenerator.GenerateNext());
-            ipb.Position = Owner.Position;
-            ipb.Rotation = rotation;
             ipb.gameObject.transform.localScale = Scale;
 
             FirearmPickup pickup = Pickup.Get(ipb).As<FirearmPickup>();

--- a/Exiled.API/Features/Items/FlashGrenade.cs
+++ b/Exiled.API/Features/Items/FlashGrenade.cs
@@ -99,7 +99,6 @@ namespace Exiled.API.Features.Items
             ItemPickupBase ipb = Object.Instantiate(Projectile.Base, position, Quaternion.identity);
 
             ipb.Info = new PickupSyncInfo(Type, Weight, ItemSerialGenerator.GenerateNext());
-            ipb.Position = Owner.Position;
 
             FlashbangProjectile grenade = (FlashbangProjectile)Pickup.Get(ipb);
 

--- a/Exiled.API/Features/Items/Item.cs
+++ b/Exiled.API/Features/Items/Item.cs
@@ -289,8 +289,6 @@ namespace Exiled.API.Features.Items
             ItemPickupBase ipb = Object.Instantiate(Base.PickupDropModel, position, rotation);
 
             ipb.Info = new(Type, Weight, ItemSerialGenerator.GenerateNext());
-            ipb.Position = Owner.Position;
-            ipb.Rotation = rotation;
             ipb.gameObject.transform.localScale = Scale;
 
             Pickup pickup = Pickup.Get(ipb);

--- a/Exiled.API/Features/Items/Scp2176.cs
+++ b/Exiled.API/Features/Items/Scp2176.cs
@@ -70,7 +70,6 @@ namespace Exiled.API.Features.Items
             ItemPickupBase ipb = Object.Instantiate(Projectile.Base, position, Quaternion.identity);
 
             ipb.Info = new PickupSyncInfo(Type, Weight, ItemSerialGenerator.GenerateNext());
-            ipb.Position = position;
 
             Scp2176Projectile grenade = (Scp2176Projectile)Pickup.Get(ipb);
 

--- a/Exiled.API/Features/Items/Scp244.cs
+++ b/Exiled.API/Features/Items/Scp244.cs
@@ -64,8 +64,6 @@ namespace Exiled.API.Features.Items
             Scp244Pickup pickup = (Scp244Pickup)Pickup.Get(Object.Instantiate(Base.PickupDropModel, position, rotation));
 
             pickup.Info = new(Type, pickup.Weight, Serial);
-            pickup.Position = Owner.Position;
-            pickup.Rotation = rotation;
             pickup.State = Base._primed ? Scp244State.Active : Scp244State.Idle;
             pickup.Scale = Scale;
 

--- a/Exiled.API/Features/Items/Scp330.cs
+++ b/Exiled.API/Features/Items/Scp330.cs
@@ -189,7 +189,6 @@ namespace Exiled.API.Features.Items
                 ItemPickupBase ipb = Object.Instantiate(Base.PickupDropModel, Owner.Position, default);
 
                 ipb.Info = new(Type, Weight, ItemSerialGenerator.GenerateNext());
-                ipb.Position = Owner.Position;
 
                 Scp330Pickup pickup = (Scp330Pickup)Pickup.Get(ipb);
 
@@ -211,7 +210,6 @@ namespace Exiled.API.Features.Items
                 ItemPickupBase ipb = Object.Instantiate(Base.PickupDropModel, Owner.Position, default);
 
                 ipb.Info = new(Type, Weight, ItemSerialGenerator.GenerateNext());
-                ipb.Position = Owner.Position;
 
                 Scp330Pickup pickup = (Scp330Pickup)Pickup.Get(ipb);
 
@@ -240,8 +238,6 @@ namespace Exiled.API.Features.Items
             Scp330Pickup pickup = (Scp330Pickup)Pickup.Get(Object.Instantiate(Base.PickupDropModel, position, rotation));
 
             pickup.Info = new(Type, Weight, ItemSerialGenerator.GenerateNext());
-            pickup.Position = Owner.Position;
-            pickup.Rotation = rotation;
             pickup.Candies = new(Base.Candies);
             pickup.ExposedCandy = ExposedType;
             pickup.Scale = Scale;

--- a/Exiled.API/Features/Items/Usable.cs
+++ b/Exiled.API/Features/Items/Usable.cs
@@ -112,8 +112,6 @@ namespace Exiled.API.Features.Items
             Pickup pickup = Pickup.Get(Object.Instantiate(Base.PickupDropModel, position, rotation));
 
             pickup.Info = new(Type, Weight, ItemSerialGenerator.GenerateNext());
-            pickup.Position = position;
-            pickup.Rotation = rotation;
             pickup.Scale = Scale;
 
             if (spawn)

--- a/Exiled.API/Features/Pickups/Pickup.cs
+++ b/Exiled.API/Features/Pickups/Pickup.cs
@@ -228,7 +228,7 @@ namespace Exiled.API.Features.Pickups
         /// <seealso cref="CreateAndSpawn(ItemType, Vector3, Quaternion, Player)"/>
         public Vector3 Position
         {
-            get => Base.transform.position;
+            get => Base.Position;
             set => Base.Position = value;
         }
 
@@ -247,7 +247,7 @@ namespace Exiled.API.Features.Pickups
         /// <seealso cref="CreateAndSpawn(ItemType, Vector3, Quaternion, Player)"/>
         public Quaternion Rotation
         {
-            get => Base.transform.rotation;
+            get => Base.Rotation;
             set => Base.Rotation = value;
         }
 

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -565,6 +565,7 @@ namespace Exiled.Events.Handlers
         /// Called before throwing a grenade.
         /// </summary>
         /// <param name="ev">The <see cref="ThrownProjectileEventArgs"/> instance.</param>
+        // TODO: rename that to OnThrownProjectile
         public static void OnThrowingProjectile(ThrownProjectileEventArgs ev) => ThrownProjectile.InvokeSafely(ev);
 
         /// <summary>

--- a/Exiled.Events/Patches/Events/Player/ThrownProjectile.cs
+++ b/Exiled.Events/Patches/Events/Player/ThrownProjectile.cs
@@ -42,6 +42,7 @@ namespace Exiled.Events.Patches.Events.Player
 
             newInstructions.InsertRange(index, new[]
             {
+                // thrownProjectile
                 new(OpCodes.Dup),
 
                 // API.Features.Player.Get(this.Owner)
@@ -52,10 +53,10 @@ namespace Exiled.Events.Patches.Events.Player
                 // this
                 new(OpCodes.Ldarg_0),
 
-                // ThrownItemEventArgs ev = new(Player.Get(this.Owner), this, thrownProjectile);
+                // ThrownProjectile ev = new(thrownProjectile, player, this);
                 new(OpCodes.Newobj, GetDeclaredConstructors(typeof(ThrownProjectileEventArgs))[0]),
 
-                // Handlers.Player.OnThrowingItem(ev);
+                // Handlers.Player.OnThrownProjectile(ev);
                 new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnThrowingProjectile))),
             });
 

--- a/Exiled.Events/Patches/Fixes/GrenadePropertiesFix.cs
+++ b/Exiled.Events/Patches/Fixes/GrenadePropertiesFix.cs
@@ -40,7 +40,9 @@ namespace Exiled.Events.Patches.Fixes
             Label cnt = generator.DefineLabel();
 
             const int offset = 1;
-            int index = newInstructions.FindLastIndex(i => i.opcode == OpCodes.Stfld) + offset;
+            int index = newInstructions.FindLastIndex(i => i.StoresField(Field(typeof(ThrowableItem), nameof(ThrowableItem._alreadyFired)))) + offset;
+
+            newInstructions.RemoveRange(index, 12);
 
             // if (Item.Get(this) is not Throwable throwable)
             // {
@@ -67,7 +69,6 @@ namespace Exiled.Events.Patches.Fixes
                 // return;
                 new(OpCodes.Ldstr, "Item is not Throwable, should never happen"),
                 new(OpCodes.Call, Method(typeof(API.Features.Log), nameof(API.Features.Log.Error), new[] { typeof(string) })),
-                new(OpCodes.Pop),
                 new(OpCodes.Ret),
 
                 // Projectile projectile = throwable.Projectile;
@@ -78,6 +79,7 @@ namespace Exiled.Events.Patches.Fixes
                 // ThrownProjectile baseProjectile = projectile.Base;
                 new(OpCodes.Stloc_S, projectile.LocalIndex),
                 new(OpCodes.Callvirt, DeclaredPropertyGetter(typeof(Projectile), nameof(Projectile.Base))),
+                new(OpCodes.Dup),
                 new(OpCodes.Dup),
                 new(OpCodes.Dup),
                 new(OpCodes.Dup),
@@ -107,7 +109,6 @@ namespace Exiled.Events.Patches.Fixes
                 new(OpCodes.Ldloc_S, projectile.LocalIndex),
                 new(OpCodes.Ldc_I4_1),
                 new(OpCodes.Callvirt, PropertySetter(typeof(Projectile), nameof(Projectile.IsSpawned))),
-                new(OpCodes.Pop),
             });
 
             for (int z = 0; z < newInstructions.Count; z++)


### PR DESCRIPTION
- some useless position/rotation setters in item/grenades spawn methods. I'm 99% sure that it wont break anything, even basegame dont set that
- I fixed `GrenadePropertiesFix` patch. The main idea for that patch was in preventing creating new `ThrownProjectile`, and using  pre-generated one