### PR TITLE
Fix position `SpawnLocationType.Inside049Armory`

### DIFF
--- a/Exiled.API/Extensions/SpawnExtensions.cs
+++ b/Exiled.API/Extensions/SpawnExtensions.cs
@@ -35,6 +35,7 @@ namespace Exiled.API.Extensions
             SpawnLocationType.InsideGr18,
             SpawnLocationType.Inside914,
             SpawnLocationType.InsideHid,
+            SpawnLocationType.Inside049Armory,
         };
 
         /// <summary>


### PR DESCRIPTION
At the moment the position `SpawnLocationType.Inside049Armory` is outside the armory. Adding in `ReversedLocations` fixes this and the position is inside the armory.