### PR TITLE
Add offset param to teleport

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -2961,72 +2961,80 @@ namespace Exiled.API.Features
         public void Teleport(Vector3 position) => Position = position;
 
         /// <summary>
-        /// Teleports the player to the given object.
+        /// Teleports the player to the given object, with no offset.
+        /// </summary>
+        /// <param name="obj">The object to teleport to.</param>
+        public void Teleport(object obj)
+            => Teleport(obj, Vector3.zero);
+
+        /// <summary>
+        /// Teleports the player to the given object, offset by the defined offset value.
         /// </summary>
         /// <param name="obj">The object to teleport the player to.</param>
-        public void Teleport(object obj)
+        /// <param name="offset">The offset to teleport.</param>
+        public void Teleport(object obj, Vector3 offset)
         {
             switch (obj)
             {
                 case TeslaGate teslaGate:
                     Teleport(
-                        teslaGate.Position + Vector3.up +
+                        teslaGate.Position + offset + Vector3.up +
                         (teslaGate.Room.Transform.rotation == new Quaternion(0f, 0f, 0f, 1f)
                             ? new Vector3(3, 0, 0)
                             : new Vector3(0, 0, 3)));
                     break;
                 case IPosition positionObject:
-                    Teleport(positionObject.Position + Vector3.up);
+                    Teleport(positionObject.Position + Vector3.up + offset);
                     break;
                 case DoorType doorType:
-                    Teleport(Door.Get(doorType).Position + Vector3.up);
+                    Teleport(Door.Get(doorType).Position + Vector3.up + offset);
                     break;
                 case SpawnLocationType sp:
-                    Teleport(sp.GetPosition());
+                    Teleport(sp.GetPosition() + offset);
                     break;
                 case RoomType roomType:
-                    Teleport(Room.Get(roomType).Position + Vector3.up);
+                    Teleport(Room.Get(roomType).Position + Vector3.up + offset);
                     break;
                 case Enums.CameraType cameraType:
-                    Teleport(Camera.Get(cameraType).Position);
+                    Teleport(Camera.Get(cameraType).Position + offset);
                     break;
                 case ElevatorType elevatorType:
-                    Teleport(Lift.Get(elevatorType).Position + Vector3.up);
+                    Teleport(Lift.Get(elevatorType).Position + Vector3.up + offset);
                     break;
                 case Scp914Controller scp914:
-                    Teleport(scp914._knobTransform.position + Vector3.up);
+                    Teleport(scp914._knobTransform.position + Vector3.up + offset);
                     break;
                 case Role role:
                     if (role.Owner is not null)
-                        Teleport(role.Owner.Position);
+                        Teleport(role.Owner.Position + offset);
                     else
                         Log.Warn($"{nameof(Teleport)}: {Assembly.GetCallingAssembly().GetName().Name}: Invalid role teleport (role is missing Owner).");
                     break;
                 case Locker locker:
-                    Teleport(locker.transform.position + Vector3.up);
+                    Teleport(locker.transform.position + Vector3.up + offset);
                     break;
                 case LockerChamber chamber:
-                    Teleport(chamber._spawnpoint.position + Vector3.up);
+                    Teleport(chamber._spawnpoint.position + Vector3.up + offset);
                     break;
                 case ElevatorChamber elevator:
-                    Teleport(elevator.transform.position + Vector3.up);
+                    Teleport(elevator.transform.position + Vector3.up + offset);
                     break;
                 case Item item:
                     if (item.Owner is not null)
-                        Teleport(item.Owner.Position);
+                        Teleport(item.Owner.Position + offset);
                     else
                         Log.Warn($"{nameof(Teleport)}: {Assembly.GetCallingAssembly().GetName().Name}: Invalid item teleport (item is missing Owner).");
                     break;
 
                 // Unity
                 case Vector3 v3: // I wouldn't be surprised if someone calls this method with a Vector3.
-                    Teleport(v3);
+                    Teleport(v3 + offset);
                     break;
                 case Component comp:
-                    Teleport(comp.transform.position + Vector3.up);
+                    Teleport(comp.transform.position + Vector3.up + offset);
                     break;
                 case GameObject go:
-                    Teleport(go.transform.position + Vector3.up);
+                    Teleport(go.transform.position + Vector3.up + offset);
                     break;
 
                 default:


### PR DESCRIPTION
I can imagine myself wanting to use `Player.Teleport(object)`, but not, because my player does not spawn at the right offset.

Behold, a solution! New method: `Player.Teleport(object obj, Vector3 offset)`.
Problem has been solved.