### PR TITLE
No need Exiled.API in Exiled & NW api dep

### DIFF
--- a/Exiled.Loader/Exiled.Loader.csproj
+++ b/Exiled.Loader/Exiled.Loader.csproj
@@ -17,6 +17,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Costura.Fody" Version="5.7.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopVersion)" IncludeAssets="All" PrivateAssets="All" />
     </ItemGroup>
 

--- a/Exiled.Loader/FodyWeavers.xml
+++ b/Exiled.Loader/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <Costura />
+</Weavers>

--- a/Exiled.Loader/LoaderPlugin.cs
+++ b/Exiled.Loader/LoaderPlugin.cs
@@ -67,12 +67,6 @@ namespace Exiled.Loader
             Directory.CreateDirectory(Paths.Plugins);
             Directory.CreateDirectory(Paths.Dependencies);
 
-            if (!File.Exists(Path.Combine(Paths.Dependencies, "Exiled.API.dll")))
-            {
-                Log.Error($"Exiled.API.dll was not found at {Path.Combine(Paths.Dependencies, "Exiled.API.dll")}, Exiled won't be loaded!");
-                return;
-            }
-
             new Loader().Run();
         }
     }


### PR DESCRIPTION
Costura.Fody makes all dependencies embedded into a single DLL. Therefore, it "merges" Exiled.API into Exiled.Loader.