### PR TITLE
Fix Dropping ammo event

### DIFF
--- a/Exiled.Events/Patches/Events/Player/DroppingAmmo.cs
+++ b/Exiled.Events/Patches/Events/Player/DroppingAmmo.cs
@@ -45,6 +45,7 @@ namespace Exiled.Events.Patches.Events.Player
 
                     // ammoType
                     new(OpCodes.Ldarg_1),
+                    new(OpCodes.Call, Method(typeof(API.Extensions.ItemExtensions), nameof(API.Extensions.ItemExtensions.GetAmmoType))),
 
                     // amount
                     new(OpCodes.Ldarg_2),


### PR DESCRIPTION
Corrected the behavior that ``ev.AmmoType`` is actually using ItemType.