### PR TITLE
Scp018 `Item::Create` fix

### DIFF
--- a/Exiled.API/Features/Items/Item.cs
+++ b/Exiled.API/Features/Items/Item.cs
@@ -201,6 +201,7 @@ namespace Exiled.API.Features.Items
                     FlashbangGrenade => new FlashGrenade(throwable),
                     ExplosionGrenade => new ExplosiveGrenade(throwable),
                     Scp2176Projectile => new Scp2176(throwable),
+                    Scp018Projectile => new Scp018(throwable),
                     _ => new Throwable(throwable),
                 },
                 _ => new Item(itemBase),
@@ -254,7 +255,8 @@ namespace Exiled.API.Features.Items
             ItemType.Radio => new Radio(),
             ItemType.MicroHID => new MicroHid(),
             ItemType.GrenadeFlash => new FlashGrenade(owner),
-            ItemType.GrenadeHE or ItemType.SCP018 => new ExplosiveGrenade(type, owner),
+            ItemType.GrenadeHE => new ExplosiveGrenade(type, owner),
+            ItemType.SCP018 => new Scp018(type, owner),
             ItemType.GunCrossvec or ItemType.GunLogicer or ItemType.GunRevolver or ItemType.GunShotgun or ItemType.GunAK or ItemType.GunCOM15 or ItemType.GunCOM18 or ItemType.GunCom45 or ItemType.GunE11SR or ItemType.GunFSP9 or ItemType.ParticleDisruptor => new Firearm(type),
             ItemType.KeycardGuard or ItemType.KeycardJanitor or ItemType.KeycardO5 or ItemType.KeycardScientist or ItemType.KeycardChaosInsurgency or ItemType.KeycardContainmentEngineer or ItemType.KeycardFacilityManager or ItemType.KeycardResearchCoordinator or ItemType.KeycardZoneManager or ItemType.KeycardNTFCommander or ItemType.KeycardNTFLieutenant or
             ItemType.KeycardNTFOfficer => new Keycard(type),

--- a/Exiled.API/Features/Items/Scp018.cs
+++ b/Exiled.API/Features/Items/Scp018.cs
@@ -1,0 +1,125 @@
+// -----------------------------------------------------------------------
+// <copyright file="Scp018.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Features.Items
+{
+    using Enums;
+
+    using Exiled.API.Features.Pickups;
+    using Exiled.API.Features.Pickups.Projectiles;
+
+    using InventorySystem.Items;
+    using InventorySystem.Items.Pickups;
+    using InventorySystem.Items.ThrowableProjectiles;
+
+    using UnityEngine;
+
+    using BaseScp018Projectile = InventorySystem.Items.ThrowableProjectiles.Scp018Projectile;
+
+    using Object = UnityEngine.Object;
+
+    using Scp018Projectile = Pickups.Projectiles.Scp018Projectile;
+
+    /// <summary>
+    /// A wrapper class for <see cref="BaseScp018Projectile"/> item.
+    /// </summary>
+    public class Scp018 : Throwable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Scp018"/> class.
+        /// </summary>
+        /// <param name="itemBase">The base <see cref="ThrowableItem"/> class.</param>
+        public Scp018(ThrowableItem itemBase)
+            : base(itemBase)
+        {
+            Projectile = (Scp018Projectile)((Throwable)this).Projectile;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Scp018"/> class.
+        /// </summary>
+        /// <param name="type">The <see cref="ItemType"/> of the grenade.</param>
+        /// <param name="player">The owner of the grenade. Leave <see langword="null"/> for no owner.</param>
+        /// <remarks>The player parameter will always need to be defined if this grenade is custom using Exiled.CustomItems.</remarks>
+        internal Scp018(ItemType type, Player player = null)
+            : this((ThrowableItem)(player ?? Server.Host).Inventory.CreateItemInstance(new(type, 0), true))
+        {
+        }
+
+        /// <summary>
+        /// Gets a <see cref="ExplosionGrenadeProjectile"/> to change grenade properties.
+        /// </summary>
+        public new Scp018Projectile Projectile { get; }
+
+        /// <summary>
+        /// Gets or sets the time for SCP-018 not to ignore the friendly fire.
+        /// </summary>
+        public float FriendlyFireTime
+        {
+            get => Projectile.FriendlyFireTime;
+            set => Projectile.FriendlyFireTime = value;
+        }
+
+        /// <summary>
+        /// Gets or sets how long the fuse will last.
+        /// </summary>
+        public float FuseTime
+        {
+            get => Projectile.FuseTime;
+            set => Projectile.FuseTime = value;
+        }
+
+        /// <summary>
+        /// Spawns an active grenade on the map at the specified location.
+        /// </summary>
+        /// <param name="position">The location to spawn the grenade.</param>
+        /// <param name="owner">Optional: The <see cref="Player"/> owner of the grenade.</param>
+        /// <returns>Spawned <see cref="Scp018Projectile">grenade</see>.</returns>
+        public Scp018Projectile SpawnActive(Vector3 position, Player owner = null)
+        {
+#if DEBUG
+            Log.Debug($"Spawning active grenade: {FuseTime}");
+#endif
+            ItemPickupBase ipb = Object.Instantiate(Projectile.Base, position, Quaternion.identity);
+
+            ipb.Info = new PickupSyncInfo(Type, Weight, ItemSerialGenerator.GenerateNext());
+
+            Scp018Projectile grenade = (Scp018Projectile)Pickup.Get(ipb);
+
+            grenade.Base.gameObject.SetActive(true);
+
+            grenade.FriendlyFireTime = FriendlyFireTime;
+            grenade.FuseTime = FuseTime;
+
+            grenade.PreviousOwner = owner ?? Server.Host;
+
+            grenade.Spawn();
+
+            grenade.Base.ServerActivate();
+
+            return grenade;
+        }
+
+        /// <summary>
+        /// Returns the ExplosiveGrenade in a human readable format.
+        /// </summary>
+        /// <returns>A string containing ExplosiveGrenade-related data.</returns>
+        public override string ToString() => $"{Type} ({Serial}) [{Weight}] *{Scale}* |{FuseTime}|";
+
+        /// <summary>
+        /// Clones current <see cref="ExplosiveGrenade"/> object.
+        /// </summary>
+        /// <returns> New <see cref="ExplosiveGrenade"/> object. </returns>
+        public override Item Clone() => new Scp018(Type)
+        {
+            FriendlyFireTime = FriendlyFireTime,
+            FuseTime = FuseTime,
+            PinPullTime = PinPullTime,
+            Repickable = Repickable,
+        };
+    }
+}


### PR DESCRIPTION
018 is no more Explosion grenade, so that pr fixes invalid cast ex