### PR TITLE
FIX BanEvent not being trigger when the ban is done by ServerHost

### DIFF
--- a/Exiled.Events/Patches/Events/Player/Banning.cs
+++ b/Exiled.Events/Patches/Events/Player/Banning.cs
@@ -7,114 +7,112 @@
 
 namespace Exiled.Events.Patches.Events.Player
 {
-#pragma warning disable SA1313
-    using System;
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
 
     using API.Features;
-
     using CommandSystem;
-
+    using Exiled.API.Features.Pools;
     using Exiled.Events.EventArgs.Player;
-
+    using Footprinting;
     using HarmonyLib;
-    using PluginAPI.Events;
 
-    using Log = API.Features.Log;
+    using static HarmonyLib.AccessTools;
 
     /// <summary>
-    ///     Patches <see cref="BanPlayer.BanUser(ReferenceHub, ICommandSender, string, long)" />.
+    ///     Patches <see cref="BanPlayer.BanUser(Footprint, ICommandSender, string, long)" />.
     ///     Adds the <see cref="Handlers.Player.Banning" /> event.
     /// </summary>
-    [HarmonyPatch(typeof(BanPlayer), nameof(BanPlayer.BanUser), typeof(ReferenceHub), typeof(ICommandSender), typeof(string), typeof(long))]
+    [HarmonyPatch(typeof(BanPlayer), nameof(BanPlayer.BanUser), typeof(Footprint), typeof(ICommandSender), typeof(string), typeof(long))]
     internal static class Banning
     {
-        private static bool Prefix(ReferenceHub target, ICommandSender issuer, string reason, long duration, ref bool __result)
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
-            try
-            {
-                if (duration == 0L)
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
+
+            Label notEmpty = generator.DefineLabel();
+            Label empty = generator.DefineLabel();
+            Label continueLabel = generator.DefineLabel();
+
+            LocalBuilder ev = generator.DeclareLocal(typeof(BanningEventArgs));
+            LocalBuilder msg = generator.DeclareLocal(typeof(string));
+
+            int offset = 1;
+            int index = newInstructions.FindLastIndex(x => x.opcode == OpCodes.Starg_S) + offset;
+
+            newInstructions.InsertRange(
+                index,
+                new[]
                 {
-                    __result = BanPlayer.KickUser(target, issuer, reason);
-                    return false;
-                }
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(Footprint) })),
 
-                if (duration > long.MaxValue)
-                    duration = long.MaxValue;
+                    new(OpCodes.Ldarg_1),
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ICommandSender) })),
 
-                if (target.serverRoles.BypassStaff)
-                {
-                    __result = false;
-                    return false;
-                }
+                    new(OpCodes.Ldarg_3),
 
-                long issuanceTime = TimeBehaviour.CurrentTimestamp();
-                long banExpirationTime = TimeBehaviour.GetBanExpirationTime((uint)duration);
-                string originalName = BanPlayer.ValidateNick(target.nicknameSync.MyNick);
-                string message = $"You have been banned. {(!string.IsNullOrEmpty(reason) ? "Reason: " + reason : string.Empty)}";
+                    new(OpCodes.Ldarg_2),
 
-                Player issuerPlayer = Player.Get(issuer);
-                if (issuerPlayer == null)
-                {
-                    issuerPlayer = Server.Host;
-                }
+                    new(OpCodes.Ldstr, "You have been banned. "),
+                    new(OpCodes.Ldarg_2),
+                    new(OpCodes.Call, Method(typeof(string), nameof(string.IsNullOrEmpty))),
+                    new(OpCodes.Brfalse_S, notEmpty),
+                    new(OpCodes.Ldsfld, Field(typeof(string), nameof(string.Empty))),
+                    new(OpCodes.Br_S, empty),
+                    new CodeInstruction(OpCodes.Ldstr, "Reason: ").WithLabels(notEmpty),
+                    new(OpCodes.Ldarg_2),
+                    new(OpCodes.Call, Method(typeof(string), nameof(string.Concat), new[] { typeof(string), typeof(string) })),
+                    new CodeInstruction(OpCodes.Call, Method(typeof(string), nameof(string.Concat), new[] { typeof(string), typeof(string) })).WithLabels(empty),
 
-                BanningEventArgs ev = new(Player.Get(target), issuerPlayer, duration, reason, message);
+                    new(OpCodes.Ldc_I4_1),
 
-                Handlers.Player.OnBanning(ev);
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(BanningEventArgs))[0]),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Stloc_S, ev.LocalIndex),
 
-                if (!ev.IsAllowed)
-                {
-                    __result = false;
-                    return false;
-                }
+                    new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnBanning))),
 
-                duration = ev.Duration;
-                reason = ev.Reason;
-                message = ev.FullMessage;
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(BanningEventArgs), nameof(BanningEventArgs.IsAllowed))),
+                    new(OpCodes.Brtrue_S, continueLabel),
 
-                if (!EventManager.ExecuteEvent(new PlayerBannedEvent(target, ev.Player.ReferenceHub, reason, duration)))
-                {
-                    __result = false;
-                    return false;
-                }
+                    new(OpCodes.Ret),
 
-                BanPlayer.ApplyIpBan(target, issuer, reason, duration);
+                    new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex).WithLabels(continueLabel),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Dup),
 
-                BanHandler.IssueBan(
-                    new BanDetails
-                    {
-                        OriginalName = originalName,
-                        Id = target.characterClassManager.UserId,
-                        IssuanceTime = issuanceTime,
-                        Expires = banExpirationTime,
-                        Reason = reason,
-                        Issuer = issuer.LogName,
-                    }, BanHandler.BanType.UserId);
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(BanningEventArgs), nameof(BanningEventArgs.Reason))),
+                    new(OpCodes.Starg_S, 2),
 
-                if (!string.IsNullOrEmpty(target.characterClassManager.UserId2))
-                {
-                    BanHandler.IssueBan(
-                        new BanDetails
-                        {
-                            OriginalName = originalName,
-                            Id = target.characterClassManager.UserId2,
-                            IssuanceTime = issuanceTime,
-                            Expires = banExpirationTime,
-                            Reason = reason,
-                            Issuer = issuer.LogName,
-                        }, BanHandler.BanType.UserId);
-                }
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(BanningEventArgs), nameof(BanningEventArgs.Duration))),
+                    new(OpCodes.Starg_S, 3),
 
-                ServerConsole.Disconnect(target.gameObject, message);
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(BanningEventArgs), nameof(BanningEventArgs.Player))),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.Sender))),
+                    new(OpCodes.Starg_S, 1),
 
-                __result = true;
-                return false;
-            }
-            catch (Exception exception)
-            {
-                Log.Error($"Exiled.Events.Patches.Events.Player.Banning: {exception}\n{exception.StackTrace}");
-                return true;
-            }
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(BanningEventArgs), nameof(BanningEventArgs.Target))),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.Footprint))),
+                    new(OpCodes.Starg_S, 0),
+
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(BanningEventArgs), nameof(BanningEventArgs.FullMessage))),
+                    new(OpCodes.Stloc_S, msg.LocalIndex),
+                });
+
+            index = newInstructions.FindLastIndex(x => x.opcode == OpCodes.Ldstr);
+
+            newInstructions.RemoveRange(index, 3);
+
+            newInstructions.Insert(index, new(OpCodes.Ldloc_S, msg.LocalIndex));
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Pool.Return(newInstructions);
         }
     }
 }


### PR DESCRIPTION
1. Should be fixed #1962 (Cuz exiled patched method that call's another banning method. Second ban method is called by FF detector)
2. Banning event now has a transpiler
3. Tested and no issues