### PR TITLE
Fixed a NullReferenceException when loading configs

### DIFF
--- a/Exiled.Loader/Features/Configs/TypeAssigningEventEmitter.cs
+++ b/Exiled.Loader/Features/Configs/TypeAssigningEventEmitter.cs
@@ -31,7 +31,7 @@ namespace Exiled.Loader.Features.Configs
         {
             if (eventInfo.Source.StaticType != typeof(object) && Type.GetTypeCode(eventInfo.Source.StaticType) == TypeCode.String && !UnderscoredNamingConvention.Instance.Properties.Contains(eventInfo.Source.Value))
             {
-                if (eventInfo.Source.Value.ToString().IndexOfAny(multiline) is -1)
+                if (eventInfo.Source.Value == null || eventInfo.Source.Value.ToString().IndexOfAny(multiline) is -1)
                     eventInfo.Style = LoaderPlugin.Config.ScalarStyle;
                 else
                     eventInfo.Style = LoaderPlugin.Config.MultiLineScalarStyle;


### PR DESCRIPTION
As the title says.