### PR TITLE
Smart ammo limits

### DIFF
--- a/Exiled.CustomRoles/API/Features/CustomAbility.cs
+++ b/Exiled.CustomRoles/API/Features/CustomAbility.cs
@@ -60,18 +60,38 @@ namespace Exiled.CustomRoles.API.Features
         public string AbilityType { get; }
 
         /// <summary>
-        /// Gets a <see cref="CustomRole"/> by name.
+        /// Gets a <see cref="CustomAbility"/> by name.
         /// </summary>
-        /// <param name="name">The name of the role to get.</param>
-        /// <returns>The role, or <see langword="null"/> if it doesn't exist.</returns>
+        /// <param name="name">The name of the ability to get.</param>
+        /// <returns>The ability, or <see langword="null"/> if it doesn't exist.</returns>
         public static CustomAbility? Get(string name) => Registered?.FirstOrDefault(r => r.Name == name);
 
         /// <summary>
-        /// Tries to get a <see cref="CustomRole"/> by name.
+        /// Gets a <see cref="CustomAbility"/> by type.
         /// </summary>
-        /// <param name="name">The name of the role to get.</param>
-        /// <param name="customAbility">The custom role.</param>
-        /// <returns>True if the role exists.</returns>
+        /// <param name="type">The type of the ability to get.</param>
+        /// <returns>The type, or <see langword="null"/> if it doesn't exist.</returns>
+        public static CustomAbility? Get(Type type) => Registered?.FirstOrDefault(r => r.GetType() == type);
+
+        /// <summary>
+        /// Tries to get a <see cref="CustomAbility"/> by type.
+        /// </summary>
+        /// <param name="type">The type of the ability to get.</param>
+        /// <param name="customAbility">The custom ability.</param>
+        /// <returns>True if the ability exists, otherwise false.</returns>
+        public static bool TryGet(Type type, out CustomAbility? customAbility)
+        {
+            customAbility = Get(type);
+
+            return customAbility is not null;
+        }
+
+        /// <summary>
+        /// Tries to get a <see cref="CustomAbility"/> by name.
+        /// </summary>
+        /// <param name="name">The name of the ability to get.</param>
+        /// <param name="customAbility">The custom ability.</param>
+        /// <returns>True if the ability exists.</returns>
         /// <exception cref="ArgumentNullException">If the name is <see langword="null"/> or an empty string.</exception>
         public static bool TryGet(string name, out CustomAbility? customAbility)
         {

--- a/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -24,6 +24,9 @@ namespace Exiled.CustomRoles.API.Features
     using Exiled.Events.EventArgs.Player;
     using Exiled.Loader;
 
+    using InventorySystem;
+    using InventorySystem.Configs;
+
     using MEC;
 
     using PlayerRoles;
@@ -912,7 +915,7 @@ namespace Exiled.CustomRoles.API.Features
                             foreach (AmmoType type in Enum.GetValues(typeof(AmmoType)))
                             {
                                 if (type != AmmoType.None)
-                                    ev.Player.SetAmmo(type, Ammo.ContainsKey(type) ? Ammo[type] : (ushort)0);
+                                    ev.Player.SetAmmo(type, Ammo.ContainsKey(type) ? Ammo[type] == ushort.MaxValue ? InventoryLimits.GetAmmoLimit(type.GetItemType(), ev.Player.ReferenceHub) : Ammo[type] : (ushort)0);
                             }
                         });
                 }


### PR DESCRIPTION
Allow Custom Roles to easily calculate the max ammo a player can carry of a specific type, and set their ammo to that, by setting the ammo property value to ushort.MaxValue.

ushort.MaxValue - 1 can still be used to give them basically the normal 65k possible max.

Also allows for getting CustomAbilities by their type, rather than name.