### PR TITLE
ECS Improvements

### DIFF
--- a/Exiled.API/Features/Core/Generic/EnumClass.cs
+++ b/Exiled.API/Features/Core/Generic/EnumClass.cs
@@ -12,6 +12,8 @@ namespace Exiled.API.Features.Core.Generic
     using System.Linq;
     using System.Reflection;
 
+    using Exiled.API.Features.Pools;
+
     using LiteNetLib.Utils;
 
     /// <summary>
@@ -150,7 +152,7 @@ namespace Exiled.API.Features.Core.Generic
         {
             results = null;
 
-            List<TObject> tmpValues = new();
+            List<TObject> tmpValues = ListPool<TObject>.Pool.Get();
             foreach (TSource value in values)
             {
                 if (!EnumClass<TSource, TObject>.values.TryGetValue(value, out TObject result))

--- a/Exiled.API/Features/Core/Generic/EnumClass.cs
+++ b/Exiled.API/Features/Core/Generic/EnumClass.cs
@@ -1,0 +1,250 @@
+// -----------------------------------------------------------------------
+// <copyright file="EnumClass.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Features.Core.Generic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    using LiteNetLib.Utils;
+
+    /// <summary>
+    /// A class which allows <see cref="Enum"/> implicit conversions.
+    /// <para>Can be used along with <see cref="Enum"/>, means it doesn't require another <see cref="EnumClass{TSource, TObject}"/> instance to be comparable or usable.</para>
+    /// </summary>
+    /// <typeparam name="TSource">The type of the source object to handle the instance of.</typeparam>
+    /// <typeparam name="TObject">The type of the child object to handle the instance of.</typeparam>
+    public abstract class EnumClass<TSource, TObject> : IComparable, IEquatable<TObject>, IComparable<TObject>, IComparer<TObject>
+        where TSource : Enum
+        where TObject : EnumClass<TSource, TObject>
+    {
+        private static SortedList<TSource, TObject> values;
+        private static bool isDefined;
+
+        private string name;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumClass{TSource, TObject}"/> class.
+        /// </summary>
+        /// <param name="value">The value of the enum item.</param>
+        protected EnumClass(TSource value)
+        {
+            values ??= new();
+
+            Value = value;
+            values.Add(value, (TObject)this);
+        }
+
+        /// <summary>
+        /// Gets all <typeparamref name="TObject"/> object instances.
+        /// </summary>
+        public static IEnumerable<TObject> Values => values.Values;
+
+        /// <summary>
+        /// Gets the value of the enum item.
+        /// </summary>
+        public TSource Value { get; }
+
+        /// <summary>
+        /// Gets the name determined from reflection.
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                if (isDefined)
+                    return name;
+
+                IEnumerable<FieldInfo> fields = typeof(TObject)
+                    .GetFields(BindingFlags.Static | BindingFlags.GetField | BindingFlags.Public)
+                    .Where(t => t.FieldType == typeof(TObject));
+
+                foreach (FieldInfo field in fields)
+                {
+                    TObject instance = (TObject)field.GetValue(null);
+                    instance.name = field.Name;
+                }
+
+                isDefined = true;
+                return name;
+            }
+        }
+
+        /// <summary>
+        /// Implicitly converts the <see cref="EnumClass{TSource, TObject}"/> to <typeparamref name="TSource"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        public static implicit operator TSource(EnumClass<TSource, TObject> value) => value.Value;
+
+        /// <summary>
+        /// Implicitly converts the <typeparamref name="TSource"/> to <see cref="EnumClass{TSource, TObject}"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        public static implicit operator EnumClass<TSource, TObject>(TSource value) => values[value];
+
+        /// <summary>
+        /// Implicitly converts the <see cref="EnumClass{TSource, TObject}"/> to <typeparamref name="TObject"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        public static implicit operator TObject(EnumClass<TSource, TObject> value) => value;
+
+        /// <summary>
+        /// Casts the specified <paramref name="value"/> to the corresponding type.
+        /// </summary>
+        /// <param name="value">The enum value to be cast.</param>
+        /// <returns>The cast object.</returns>
+        public static TObject Cast(TSource value) => values[value];
+
+        /// <summary>
+        /// Casts the specified <paramref name="values"/> to the corresponding type.
+        /// </summary>
+        /// <param name="values">The enum values to be cast.</param>
+        /// <returns>The cast object.</returns>
+        public static IEnumerable<TObject> Cast(IEnumerable<TSource> values)
+        {
+            foreach (TSource value in values)
+                yield return EnumClass<TSource, TObject>.values[value];
+        }
+
+        /// <summary>
+        /// Retrieves an array of the values of the constants in a specified <see cref="EnumClass{TSource, TObject}"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="EnumClass{TSource, TObject}"/> type.</param>
+        /// <returns>An array of the values of the constants in a specified <see cref="EnumClass{TSource, TObject}"/>.</returns>
+        public static TSource[] GetValues(Type type)
+        {
+            if (type is null)
+                throw new NullReferenceException("The specified type parameter is null");
+
+            if (!type.IsSubclassOf(typeof(EnumClass<TSource, TObject>)) && type.BaseType != typeof(EnumClass<TSource, TObject>))
+                throw new InvalidTypeException("The specified type parameter is not a EnumClass<TSource, TObject> type.");
+
+            return typeof(TSource)
+                .GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.GetField)
+                .Where(field => field.FieldType == typeof(TSource))
+                .Select(field => (TSource)field.GetValue(null))
+                .ToArray();
+        }
+
+        /// <summary>
+        /// Safely casts the specified <paramref name="value"/> to the corresponding type.
+        /// </summary>
+        /// <param name="value">The enum value to be cast.</param>
+        /// <param name="result">The cast <paramref name="value"/>.</param>
+        /// <returns><see langword="true"/> if the <paramref name="value"/> was cast; otherwise, <see langword="false"/>.</returns>
+        public static bool SafeCast(TSource value, out TObject result) => values.TryGetValue(value, out result);
+
+        /// <summary>
+        /// Safely casts the specified <paramref name="values"/> to the corresponding type.
+        /// </summary>
+        /// <param name="values">The enum value to be cast.</param>
+        /// <param name="results">The cast <paramref name="values"/>.</param>
+        /// <returns><see langword="true"/> if the <paramref name="values"/> was cast; otherwise, <see langword="false"/>.</returns>
+        public static bool SafeCast(IEnumerable<TSource> values, out IEnumerable<TObject> results)
+        {
+            results = null;
+
+            List<TObject> tmpValues = new();
+            foreach (TSource value in values)
+            {
+                if (!EnumClass<TSource, TObject>.values.TryGetValue(value, out TObject result))
+                    return false;
+
+                tmpValues.Add(result);
+            }
+
+            results = tmpValues;
+            return true;
+        }
+
+        /// <summary>
+        /// Parses a <see cref="string"/> object.
+        /// </summary>
+        /// <param name="obj">The object to be parsed.</param>
+        /// <returns>The corresponding <typeparamref name="TObject"/> object instance, or <see langword="null"/> if not found.</returns>
+        public static TObject Parse(string obj)
+        {
+            foreach (TObject value in values.Values.Where(value => string.Compare(value.Name, obj, true) == 0))
+                return value;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumClass{TSource, TObject}"/> instance to a human-readable <see cref="string"/> representation.
+        /// </summary>
+        /// <returns>A human-readable <see cref="string"/> representation of the <see cref="EnumClass{TSource, TObject}"/> instance.</returns>
+        public override string ToString() => name;
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj">The object to compare.</param>
+        /// <returns><see langword="true"/> if the object was equal; otherwise, <see langword="false"/>.</returns>
+        public override bool Equals(object obj) =>
+            obj != null && (obj is TSource value ? Value.Equals(value) : obj is TObject derived && Value.Equals(derived.Value));
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="other">The object to compare.</param>
+        /// <returns><see langword="true"/> if the object was equal; otherwise, <see langword="false"/>.</returns>
+        public bool Equals(TObject other) => Value.Equals(other.Value);
+
+        /// <summary>
+        /// Returns a the 32-bit signed hash code of the current object instance.
+        /// </summary>
+        /// <returns>The 32-bit signed hash code of the current object instance.</returns>
+        public override int GetHashCode() => Value.GetHashCode();
+
+        /// <summary>
+        /// Compares the current instance with another object of the same type and returns
+        /// an integer that indicates whether the current instance precedes, follows, or
+        /// occurs in the same position in the sort order as the other object.
+        /// </summary>
+        /// <param name="other">An object to compare with this instance.</param>
+        /// <returns>
+        /// A value that indicates the relative order of the objects being compared.
+        /// The return value has these meanings: Value Meaning Less than zero This instance precedes other in the sort order.
+        /// Zero This instance occurs in the same position in the sort order as other.
+        /// Greater than zero This instance follows other in the sort order.
+        /// </returns>
+        public int CompareTo(TObject other) => Value.CompareTo(other.Value);
+
+        /// <summary>
+        /// Compares the current instance with another object of the same type and returns
+        /// an integer that indicates whether the current instance precedes, follows, or
+        /// occurs in the same position in the sort order as the other object.
+        /// </summary>
+        /// <param name="obj">An object to compare with this instance.</param>
+        /// <returns>
+        /// A value that indicates the relative order of the objects being compared.
+        /// The return value has these meanings: Value Meaning Less than zero This instance precedes other in the sort order.
+        /// Zero This instance occurs in the same position in the sort order as other.
+        /// Greater than zero This instance follows other in the sort order.
+        /// </returns>
+        public int CompareTo(object obj) =>
+            obj == null ? -1 : obj is TSource value ? Value.CompareTo(value) : obj is TObject derived ? Value.CompareTo(derived.Value) : -1;
+
+        /// <summary>
+        /// Compares the specified object instance with another object of the same type and returns
+        /// an integer that indicates whether the current instance precedes, follows, or
+        /// occurs in the same position in the sort order as the other object.
+        /// </summary>
+        /// <param name="x">An object to compare.</param>
+        /// <param name="y">Another object to compare.</param>
+        /// <returns>
+        /// A value that indicates the relative order of the objects being compared.
+        /// The return value has these meanings: Value Meaning Less than zero This instance precedes other in the sort order.
+        /// Zero This instance occurs in the same position in the sort order as other.
+        /// Greater than zero This instance follows other in the sort order.
+        /// </returns>
+        public int Compare(TObject x, TObject y) => x == null ? -1 : y == null ? 1 : x.Value.CompareTo(y.Value);
+    }
+}

--- a/Exiled.API/Features/Core/Generic/Singleton.cs
+++ b/Exiled.API/Features/Core/Generic/Singleton.cs
@@ -1,0 +1,89 @@
+// -----------------------------------------------------------------------
+// <copyright file="Singleton.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Features.Core.Generic
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Exiled.API.Features.Core;
+
+    /// <summary>
+    /// A class to handle object instances.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to handle the instance of.</typeparam>
+    public sealed class Singleton<T> : TypeCastObject<T>
+        where T : class
+    {
+        private static readonly Dictionary<T, Singleton<T>> Instances = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Singleton{T}"/> class.
+        /// </summary>
+        /// <param name="value">The branch to instantiate.</param>
+        public Singleton(T value)
+        {
+            Destroy(value);
+            Value = value;
+            Instances.Add(value, this);
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="Singleton{T}"/> class.
+        /// </summary>
+        ~Singleton() => Instances.Remove(Value);
+
+        /// <summary>
+        /// Gets the relative value.
+        /// </summary>
+        public static T Instance => Instances.FirstOrDefault(@object => @object.Key.GetType() == typeof(T)).Value;
+
+        /// <summary>
+        /// Gets the singleton value.
+        /// </summary>
+        internal T Value { get; private set; }
+
+        /// <summary>
+        /// Converts the given <see cref="Singleton{T}"/> instance into <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="instance">The <see cref="Singleton{T}"/> instance to convert.</param>
+        public static implicit operator T(Singleton<T> instance) => instance.Value;
+
+        /// <summary>
+        /// Tries to get the relative value.
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object.</typeparam>
+        /// <param name="instance">The object instance.</param>
+        /// <returns><see langword="true"/> if the object instance is not null and can be casted as the specified type; otherwise, <see langword="false"/>.</returns>
+        public static bool TryGet<TObject>(out TObject instance)
+            where TObject : class
+        {
+            instance = Instance as TObject;
+
+            return instance is not null;
+        }
+
+        /// <inheritdoc cref="Singleton(T)"/>
+        public static void Create(T @object) => new Singleton<T>(@object);
+
+        /// <summary>
+        /// Destroys the given <typeparamref name="T"/> instance.
+        /// </summary>
+        /// <param name="object">The object to destroy.</param>
+        /// <returns><see langword="true"/> if the instance was destroyed; otherwise, <see langword="false"/>.</returns>
+        public static bool Destroy(T @object)
+        {
+            if (Instances.TryGetValue(@object, out Singleton<T> _))
+            {
+                Instances[@object] = null;
+                Instances.Remove(@object);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Exiled.API/Features/Core/Generic/Singleton.cs
+++ b/Exiled.API/Features/Core/Generic/Singleton.cs
@@ -9,6 +9,7 @@ namespace Exiled.API.Features.Core.Generic
 {
     using System.Collections.Generic;
     using System.Linq;
+
     using Exiled.API.Features.Core;
 
     /// <summary>

--- a/Exiled.API/Features/Core/Generic/Singleton.cs
+++ b/Exiled.API/Features/Core/Generic/Singleton.cs
@@ -60,12 +60,7 @@ namespace Exiled.API.Features.Core.Generic
         /// <param name="instance">The object instance.</param>
         /// <returns><see langword="true"/> if the object instance is not null and can be casted as the specified type; otherwise, <see langword="false"/>.</returns>
         public static bool TryGet<TObject>(out TObject instance)
-            where TObject : class
-        {
-            instance = Instance as TObject;
-
-            return instance is not null;
-        }
+            where TObject : class => (instance = Instance as TObject) is not null;
 
         /// <inheritdoc cref="Singleton(T)"/>
         public static void Create(T @object) => new Singleton<T>(@object);
@@ -80,8 +75,7 @@ namespace Exiled.API.Features.Core.Generic
             if (Instances.TryGetValue(@object, out Singleton<T> _))
             {
                 Instances[@object] = null;
-                Instances.Remove(@object);
-                return true;
+                return Instances.Remove(@object);
             }
 
             return false;

--- a/Exiled.API/Features/Core/Generic/StaticActor.cs
+++ b/Exiled.API/Features/Core/Generic/StaticActor.cs
@@ -1,0 +1,169 @@
+// -----------------------------------------------------------------------
+// <copyright file="StaticActor.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Features.Core.Generic
+{
+    using Exiled.API.Features;
+    using Exiled.API.Features.Core;
+
+    /// <summary>
+    /// This is a generic Singleton implementation for components.
+    /// <br>Create a derived class where the type <typeparamref name="T"/> is the script you want to "Singletonize"</br>
+    /// </summary>
+    /// <typeparam name="T">The type of the class.</typeparam>
+    /// <remarks>
+    /// Do not redefine <see cref="PostInitialize()"/> <see cref="OnBeginPlay()"/> or <see cref="OnEndPlay()"/> in derived classes.
+    /// <br>Instead, use <see langword="protected virtual"/> methods:</br>
+    /// <br><see cref="PostInitialize_Static()"/></br>
+    /// <br><see cref="BeginPlay_Static()"/></br>
+    /// <br><see cref="EndPlay_Static()"/></br>
+    /// <para>
+    /// To perform the initialization and cleanup: those methods are guaranteed to only be called once in the entire lifetime of the component.
+    /// </para>
+    /// </remarks>
+    public abstract class StaticActor<T> : EActor
+        where T : EActor
+    {
+        private static T instance;
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="PostInitialize()"/> method has already been called by Unity.
+        /// </summary>
+        public static bool IsInitialized { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="OnBeginPlay()"/> method has already been called by Unity.
+        /// </summary>
+        public static bool IsStarted { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="OnEndPlay()"/> method has already been called by Unity.
+        /// </summary>
+        public static bool IsDestroyed { get; private set; }
+
+        /// <summary>
+        /// Gets the global access point to the unique instance of this class.
+        /// </summary>
+        public static T Instance => instance ? instance : IsDestroyed ? null : (instance = FindExistingInstance() ?? CreateNewInstance());
+
+        /// <summary>
+        /// Looks or an existing instance of the <see cref="StaticActor{T}"/>.
+        /// </summary>
+        /// <returns>The existing <typeparamref name="T"/> instance, or <see langword="null"/> if not found.</returns>
+        public static T FindExistingInstance()
+        {
+            T[] existingInstances = FindActiveObjectsOfType<T>();
+            return existingInstances == null || existingInstances.Length == 0 ? null : existingInstances[0];
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="StaticActor{T}"/>.
+        /// </summary>
+        /// <returns>The created <typeparamref name="T"/> instance, or <see langword="null"/> if not found.</returns>
+        public static T CreateNewInstance()
+        {
+            EObject @object = CreateDefaultSubobject<T>();
+            @object.Name = "__" + typeof(T).Name + " (StaticActor)";
+            return @object.Cast<T>();
+        }
+
+        /// <inheritdoc/>
+        protected override void PostInitialize()
+        {
+            base.PostInitialize();
+
+            T ldarg_0 = GetComponent<T>();
+
+            if (instance == null)
+            {
+                instance = ldarg_0;
+            }
+            else if (ldarg_0 != instance)
+            {
+                Log.Warn($"Found a duplicated instance of a StaticActor with type {GetType().Name} in the Actor {Name} that will be ignored");
+                NotifyInstanceRepeated();
+                return;
+            }
+
+            if (!IsInitialized)
+            {
+                Log.Info($"Start() StaticActor with type {GetType().Name} in the Actor {Name}");
+                PostInitialize_Static();
+                IsInitialized = true;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnBeginPlay()
+        {
+            base.OnBeginPlay();
+
+            if (IsStarted)
+                return;
+
+            BeginPlay_Static();
+            IsStarted = true;
+        }
+
+        /// <inheritdoc/>
+        protected override void OnEndPlay()
+        {
+            if (this != instance)
+                return;
+
+            IsDestroyed = true;
+            EndPlay_Static();
+        }
+
+        /// <summary>
+        /// Flushes the current actor.
+        /// </summary>
+        protected virtual void Flush() => Destroy();
+
+        /// <summary>
+        /// Fired on <see cref="PostInitialize()"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will only be called once even if multiple instances of the <see cref="StaticActor{T}"/> component exist in the scene.
+        /// <br>You can override this method in derived classes to customize the initialization of the component.</br>
+        /// </remarks>
+        protected virtual void PostInitialize_Static()
+        {
+        }
+
+        /// <summary>
+        /// Fired on <see cref="OnBeginPlay()"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will only be called once even if multiple instances of the <see cref="StaticActor{T}"/> component exist in the scene.
+        /// <br>You can override this method in derived classes to customize the initialization of the component.</br>
+        /// </remarks>
+        protected virtual void BeginPlay_Static()
+        {
+        }
+
+        /// <summary>
+        /// Fired on <see cref="OnEndPlay()"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will only be called once even if multiple instances of the <see cref="StaticActor{T}"/> component exist in the scene.
+        /// <br>You can override this method in derived classes to customize the initialization of the component.</br>
+        /// </remarks>
+        protected virtual void EndPlay_Static()
+        {
+        }
+
+        /// <summary>
+        /// If a duplicated instance of a <see cref="StaticActor{T}"/> component is loaded into the scene this method will be called instead of <see cref="PostInitialize_Static()"/>.
+        /// <br>That way you can customize what to do with repeated instances.</br>
+        /// </summary>
+        /// <remarks>
+        /// The default approach is delete the duplicated component.
+        /// </remarks>
+        protected virtual void NotifyInstanceRepeated() => Destroy(GetComponent<T>());
+    }
+}

--- a/Exiled.API/Features/Core/Generic/StaticActor.cs
+++ b/Exiled.API/Features/Core/Generic/StaticActor.cs
@@ -57,7 +57,7 @@ namespace Exiled.API.Features.Core.Generic
         public static T FindExistingInstance()
         {
             T[] existingInstances = FindActiveObjectsOfType<T>();
-            return existingInstances == null || existingInstances.Length == 0 ? null : existingInstances[0];
+            return existingInstances?.Length == 0 ? null : existingInstances[0];
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace Exiled.API.Features.Core.Generic
 
             if (!IsInitialized)
             {
-                Log.Info($"Start() StaticActor with type {GetType().Name} in the Actor {Name}");
+                Log.Debug($"Start() StaticActor with type {GetType().Name} in the Actor {Name}");
                 PostInitialize_Static();
                 IsInitialized = true;
             }

--- a/Exiled.API/Features/Core/Generic/UnmanagedEnumClass.cs
+++ b/Exiled.API/Features/Core/Generic/UnmanagedEnumClass.cs
@@ -12,6 +12,8 @@ namespace Exiled.API.Features.Core.Generic
     using System.Linq;
     using System.Reflection;
 
+    using Exiled.API.Features.Pools;
+
     using LiteNetLib.Utils;
 
     /// <summary>
@@ -152,7 +154,7 @@ namespace Exiled.API.Features.Core.Generic
         {
             results = null;
 
-            List<TObject> tmpValues = new();
+            List<TObject> tmpValues = ListPool<TObject>.Pool.Get();
             foreach (TSource value in values)
             {
                 if (!UnmanagedEnumClass<TSource, TObject>.values.TryGetValue(value, out TObject result))

--- a/Exiled.API/Features/Core/Generic/UnmanagedEnumClass.cs
+++ b/Exiled.API/Features/Core/Generic/UnmanagedEnumClass.cs
@@ -1,0 +1,272 @@
+// -----------------------------------------------------------------------
+// <copyright file="UnmanagedEnumClass.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Features.Core.Generic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    using LiteNetLib.Utils;
+
+    /// <summary>
+    /// A class which allows <see langword="unmanaged"/> data implicit conversions.
+    /// <para>Can be used along with <see langword="unmanaged"/>, means it doesn't require another <see cref="UnmanagedEnumClass{TSource, TObject}"/> instance to be comparable or usable.</para>
+    /// </summary>
+    /// <typeparam name="TSource">The type of the <see langword="unmanaged"/> source object to handle the instance of.</typeparam>
+    /// <typeparam name="TObject">The type of the child object to handle the instance of.</typeparam>
+    public abstract class UnmanagedEnumClass<TSource, TObject> : IComparable, IEquatable<TObject>, IComparable<TObject>, IComparer<TObject>
+        where TSource : unmanaged, IComparable, IFormattable, IConvertible, IComparable<TSource>, IEquatable<TSource>
+        where TObject : UnmanagedEnumClass<TSource, TObject>
+    {
+        private static SortedList<TSource, TObject> values;
+        private static bool isDefined;
+
+        private string name;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnmanagedEnumClass{TSource, TObject}"/> class.
+        /// </summary>
+        /// <param name="value">The value of the unmanaged item.</param>
+        protected UnmanagedEnumClass(TSource value)
+        {
+            values ??= new();
+
+            Value = value;
+            values.Add(value, (TObject)this);
+        }
+
+        /// <summary>
+        /// Gets all <typeparamref name="TObject"/> object instances.
+        /// </summary>
+        public static IEnumerable<TObject> Values => values.Values;
+
+        /// <summary>
+        /// Gets the value of the enum item.
+        /// </summary>
+        public TSource Value { get; }
+
+        /// <summary>
+        /// Gets the name determined from reflection.
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                if (isDefined)
+                    return name;
+
+                IEnumerable<FieldInfo> fields = typeof(TObject)
+                    .GetFields(BindingFlags.Static | BindingFlags.GetField | BindingFlags.Public)
+                    .Where(t => t.FieldType == typeof(TObject));
+
+                foreach (FieldInfo field in fields)
+                {
+                    TObject instance = (TObject)field.GetValue(null);
+                    instance.name = field.Name;
+                }
+
+                isDefined = true;
+                return name;
+            }
+        }
+
+        /// <summary>
+        /// Implicitly converts the <see cref="UnmanagedEnumClass{TSource, TObject}"/> to <typeparamref name="TSource"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        public static implicit operator TSource(UnmanagedEnumClass<TSource, TObject> value) => value.Value;
+
+        /// <summary>
+        /// Implicitly converts the <typeparamref name="TSource"/> to <see cref="EnumClass{TSource, TObject}"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        public static implicit operator UnmanagedEnumClass<TSource, TObject>(TSource value) => values[value];
+
+        /// <summary>
+        /// Implicitly converts the <see cref="UnmanagedEnumClass{TSource, TObject}"/> to <typeparamref name="TObject"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        public static implicit operator TObject(UnmanagedEnumClass<TSource, TObject> value) => value;
+
+        /// <summary>
+        /// Casts the specified <paramref name="value"/> to the corresponding type.
+        /// </summary>
+        /// <param name="value">The enum value to be cast.</param>
+        /// <returns>The cast object.</returns>
+        public static TObject Cast(TSource value) => values[value];
+
+        /// <summary>
+        /// Casts the specified <paramref name="values"/> to the corresponding type.
+        /// </summary>
+        /// <param name="values">The enum values to be cast.</param>
+        /// <returns>The cast object.</returns>
+        public static IEnumerable<TObject> Cast(IEnumerable<TSource> values)
+        {
+            foreach (TSource value in values)
+                yield return UnmanagedEnumClass<TSource, TObject>.values[value];
+        }
+
+        /// <summary>
+        /// Casts the specified <paramref name="values"/> to the corresponding type.
+        /// </summary>
+        /// <typeparam name="T">The type to cast the enum to.</typeparam>
+        /// <param name="values">The enum values to be cast.</param>
+        /// <returns>The cast <typeparamref name="T"/> object.</returns>
+        public static IEnumerable<T> Cast<T>(IEnumerable<TSource> values)
+            where T : TObject
+        {
+            foreach (TSource value in values)
+                yield return Cast<T>(value);
+        }
+
+        /// <summary>
+        /// Casts the specified <paramref name="value"/> to the corresponding type.
+        /// </summary>
+        /// <typeparam name="T">The type to cast the enum to.</typeparam>
+        /// <param name="value">The enum value to be cast.</param>
+        /// <returns>The cast <typeparamref name="T"/> object.</returns>
+        public static T Cast<T>(TSource value)
+            where T : TObject => (T)values[value];
+
+        /// <summary>
+        /// Safely casts the specified <paramref name="value"/> to the corresponding type.
+        /// </summary>
+        /// <param name="value">The enum value to be cast.</param>
+        /// <param name="result">The cast <paramref name="value"/>.</param>
+        /// <returns><see langword="true"/> if the <paramref name="value"/> was cast; otherwise, <see langword="false"/>.</returns>
+        public static bool SafeCast(TSource value, out TObject result) => values.TryGetValue(value, out result);
+
+        /// <summary>
+        /// Safely casts the specified <paramref name="values"/> to the corresponding type.
+        /// </summary>
+        /// <param name="values">The enum value to be cast.</param>
+        /// <param name="results">The cast <paramref name="values"/>.</param>
+        /// <returns><see langword="true"/> if the <paramref name="values"/> was cast; otherwise, <see langword="false"/>.</returns>
+        public static bool SafeCast(IEnumerable<TSource> values, out IEnumerable<TObject> results)
+        {
+            results = null;
+
+            List<TObject> tmpValues = new();
+            foreach (TSource value in values)
+            {
+                if (!UnmanagedEnumClass<TSource, TObject>.values.TryGetValue(value, out TObject result))
+                    return false;
+
+                tmpValues.Add(result);
+            }
+
+            results = tmpValues;
+            return true;
+        }
+
+        /// <summary>
+        /// Retrieves an array of the values of the constants in a specified <see cref="UnmanagedEnumClass{TSource, TObject}"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="UnmanagedEnumClass{TSource, TObject}"/> type.</param>
+        /// <returns>An array of the values of the constants in a specified <see cref="UnmanagedEnumClass{TSource, TObject}"/>.</returns>
+        public static TSource[] GetValues(Type type)
+        {
+            if (type is null)
+                throw new NullReferenceException("The specified type parameter is null");
+
+            if (!type.IsSubclassOf(typeof(UnmanagedEnumClass<TSource, TObject>)) && type.BaseType != typeof(UnmanagedEnumClass<TSource, TObject>))
+                throw new InvalidTypeException("The specified type parameter is not a UnmanagedEnumClass<TSource, TObject> type.");
+
+            return typeof(TSource)
+                .GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.GetField)
+                .Where(field => field.FieldType == typeof(TSource))
+                .Select(field => (TSource)field.GetValue(null))
+                .ToArray();
+        }
+
+        /// <summary>
+        /// Parses a <see cref="string"/> object.
+        /// </summary>
+        /// <param name="obj">The object to be parsed.</param>
+        /// <returns>The corresponding <typeparamref name="TObject"/> object instance, or <see langword="null"/> if not found.</returns>
+        public static TObject Parse(string obj)
+        {
+            foreach (TObject value in values.Values.Where(value => string.Compare(value.Name, obj, true) == 0))
+                return value;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="UnmanagedEnumClass{TSource, TObject}"/> instance to a human-readable <see cref="string"/> representation.
+        /// </summary>
+        /// <returns>A human-readable <see cref="string"/> representation of the <see cref="UnmanagedEnumClass{TSource, TObject}"/> instance.</returns>
+        public override string ToString() => name;
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj">The object to compare.</param>
+        /// <returns><see langword="true"/> if the object was equal; otherwise, <see langword="false"/>.</returns>
+        public override bool Equals(object obj) =>
+            obj != null && (obj is TSource value ? Value.Equals(value) : obj is TObject derived && Value.Equals(derived.Value));
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="other">The object to compare.</param>
+        /// <returns><see langword="true"/> if the object was equal; otherwise, <see langword="false"/>.</returns>
+        public bool Equals(TObject other) => Value.Equals(other.Value);
+
+        /// <summary>
+        /// Returns a the 32-bit signed hash code of the current object instance.
+        /// </summary>
+        /// <returns>The 32-bit signed hash code of the current object instance.</returns>
+        public override int GetHashCode() => Value.GetHashCode();
+
+        /// <summary>
+        /// Compares the current instance with another object of the same type and returns
+        /// an integer that indicates whether the current instance precedes, follows, or
+        /// occurs in the same position in the sort order as the other object.
+        /// </summary>
+        /// <param name="other">An object to compare with this instance.</param>
+        /// <returns>
+        /// A value that indicates the relative order of the objects being compared.
+        /// The return value has these meanings: Value Meaning Less than zero This instance precedes other in the sort order.
+        /// Zero This instance occurs in the same position in the sort order as other.
+        /// Greater than zero This instance follows other in the sort order.
+        /// </returns>
+        public int CompareTo(TObject other) => Value.CompareTo(other.Value);
+
+        /// <summary>
+        /// Compares the current instance with another object of the same type and returns
+        /// an integer that indicates whether the current instance precedes, follows, or
+        /// occurs in the same position in the sort order as the other object.
+        /// </summary>
+        /// <param name="obj">An object to compare with this instance.</param>
+        /// <returns>
+        /// A value that indicates the relative order of the objects being compared.
+        /// The return value has these meanings: Value Meaning Less than zero This instance precedes other in the sort order.
+        /// Zero This instance occurs in the same position in the sort order as other.
+        /// Greater than zero This instance follows other in the sort order.
+        /// </returns>
+        public int CompareTo(object obj) =>
+            obj == null ? -1 : obj is TSource value ? Value.CompareTo(value) : obj is TObject derived ? Value.CompareTo(derived.Value) : -1;
+
+        /// <summary>
+        /// Compares the specified object instance with another object of the same type and returns
+        /// an integer that indicates whether the current instance precedes, follows, or
+        /// occurs in the same position in the sort order as the other object.
+        /// </summary>
+        /// <param name="x">An object to compare.</param>
+        /// <param name="y">Another object to compare.</param>
+        /// <returns>
+        /// A value that indicates the relative order of the objects being compared.
+        /// The return value has these meanings: Value Meaning Less than zero This instance precedes other in the sort order.
+        /// Zero This instance occurs in the same position in the sort order as other.
+        /// Greater than zero This instance follows other in the sort order.
+        /// </returns>
+        public int Compare(TObject x, TObject y) => x == null ? -1 : y == null ? 1 : x.Value.CompareTo(y.Value);
+    }
+}

--- a/Exiled.API/Features/Core/StaticActor.cs
+++ b/Exiled.API/Features/Core/StaticActor.cs
@@ -1,0 +1,226 @@
+// -----------------------------------------------------------------------
+// <copyright file="StaticActor.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Features.Core
+{
+    using System;
+
+    using Exiled.API.Features;
+    using Exiled.API.Features.Core;
+
+    /// <summary>
+    /// This is a generic Singleton implementation for components.
+    /// <br>Create a derived class of the script you want to "Singletonize"</br>
+    /// </summary>
+    /// <remarks>
+    /// Do not redefine <see cref="PostInitialize()"/> <see cref="OnBeginPlay()"/> or <see cref="OnEndPlay()"/> in derived classes.
+    /// <br>Instead, use <see langword="protected virtual"/> methods:</br>
+    /// <br><see cref="PostInitialize_Static()"/></br>
+    /// <br><see cref="BeginPlay_Static()"/></br>
+    /// <br><see cref="EndPlay_Static()"/></br>
+    /// <para>
+    /// To perform the initialization and cleanup: those methods are guaranteed to only be called once in the entire lifetime of the component.
+    /// </para>
+    /// </remarks>
+    public abstract class StaticActor : EActor
+    {
+        private static StaticActor instance;
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="PostInitialize()"/> method has already been called by Unity.
+        /// </summary>
+        public static bool IsInitialized { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="OnBeginPlay()"/> method has already been called by Unity.
+        /// </summary>
+        public static bool IsStarted { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="OnEndPlay()"/> method has already been called by Unity.
+        /// </summary>
+        public static bool IsDestroyed { get; private set; }
+
+        /// <summary>
+        /// Gets the global access point to the unique instance of this class.
+        /// </summary>
+        public static StaticActor Instance => instance ? instance : IsDestroyed ? null : (instance = FindExistingInstance() ?? CreateNewInstance());
+
+        /// <summary>
+        /// Looks or an existing instance of the <see cref="StaticActor"/>.
+        /// </summary>
+        /// <returns>The existing <see cref="StaticActor"/> instance, or <see langword="null"/> if not found.</returns>
+        public static StaticActor FindExistingInstance()
+        {
+            StaticActor[] existingInstances = FindActiveObjectsOfType<StaticActor>();
+            return existingInstances == null || existingInstances.Length == 0 ? null : existingInstances[0];
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="StaticActor"/>.
+        /// </summary>
+        /// <returns>The created <see cref="StaticActor"/> instance, or <see langword="null"/> if not found.</returns>
+        public static StaticActor CreateNewInstance()
+        {
+            EObject @object = CreateDefaultSubobject<StaticActor>();
+            @object.Name = "__" + typeof(StaticActor).Name + " (StaticActor)";
+            return @object.Cast<StaticActor>();
+        }
+
+        /// <summary>
+        /// Gets a <see cref="StaticActor"/> given the specified type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the <see cref="StaticActor"/> to look for.</typeparam>
+        /// <returns>The corresponding <see cref="StaticActor"/>, or <see langword="null"/> if not found.</returns>
+        public static T Get<T>()
+            where T : StaticActor
+        {
+            foreach (StaticActor actor in FindActiveObjectsOfType<StaticActor>())
+            {
+                if (!actor.Cast(out StaticActor staticActor) || staticActor.GetType() != typeof(T))
+                    continue;
+
+                return actor.Cast<T>();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="StaticActor"/> given the specified type.
+        /// </summary>
+        /// <param name="type">The the type of the <see cref="StaticActor"/> to look for.</param>
+        /// <typeparam name="T">The type to cast the <see cref="StaticActor"/> to.</typeparam>
+        /// <returns>The corresponding <see cref="StaticActor"/> of type <typeparamref name="T"/>, or <see langword="null"/> if not found.</returns>
+        public static T Get<T>(Type type)
+            where T : StaticActor
+        {
+            foreach (StaticActor actor in FindActiveObjectsOfType<StaticActor>())
+            {
+                if (!actor.Cast(out StaticActor staticActor) || staticActor.GetType() != type)
+                    continue;
+
+                return actor.Cast<T>();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="StaticActor"/> given the specified type.
+        /// </summary>
+        /// <param name="type">The the type of the <see cref="StaticActor"/> to look for.</param>
+        /// <returns>The corresponding <see cref="StaticActor"/>, or <see langword="null"/> if not found.</returns>
+        public static StaticActor Get(Type type)
+        {
+            foreach (StaticActor actor in FindActiveObjectsOfType<StaticActor>())
+            {
+                if (!actor.Cast(out StaticActor staticActor) || staticActor.GetType() != type)
+                    continue;
+
+                return actor;
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc/>
+        protected override void PostInitialize()
+        {
+            base.PostInitialize();
+
+            StaticActor ldarg_0 = GetComponent<StaticActor>();
+
+            if (instance == null)
+            {
+                instance = ldarg_0;
+            }
+            else if (ldarg_0 != instance)
+            {
+                Log.Warn($"Found a duplicated instance of a StaticActor with type {GetType().Name} in the Actor {Name} that will be ignored");
+                NotifyInstanceRepeated();
+                return;
+            }
+
+            if (!IsInitialized)
+            {
+                Log.Info($"Start() StaticActor with type {GetType().Name} in the Actor {Name}");
+                PostInitialize_Static();
+                IsInitialized = true;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnBeginPlay()
+        {
+            base.OnBeginPlay();
+
+            if (IsStarted)
+                return;
+
+            BeginPlay_Static();
+            IsStarted = true;
+        }
+
+        /// <inheritdoc/>
+        protected override void OnEndPlay()
+        {
+            if (this != instance)
+                return;
+
+            IsDestroyed = true;
+            EndPlay_Static();
+        }
+
+        /// <summary>
+        /// Flushes the current actor.
+        /// </summary>
+        protected virtual void Flush() => Destroy();
+
+        /// <summary>
+        /// Fired on <see cref="PostInitialize()"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will only be called once even if multiple instances of the <see cref="StaticActor"/> component exist in the scene.
+        /// <br>You can override this method in derived classes to customize the initialization of the component.</br>
+        /// </remarks>
+        protected virtual void PostInitialize_Static()
+        {
+        }
+
+        /// <summary>
+        /// Fired on <see cref="OnBeginPlay()"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will only be called once even if multiple instances of the <see cref="StaticActor"/> component exist in the scene.
+        /// <br>You can override this method in derived classes to customize the initialization of the component.</br>
+        /// </remarks>
+        protected virtual void BeginPlay_Static()
+        {
+        }
+
+        /// <summary>
+        /// Fired on <see cref="OnEndPlay()"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will only be called once even if multiple instances of the <see cref="StaticActor"/> component exist in the scene.
+        /// <br>You can override this method in derived classes to customize the initialization of the component.</br>
+        /// </remarks>
+        protected virtual void EndPlay_Static()
+        {
+        }
+
+        /// <summary>
+        /// If a duplicated instance of a <see cref="StaticActor"/> component is loaded into the scene this method will be called instead of <see cref="PostInitialize_Static()"/>.
+        /// <br>That way you can customize what to do with repeated instances.</br>
+        /// </summary>
+        /// <remarks>
+        /// The default approach is delete the duplicated component.
+        /// </remarks>
+        protected virtual void NotifyInstanceRepeated() => Destroy(GetComponent<StaticActor>());
+    }
+}

--- a/Exiled.API/Features/Core/StaticActor.cs
+++ b/Exiled.API/Features/Core/StaticActor.cs
@@ -148,7 +148,7 @@ namespace Exiled.API.Features.Core
 
             if (!IsInitialized)
             {
-                Log.Info($"Start() StaticActor with type {GetType().Name} in the Actor {Name}");
+                Log.Debug($"Start() StaticActor with type {GetType().Name} in the Actor {Name}");
                 PostInitialize_Static();
                 IsInitialized = true;
             }

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -71,7 +71,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// Represents the in-game player, by encapsulating a <see cref="global::ReferenceHub"/>.
     /// </summary>
-    public class Player : IEntity, IWorldSpace
+    public class Player : TypeCastObject<Player>, IEntity, IWorldSpace
     {
 #pragma warning disable SA1401
         /// <summary>


### PR DESCRIPTION
Added `EnumClass`, can be used within existing enums.
Added `UnmanagedEnumClass`, can be used within existing unmanaged data types.
Added `Singleton<T>`, a managed singleton object.
Added `StaticActor` and `StaticActor<T>`, a singleton using ECS and entirely managed by Exiled.
Made `Player` a `TypeCastObject`<T>`.