### PR TITLE
Add `SoundtrackMute` to exceptions

### DIFF
--- a/Exiled.API/Features/Pickups/Pickup.cs
+++ b/Exiled.API/Features/Pickups/Pickup.cs
@@ -353,7 +353,7 @@ namespace Exiled.API.Features.Pickups
         /// </summary>
         /// <param name="pickups">An <see cref="IEnumerable{T}"/> of <see cref="ItemPickupBase"/> to convert into an <see cref="IEnumerable{T}"/> of <see cref="Pickup"/>.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Pickup"/> containing all existing <see cref="ItemPickupBase"/> instances.</returns>
-        public static IEnumerable<Pickup> Get(IEnumerable<ItemPickupBase> pickups) => from ItemPickupBase ipb in pickups select Get(ipb);
+        public static IEnumerable<Pickup> Get(IEnumerable<ItemPickupBase> pickups) => pickups.Select(ipb => Get(ipb));
 
         /// <summary>
         /// Gets an <see cref="IEnumerable{T}"/> of <see cref="Pickup"/> containing all existing <see cref="ItemPickupBase"/> instances given an <see cref="ItemType"/>.

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -2727,6 +2727,12 @@ namespace Exiled.API.Features
         /// <param name="addDurationIfActive">If the effect is already active, setting to <see langword="true"/> will add this duration onto the effect.</param>
         public void EnableEffect(EffectType type, float duration = 0f, bool addDurationIfActive = false)
         {
+            if (type is EffectType.SoundtrackMute)
+            {
+                EnableEffect<SoundtrackMute>(duration, addDurationIfActive);
+                return;
+            }
+
             if (TryGetEffect(type, out StatusEffectBase statusEffect))
                 EnableEffect(statusEffect, duration, addDurationIfActive);
         }

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -2701,7 +2701,13 @@ namespace Exiled.API.Features
         /// <param name="addDurationIfActive">If the effect is already active, setting to <see langword="true"/> will add this duration onto the effect.</param>
         /// <returns>A bool indicating whether or not the effect was valid and successfully enabled.</returns>
         public bool EnableEffect(StatusEffectBase statusEffect, float duration = 0f, bool addDurationIfActive = false)
-            => EnableEffect(statusEffect.GetType().Name, duration, addDurationIfActive).IsEnabled;
+        {
+            if (statusEffect is null)
+                return false;
+
+            StatusEffectBase effect = EnableEffect(statusEffect.GetType().Name, duration, addDurationIfActive);
+            return effect is not null && effect.IsEnabled;
+        }
 
         /// <summary>
         /// Enables a <see cref="StatusEffectBase">status effect</see> on the player.

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -2727,14 +2727,23 @@ namespace Exiled.API.Features
         /// <param name="addDurationIfActive">If the effect is already active, setting to <see langword="true"/> will add this duration onto the effect.</param>
         public void EnableEffect(EffectType type, float duration = 0f, bool addDurationIfActive = false)
         {
-            if (type is EffectType.SoundtrackMute)
+            switch (type)
             {
-                EnableEffect<SoundtrackMute>(duration, addDurationIfActive);
-                return;
-            }
+                case EffectType.AmnesiaItems:
+                    EnableEffect<AmnesiaItems>(duration, addDurationIfActive);
+                    break;
+                case EffectType.AmnesiaVision:
+                    EnableEffect<AmnesiaVision>(duration, addDurationIfActive);
+                    break;
+                case EffectType.SoundtrackMute:
+                    EnableEffect<SoundtrackMute>(duration, addDurationIfActive);
+                    break;
+                default:
+                    if (TryGetEffect(type, out StatusEffectBase statusEffect))
+                        EnableEffect(statusEffect, duration, addDurationIfActive);
 
-            if (TryGetEffect(type, out StatusEffectBase statusEffect))
-                EnableEffect(statusEffect, duration, addDurationIfActive);
+                    break;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Of course it is what it is, however unless we re-define the dictionary from which we get all effects, that's the only way to fix it.