### PR TITLE
Reworked Plugin Config Detection.

### DIFF
--- a/Exiled.Loader/ConfigManager.cs
+++ b/Exiled.Loader/ConfigManager.cs
@@ -44,11 +44,9 @@ namespace Exiled.Loader
                 foreach (IPlugin<IConfig> plugin in Loader.Plugins)
                 {
                     if (!deserializedConfigs.ContainsKey(plugin.Prefix))
-                    {
                         deserializedConfigs.Add(plugin.Prefix, plugin.LoadConfig(rawDeserializedConfigs));
-                    } else {
+                    else
                         Log.Warn($"{plugin.Prefix} already exists in {plugin.Name}'s configuration. {plugin.Prefix} has been skipped.");
-                    }
                 }
 
                 // Make sure that no keys in the config file were discarded. (Individual can ignore this since rawDeserializedConfigs is null)
@@ -58,7 +56,7 @@ namespace Exiled.Loader
                     File.WriteAllText(Paths.BackupConfig, rawConfigs);
                 }
 
-                Log.Info("All plugin configs have been loaded successfully!");
+                Log.Info("Plugin configs loaded successfully!");
 
                 DictionaryPool<string, object>.Pool.Return(rawDeserializedConfigs);
                 return deserializedConfigs;

--- a/Exiled.Loader/ConfigManager.cs
+++ b/Exiled.Loader/ConfigManager.cs
@@ -40,13 +40,13 @@ namespace Exiled.Loader
                 Dictionary<string, object> rawDeserializedConfigs = Loader.Deserializer.Deserialize<Dictionary<string, object>>(rawConfigs) ?? DictionaryPool<string, object>.Pool.Get();
                 SortedDictionary<string, IConfig> deserializedConfigs = new(StringComparer.Ordinal);
 
-                //Only allow unique keys to be loaded. Any duplicates in the plugin's config will be skipped.
+                // Only allow unique keys to be loaded. Any duplicates in the plugin's config will be skipped.
                 foreach (IPlugin<IConfig> plugin in Loader.Plugins)
                 {
                     if (!deserializedConfigs.ContainsKey(plugin.Prefix))
                     {
                         deserializedConfigs.Add(plugin.Prefix, plugin.LoadConfig(rawDeserializedConfigs));
-                    }else{
+                    } else {
                         Log.Warn($"{plugin.Prefix} already exists in {plugin.Name}'s configuration. {plugin.Prefix} has been skipped.");
                     }
                 }


### PR DESCRIPTION
Stopped plugin configs from loading duplicate keys.

It will ignore keys that have been duplicated after the original key has been loaded.