### PR TITLE
Ability use hint changes

### DIFF
--- a/Exiled.API/Features/Core/Generic/Singleton.cs
+++ b/Exiled.API/Features/Core/Generic/Singleton.cs
@@ -62,7 +62,7 @@ namespace Exiled.API.Features.Core.Generic
         public static bool TryGet<TObject>(out TObject instance)
             where TObject : class => (instance = Instance as TObject) is not null;
 
-        /// <inheritdoc cref="Singleton(T)"/>
+        /// <inheritdoc cref="Singleton{T}"/>
         public static void Create(T @object) => new Singleton<T>(@object);
 
         /// <summary>

--- a/Exiled.API/Features/Pickups/Pickup.cs
+++ b/Exiled.API/Features/Pickups/Pickup.cs
@@ -453,8 +453,8 @@ namespace Exiled.API.Features.Pickups
         /// <br />- The Micro HID can be cast to <see cref="MicroHIDPickup"/>.
         /// <br />- SCP-244 A and B variants can be cast to <see cref="Scp244Pickup"/>.
         /// <br />- SCP-330 can be cast to <see cref="Scp330Pickup"/>.
-        /// <br />- SCP-018 can be cast to <see cref="Scp018Projectile"/>.
-        /// <br />- SCP-2176 can be cast to <see cref="Scp2176Projectile"/>.
+        /// <br />- SCP-018 can be cast to <see cref="Projectiles.Scp018Projectile"/>.
+        /// <br />- SCP-2176 can be cast to <see cref="Projectiles.Scp2176Projectile"/>.
         /// </para>
         /// <para>
         /// Items that are not listed above do not have a subclass, and can only use the base <see cref="Pickup"/> class.

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -539,9 +539,9 @@ namespace Exiled.API.Features
         /// Gets a <see cref="Roles.Role"/> that is unique to this player and this class. This allows modification of various aspects related to the role solely.
         /// <para>
         /// The type of the Role is different based on the <see cref="RoleTypeId"/> of the player, and casting should be used to modify the role.
-        /// <br /><see cref="RoleTypeId.Spectator"/> = <see cref="SpectatorRole"/>.
-        /// <br /><see cref="RoleTypeId.Overwatch"/> = <see cref="OverwatchRole"/>.
-        /// <br /><see cref="RoleTypeId.None"/> = <see cref="NoneRole"/>.
+        /// <br /><see cref="RoleTypeId.Spectator"/> = <see cref="Roles.SpectatorRole"/>.
+        /// <br /><see cref="RoleTypeId.Overwatch"/> = <see cref="Roles.OverwatchRole"/>.
+        /// <br /><see cref="RoleTypeId.None"/> = <see cref="Roles.NoneRole"/>.
         /// <br /><see cref="RoleTypeId.Scp049"/> = <see cref="Scp049Role"/>.
         /// <br /><see cref="RoleTypeId.Scp0492"/> = <see cref="Scp0492Role"/>.
         /// <br /><see cref="RoleTypeId.Scp079"/> = <see cref="Scp079Role"/>.

--- a/Exiled.CustomRoles/API/Features/ActiveAbility.cs
+++ b/Exiled.CustomRoles/API/Features/ActiveAbility.cs
@@ -69,7 +69,6 @@ namespace Exiled.CustomRoles.API.Features
         {
             ActivePlayers.Add(player);
             LastUsed[player] = DateTime.Now;
-            ShowMessage(player);
             AbilityUsed(player);
             Timing.CallDelayed(Duration, () => EndAbility(player));
         }
@@ -225,13 +224,6 @@ namespace Exiled.CustomRoles.API.Features
         protected virtual void AbilityEnded(Player player)
         {
         }
-
-        /// <summary>
-        /// Called when the ability is successfully used.
-        /// </summary>
-        /// <param name="player">The <see cref="Player"/> using the ability.</param>
-        protected virtual void ShowMessage(Player player) =>
-            player.ShowHint(string.Format(CustomRoles.Instance!.Config.UsedAbilityHint.Content, Name, Description), CustomRoles.Instance.Config.UsedAbilityHint.Duration);
 
         /// <summary>
         /// Called when the ability is selected.

--- a/Exiled.CustomRoles/API/Features/ActiveAbility.cs
+++ b/Exiled.CustomRoles/API/Features/ActiveAbility.cs
@@ -229,6 +229,7 @@ namespace Exiled.CustomRoles.API.Features
         /// Called when the ability is successfully used.
         /// </summary>
         /// <param name="player">The <see cref="Player"/> using the ability.</param>
+        [Obsolete("The Keypress Activator will already do this, you do not need to call this unless you are overwriting the keypress activator.", true)]
         protected virtual void ShowMessage(Player player) =>
             player.ShowHint(string.Format(CustomRoles.Instance!.Config.UsedAbilityHint.Content, Name, Description), CustomRoles.Instance.Config.UsedAbilityHint.Duration);
 

--- a/Exiled.CustomRoles/API/Features/ActiveAbility.cs
+++ b/Exiled.CustomRoles/API/Features/ActiveAbility.cs
@@ -226,6 +226,13 @@ namespace Exiled.CustomRoles.API.Features
         }
 
         /// <summary>
+        /// Called when the ability is successfully used.
+        /// </summary>
+        /// <param name="player">The <see cref="Player"/> using the ability.</param>
+        protected virtual void ShowMessage(Player player) =>
+            player.ShowHint(string.Format(CustomRoles.Instance!.Config.UsedAbilityHint.Content, Name, Description), CustomRoles.Instance.Config.UsedAbilityHint.Duration);
+
+        /// <summary>
         /// Called when the ability is selected.
         /// </summary>
         /// <param name="player">The <see cref="Player"/> selecting the ability.</param>

--- a/Exiled.CustomRoles/API/Features/KeypressActivator.cs
+++ b/Exiled.CustomRoles/API/Features/KeypressActivator.cs
@@ -96,7 +96,7 @@ namespace Exiled.CustomRoles.API.Features
             };
 
             bool preformed = PreformAction(player, type, out string response);
-            if (preformed)
+            if (preformed && type == AbilityKeypressTriggerType.Activate)
             {
                 string[] split = response.Split('|');
                 response = CustomRoles.Instance.Config.UsedAbilityHint.Content.Replace("{0}", split[0]).Replace("{1}", split[1]);

--- a/Exiled.CustomRoles/API/Features/KeypressActivator.cs
+++ b/Exiled.CustomRoles/API/Features/KeypressActivator.cs
@@ -96,14 +96,15 @@ namespace Exiled.CustomRoles.API.Features
             };
 
             bool preformed = PreformAction(player, type, out string response);
-            if (preformed && type == AbilityKeypressTriggerType.Activate)
+            switch (preformed)
             {
-                string[] split = response.Split('|');
-                response = CustomRoles.Instance.Config.UsedAbilityHint.Content.Replace("{0}", split[0]).Replace("{1}", split[1]);
-            }
-            else
-            {
-                response = CustomRoles.Instance.Config.FailedActionHint.Content.Replace("{0}", response);
+                case true when type == AbilityKeypressTriggerType.Activate:
+                    string[] split = response.Split('|');
+                    response = string.Format(CustomRoles.Instance.Config.UsedAbilityHint.Content, split);
+                    break;
+                case false:
+                    response = string.Format(CustomRoles.Instance.Config.FailedActionHint.Content, response);
+                    break;
             }
 
             float dur = preformed ? CustomRoles.Instance.Config.UsedAbilityHint.Duration : CustomRoles.Instance.Config.FailedActionHint.Duration;

--- a/Exiled.CustomRoles/API/Features/KeypressActivator.cs
+++ b/Exiled.CustomRoles/API/Features/KeypressActivator.cs
@@ -95,7 +95,18 @@ namespace Exiled.CustomRoles.API.Features
                 _ => AbilityKeypressTriggerType.None,
             };
 
-            player.ShowHint(!PreformAction(player, type, out string response) ? $"Failed to preform action: {response}" : $"Preformed action: {response}", 5f);
+            bool preformed = PreformAction(player, type, out string response);
+            if (preformed)
+            {
+                string[] split = response.Split('|');
+                response = CustomRoles.Instance.Config.UsedAbilityHint.Content.Replace("{0}", split[0]).Replace("{1}", split[1]);
+            }
+            else
+            {
+                response = CustomRoles.Instance.Config.FailedAbilityHint.Content.Replace("{0}", response);
+            }
+
+            player.ShowHint(response, CustomRoles.Instance.Config.UsedAbilityHint.Duration);
             altTracker[player] = 0;
         }
 
@@ -112,7 +123,7 @@ namespace Exiled.CustomRoles.API.Features
 
                 if (!selected.CanUseAbility(player, out response, CustomRoles.Instance.Config.ActivateOnlySelected))
                     return false;
-                response = $"{selected.Name} used.";
+                response = $"{selected.Name}|{selected.Description}";
                 selected.UseAbility(player);
                 return true;
             }

--- a/Exiled.CustomRoles/API/Features/KeypressActivator.cs
+++ b/Exiled.CustomRoles/API/Features/KeypressActivator.cs
@@ -103,10 +103,11 @@ namespace Exiled.CustomRoles.API.Features
             }
             else
             {
-                response = CustomRoles.Instance.Config.FailedAbilityHint.Content.Replace("{0}", response);
+                response = CustomRoles.Instance.Config.FailedActionHint.Content.Replace("{0}", response);
             }
 
-            player.ShowHint(response, CustomRoles.Instance.Config.UsedAbilityHint.Duration);
+            float dur = preformed ? CustomRoles.Instance.Config.UsedAbilityHint.Duration : CustomRoles.Instance.Config.FailedActionHint.Duration;
+            player.ShowHint(response, dur);
             altTracker[player] = 0;
         }
 

--- a/Exiled.CustomRoles/API/Features/KeypressActivator.cs
+++ b/Exiled.CustomRoles/API/Features/KeypressActivator.cs
@@ -102,12 +102,21 @@ namespace Exiled.CustomRoles.API.Features
                     string[] split = response.Split('|');
                     response = string.Format(CustomRoles.Instance.Config.UsedAbilityHint.Content, split);
                     break;
+                case true when type is AbilityKeypressTriggerType.SwitchBackward or AbilityKeypressTriggerType.SwitchForward:
+                    response = string.Format(CustomRoles.Instance.Config.SwitchedAbilityHint.Content, response);
+                    break;
                 case false:
                     response = string.Format(CustomRoles.Instance.Config.FailedActionHint.Content, response);
                     break;
             }
 
-            float dur = preformed ? CustomRoles.Instance.Config.UsedAbilityHint.Duration : CustomRoles.Instance.Config.FailedActionHint.Duration;
+            float dur = type switch
+            {
+                AbilityKeypressTriggerType.Activate when preformed => CustomRoles.Instance.Config.UsedAbilityHint.Duration,
+                AbilityKeypressTriggerType.SwitchBackward or AbilityKeypressTriggerType.SwitchForward when preformed => CustomRoles.Instance.Config.SwitchedAbilityHint.Duration,
+                _ => CustomRoles.Instance.Config.FailedActionHint.Duration,
+            };
+
             player.ShowHint(response, dur);
             altTracker[player] = 0;
         }
@@ -166,12 +175,12 @@ namespace Exiled.CustomRoles.API.Features
 
                     selected.UnSelectAbility(player);
                     abilities[index].SelectAbility(player);
-                    response = $"{abilities[index].Name} has been selected.";
+                    response = $"{abilities[index].Name}";
                     return true;
                 }
 
                 abilities[0].SelectAbility(player);
-                response = $"{abilities[0].Name} has been selected.";
+                response = $"{abilities[0].Name}";
                 return true;
             }
 

--- a/Exiled.CustomRoles/Config.cs
+++ b/Exiled.CustomRoles/Config.cs
@@ -54,9 +54,15 @@ namespace Exiled.CustomRoles
         public bool ActivateOnlySelected { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the hing that is shown when someone fails to use a <see cref="ActiveAbility"/>.
+        /// Gets or sets the hint that is shown when someone fails to use a <see cref="ActiveAbility"/>.
         /// </summary>
         [Description("The hint showed to players when they fail to preform an action.")]
         public Broadcast FailedActionHint { get; set; } = new("Failed to preform action: {0}", 5);
+
+        /// <summary>
+        /// Gets or sets the hint that is shown when someone switches their selected <see cref="ActiveAbility"/>.
+        /// </summary>
+        [Description("The hint that is shown to players when they switch abilities.")]
+        public Broadcast SwitchedAbilityHint { get; set; } = new("Selected ability {0}", 5);
     }
 }

--- a/Exiled.CustomRoles/Config.cs
+++ b/Exiled.CustomRoles/Config.cs
@@ -57,6 +57,6 @@ namespace Exiled.CustomRoles
         /// Gets or sets the hing that is shown when someone fails to use a <see cref="ActiveAbility"/>.
         /// </summary>
         [Description("The hint showed to players when they fail to preform an action.")]
-        public Broadcast FailedAbilityHint { get; set; } = new("Failed to preform action: {0}");
+        public Broadcast FailedActionHint { get; set; } = new("Failed to preform action: {0}", 5);
     }
 }

--- a/Exiled.CustomRoles/Config.cs
+++ b/Exiled.CustomRoles/Config.cs
@@ -36,7 +36,7 @@ namespace Exiled.CustomRoles
         public Broadcast GotRoleHint { get; private set; } = new("You have spawned as a {0}\n{1}", 6);
 
         /// <summary>
-        /// Gets the hint that is shown when someone used a <see cref="CustomAbility"/>.
+        /// Gets the hint that is shown when someone used a <see cref="ActiveAbility"/>.
         /// </summary>
         [Description("The hint that is shown when someone used a custom ability.")]
         public Broadcast UsedAbilityHint { get; private set; } = new("Ability {0} has been activated.\n{1}", 5);
@@ -52,5 +52,11 @@ namespace Exiled.CustomRoles
         /// </summary>
         [Description("Whether or not abilities that are not selected as the current keypress ability can still be activated.")]
         public bool ActivateOnlySelected { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the hing that is shown when someone fails to use a <see cref="ActiveAbility"/>.
+        /// </summary>
+        [Description("The hint showed to players when they fail to preform an action.")]
+        public Broadcast FailedAbilityHint { get; set; } = new("Failed to preform action: {0}");
     }
 }


### PR DESCRIPTION
Removed redundant hint message that resulted in multiple hints being sent to the player when an ability is successfully activated.
The keypress activator message takes priority over the UseAbility() message, as it can include both the activator messages (no selected ability, etc) as well as the CanUseAbility() response, or the name & description of the ability that's been used, so it's just simpler to handle all of these in one place.

This is not a breaking change, as ActiveAbility.ShowMessage(Player) still exists, it just isn't called by the base class code anymore, thus it has been marked Obsolete.