### PR TITLE
Add LocalPositionOffset to Room

### DIFF
--- a/Exiled.API/Features/Room.cs
+++ b/Exiled.API/Features/Room.cs
@@ -308,6 +308,13 @@ namespace Exiled.API.Features
         public Vector3 WorldPosition(Vector3 offset) => Transform.InverseTransformPoint(offset);
 
         /// <summary>
+        /// Returns the local offset from the center of the Room, based on a world position.
+        /// </summary>
+        /// <param name="position">World Position.</param>
+        /// <returns>Local offset, based on the room.</returns>
+        public Vector3 LocalPositionOffset(Vector3 position) => Transform.InverseTransformPoint(position);
+
+        /// <summary>
         /// Flickers the room's lights off for a duration.
         /// </summary>
         /// <param name="duration">Duration in seconds.</param>


### PR DESCRIPTION
Just a little addition to determine the LocalPosition offset based on World Position

Basically, if I have a Room and want to determine it's LocalPosition in order to, for example, spawn something at a certain place in a room no matter the rotation, I can do so using this.
I've been doing this before using MER and primitiveobjects which showed localposition, but I thought of adding it as a normal thing so it doesn't have to be this unnecessarily complicated