### PR TITLE
Fixing someones tiny brain

### DIFF
--- a/Exiled.Events/Patches/Fixes/HurtingFix.cs
+++ b/Exiled.Events/Patches/Fixes/HurtingFix.cs
@@ -50,6 +50,10 @@ namespace Exiled.Events.Patches.Events.Player
                     //   skip;
                     new(OpCodes.Ldloc_1),
                     new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Stloc, player.LocalIndex),
+                    new(OpCodes.Brfalse_S, skip),
+                    new(OpCodes.Ldloc, player.LocalIndex),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.IsAlive))),
                     new(OpCodes.Brfalse_S, skip),
                 });


### PR DESCRIPTION
There used to be a null check here, at some point. I know because I added it, and my local variable for the player is still in the patch.

Removing the null check causes Npc.Destroy() to throw exceptions on  `CustomNetworkManager.TypedSingleton.OnServerDisconnect(conn);`

This re-adds the check to allow for proper disposal of NPCs when you no longer have need of their services.