### PR TITLE
Fix `Scp0492.ConsumingCorpse` event was called with `Scp049`

### DIFF
--- a/Exiled.Events/EventArgs/Scp0492/ConsumingCorpseEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp0492/ConsumingCorpseEventArgs.cs
@@ -58,15 +58,8 @@ namespace Exiled.Events.EventArgs.Scp0492
         /// </summary>
         public bool IsAllowed
         {
-            get
-            {
-                return ErrorCode == ZombieConsumeAbility.ConsumeError.None;
-            }
-
-            set
-            {
-                ErrorCode = value ? ZombieConsumeAbility.ConsumeError.None : ZombieConsumeAbility.ConsumeError.TargetNotValid;
-            }
+            get => ErrorCode == ZombieConsumeAbility.ConsumeError.None;
+            set => ErrorCode = value ? ZombieConsumeAbility.ConsumeError.None : ZombieConsumeAbility.ConsumeError.TargetNotValid;
         }
     }
 }

--- a/Exiled.Events/EventArgs/Scp0492/ConsumingCorpseEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp0492/ConsumingCorpseEventArgs.cs
@@ -25,14 +25,14 @@ namespace Exiled.Events.EventArgs.Scp0492
         /// <param name="ragDoll"> <inheritdoc cref="Ragdoll"/> </param>
         /// <param name="error"> <inheritdoc cref="ErrorCode"/> </param>
         /// <param name="isAllowed"> <inheritdoc cref="IsAllowed"/> </param>
-        /// <remarks> See <see cref="ZombieConsumeAbility.ConsumedRagdolls"/> for all RagDolls consumed. </remarks>
+        /// <remarks> See <see cref="ZombieConsumeAbility.ConsumedRagdolls"/> for all RagDolls consumed.</remarks>
+        // TODO: remove isAllowed argument
         public ConsumingCorpseEventArgs(ReferenceHub player, BasicRagdoll ragDoll, ZombieConsumeAbility.ConsumeError error, bool isAllowed = true)
         {
             Player = Player.Get(player);
             Scp0492 = Player.Role.As<Scp0492Role>();
             Ragdoll = Ragdoll.Get(ragDoll);
             ErrorCode = error;
-            IsAllowed = isAllowed;
         }
 
         /// <summary>
@@ -56,6 +56,17 @@ namespace Exiled.Events.EventArgs.Scp0492
         /// <summary>
         ///     Gets or sets a value indicating whether 049-2 can consume a corpse.
         /// </summary>
-        public bool IsAllowed { get; set; }
+        public bool IsAllowed
+        {
+            get
+            {
+                return ErrorCode == ZombieConsumeAbility.ConsumeError.None;
+            }
+
+            set
+            {
+                ErrorCode = value ? ZombieConsumeAbility.ConsumeError.None : ZombieConsumeAbility.ConsumeError.TargetNotValid;
+            }
+        }
     }
 }

--- a/Exiled.Events/Patches/Events/Scp0492/Consuming.cs
+++ b/Exiled.Events/Patches/Events/Scp0492/Consuming.cs
@@ -11,6 +11,9 @@ namespace Exiled.Events.Patches.Events.Scp0492
     using System.Reflection.Emit;
 
     using API.Features.Pools;
+
+    using Exiled.API.Extensions;
+    using Exiled.API.Features;
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Scp0492;
     using HarmonyLib;
@@ -25,67 +28,41 @@ namespace Exiled.Events.Patches.Events.Scp0492
     ///     to add <see cref="Handlers.Scp0492.ConsumingCorpse" /> event.
     /// </summary>
     [EventPatch(typeof(Handlers.Scp0492), nameof(Handlers.Scp0492.ConsumingCorpse))]
-    [HarmonyPatch(typeof(RagdollAbilityBase<ZombieRole>), nameof(RagdollAbilityBase<ZombieRole>.ServerProcessCmd))]
+    [HarmonyPatch(typeof(ZombieConsumeAbility), nameof(ZombieConsumeAbility.ServerValidateBegin))]
     public class Consuming
     {
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
 
-            int offset = 2;
-            int index = newInstructions.FindIndex(instrc => instrc.Calls(Method(typeof(RagdollAbilityBase<ZombieRole>), nameof(RagdollAbilityBase<ZombieRole>.ServerValidateBegin)))) + offset;
-
-            Label retLabel = generator.DefineLabel();
-            Label cnt = generator.DefineLabel();
-
-            LocalBuilder ev = generator.DeclareLocal(typeof(ConsumingCorpseEventArgs));
+            int offset = 0;
+            int index = newInstructions.FindLastIndex(i => i.opcode == OpCodes.Ldc_I4_0) + offset;
 
             newInstructions.InsertRange(index, new CodeInstruction[]
             {
-                // if (this is not ZombieConsumeAbility)
-                //     return;
-                new(OpCodes.Ldarg_0),
-                new(OpCodes.Isinst, typeof(ZombieConsumeAbility)),
-                new(OpCodes.Brfalse_S, cnt),
-
                 // this.Owner
-                new(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldarg_0).MoveLabelsFrom(newInstructions[index]),
                 new(OpCodes.Callvirt, PropertyGetter(typeof(ScpStandardSubroutine<ZombieRole>), nameof(ScpStandardSubroutine<ZombieRole>.Owner))),
 
-                // this.CurRagdoll
-                new(OpCodes.Ldarg_0),
-                new(OpCodes.Callvirt, PropertyGetter(typeof(RagdollAbilityBase<ZombieRole>), nameof(RagdollAbilityBase<ZombieRole>.CurRagdoll))),
+                // radgoll
+                new(OpCodes.Ldarg_1),
 
-                // this._errorCode
-                new(OpCodes.Ldarg_0),
-                new(OpCodes.Ldfld, Field(typeof(RagdollAbilityBase<ZombieRole>), nameof(RagdollAbilityBase<ZombieRole>._errorCode))),
+                // ConsumeError.None
+                new(OpCodes.Ldc_I4_0),
 
                 // true
                 new(OpCodes.Ldc_I4_1),
 
-                // ConsumingCorpseEventArgs ev = new(this.Owner, this.Ragdoll, this._errorCode, true)
+                // ConsumingCorpseEventArgs ev = new(this.Owner, this.Ragdoll, ConsumeError.None, true)
                 new(OpCodes.Newobj, GetDeclaredConstructors(typeof(ConsumingCorpseEventArgs))[0]),
                 new(OpCodes.Dup),
-                new(OpCodes.Dup),
-                new(OpCodes.Stloc, ev.LocalIndex),
 
                 // Handlers.Scp0492.OnConsumingCorpse(ev)
                 new(OpCodes.Call, Method(typeof(Handlers.Scp0492), nameof(Handlers.Scp0492.OnConsumingCorpse))),
 
-                // if (!ev.IsAllowed)
-                //   return
-                new(OpCodes.Callvirt, PropertyGetter(typeof(ConsumingCorpseEventArgs), nameof(ConsumingCorpseEventArgs.IsAllowed))),
-                new(OpCodes.Brtrue_S, retLabel),
-
-                new(OpCodes.Ret),
-
-                // this._errorCode = ev.ErrorCode
-                new CodeInstruction(OpCodes.Ldloc, ev.LocalIndex).WithLabels(retLabel),
-                new(OpCodes.Ldarg_0),
+                // return new code
                 new(OpCodes.Callvirt, PropertyGetter(typeof(ConsumingCorpseEventArgs), nameof(ConsumingCorpseEventArgs.ErrorCode))),
-                new(OpCodes.Stfld, Field(typeof(RagdollAbilityBase<ZombieRole>), nameof(RagdollAbilityBase<ZombieRole>._errorCode))),
-
-                new CodeInstruction(OpCodes.Nop).WithLabels(cnt),
+                new(OpCodes.Ret),
             });
 
             foreach (var instruction in newInstructions)


### PR DESCRIPTION
Scp049 resurrect ability calls zombie event.
Idk how is can be, but seems like patching generic classes is weird.
tested and confirmed by me