### PR TITLE
Added bool WasDisguised

### DIFF
--- a/Exiled.API/Features/Roles/Scp3114Role.cs
+++ b/Exiled.API/Features/Roles/Scp3114Role.cs
@@ -233,6 +233,5 @@ namespace Exiled.API.Features.Roles
         /// <param name="alreadySpawned">The List of Roles already spawned.</param>
         /// <returns>The Spawn Chance.</returns>
         public float GetSpawnChance(List<RoleTypeId> alreadySpawned) => Base is ISpawnableScp spawnableScp ? spawnableScp.GetSpawnChance(alreadySpawned) : 0;
-        halloween-2023
     }
 }

--- a/Exiled.API/Features/Roles/Scp3114Role.cs
+++ b/Exiled.API/Features/Roles/Scp3114Role.cs
@@ -223,5 +223,14 @@ namespace Exiled.API.Features.Roles
         /// <param name="alreadySpawned">The List of Roles already spawned.</param>
         /// <returns>The Spawn Chance.</returns>
         public float GetSpawnChance(List<RoleTypeId> alreadySpawned) => 0;
+
+        /// <summary>
+        /// Gets or sets wasDisguised boolean.
+        /// </summary>
+        public bool WasDisguised
+        {
+            get => Identity._wasDisguised;
+            set => Identity._wasDisguised = value;
+        }
     }
 }


### PR DESCRIPTION
This has been tested.

.wasDisguised is used a bit throughout the 3114-identity class. Which controls if he can/cannot attack, if he is able to remove his disguise, and activates/devastates voicelines for 3114