### PR TITLE
`[Exiled::Events]` (Addition) `EventExceptionLogger` to capture event exceptions.

### DIFF
--- a/Exiled.Events/Features/Event.cs
+++ b/Exiled.Events/Features/Event.cs
@@ -109,7 +109,7 @@ namespace Exiled.Events.Features
                 }
                 catch (Exception ex)
                 {
-                    Log.Error($"Method \"{handler.Method.Name}\" of the class \"{handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
+                    EventExceptionLogger.CaptureException(ex, GetType().FullName, handler.Method);
                 }
             }
         }

--- a/Exiled.Events/Features/EventExceptionLogger.cs
+++ b/Exiled.Events/Features/EventExceptionLogger.cs
@@ -1,0 +1,31 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="EventExceptionLogger.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Features
+{
+    using System;
+    using System.Reflection;
+
+    using Exiled.API.Features;
+
+    /// <summary>
+    /// A class that logs exceptions that occur when handling events.
+    /// </summary>
+    public static class EventExceptionLogger
+    {
+        /// <summary>
+        /// Logs an exception that occurred when handling an event.
+        /// </summary>
+        /// <param name="ex">The exception that occurred.</param>
+        /// <param name="eventName">The name of the event.</param>
+        /// <param name="method">The method that caused the exception.</param>
+        public static void CaptureException(Exception ex, string eventName, MethodInfo method)
+        {
+            Log.Error($"Method \"{method.Name}\" of the class \"{method.ReflectedType.FullName}\" caused an exception when handling the event \"{eventName}\"\n{ex}");
+        }
+    }
+}

--- a/Exiled.Events/Features/Event{T}.cs
+++ b/Exiled.Events/Features/Event{T}.cs
@@ -114,7 +114,7 @@ namespace Exiled.Events.Features
                 }
                 catch (Exception ex)
                 {
-                    Log.Error($"Method \"{handler.Method.Name}\" of the class \"{handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
+                    EventExceptionLogger.CaptureException(ex, GetType().FullName, handler.Method);
                 }
             }
         }


### PR DESCRIPTION
the same as #2183 but for dev branch
> No breaking changes.
>
> I extracted error logging from Exiled.Events.Features.Event.InvokeSafely() into a separate public static class.
>
> This can be useful for patching, logging errors not only to the console but also to services like Sentry, Hawk, DataDog, or any other destination of choice.