### PR TITLE
Fix NRE

### DIFF
--- a/Exiled.Events/Patches/Fixes/FixNWDestroyItem.cs
+++ b/Exiled.Events/Patches/Fixes/FixNWDestroyItem.cs
@@ -1,0 +1,60 @@
+// -----------------------------------------------------------------------
+// <copyright file="FixNWDestroyItem.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Fixes
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection.Emit;
+
+    using API.Features.Pools;
+    using Footprinting;
+    using HarmonyLib;
+    using InventorySystem;
+    using InventorySystem.Items.Firearms.Ammo;
+    using InventorySystem.Items.Pickups;
+    using VoiceChat;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    /// Patches <see cref="Inventory.DestroyItemInstance(ushort, ItemPickupBase, out InventorySystem.Items.ItemBase)"/> delegate.
+    /// Fix than NW give a NRE because of GameObject being null.
+    /// </summary>
+    [HarmonyPatch(typeof(Inventory), nameof(Inventory.DestroyItemInstance))]
+    internal class FixNWDestroyItem
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
+
+            Label retLabel = generator.DefineLabel();
+
+            const int offset = -4;
+            int index = newInstructions.FindLastIndex(instruction => instruction.Calls(Method(typeof(UnityEngine.Object), nameof(UnityEngine.Object.Destroy), new System.Type[] { typeof(UnityEngine.Object), }))) + offset;
+
+            newInstructions.InsertRange(
+                index,
+                new CodeInstruction[]
+                {
+                    // if (pickup == null) return false;
+                    new CodeInstruction(OpCodes.Ldarg_3).MoveLabelsFrom(newInstructions[index]),
+                    new(OpCodes.Ldind_Ref),
+                    new(OpCodes.Ldnull),
+                    new(OpCodes.Call, Method(typeof(UnityEngine.Object), "op_Equality", new System.Type[] { typeof(UnityEngine.Object), typeof(UnityEngine.Object), })),
+                    new(OpCodes.Brtrue_S, retLabel),
+                });
+
+            newInstructions[newInstructions.FindIndex(x => x.opcode == OpCodes.Ret) - 1].labels.Add(retLabel);
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Pool.Return(newInstructions);
+        }
+    }
+}


### PR DESCRIPTION
```[2023-11-18 18:58:43.183 +00:00] [ERROR] [Exiled.API] Method "OnChangingRole" of the class "Exiled.Events.Handlers.Internal.Round" caused an exception when handling the event "Exiled.Events.Features.Event`1[[Exiled.Events.EventArgs.Player.ChangingRoleEventArgs, Exiled.Events, Version=8.4.1.0, Culture=neutral, PublicKeyToken=null]]"
                                 System.NullReferenceException
                                   at (wrapper managed-to-native) UnityEngine.Component.get_gameObject(UnityEngine.Component)
                                   at InventorySystem.Inventory.DestroyItemInstance (System.UInt16 targetInstance, InventorySystem.Items.Pickups.ItemPickupBase pickup, InventorySystem.Items.ItemBase& foundItem) [0x00034] in <30e436d80b42480193d332dace60c092>:0
                                   at (wrapper dynamic-method) InventorySystem.InventoryExtensions.InventorySystem.InventoryExtensions.ServerRemoveItem_Patch0(InventorySystem.Inventory,uint16,InventorySystem.Items.Pickups.ItemPickupBase)
                                   at InventorySystem.Items.ItemBase.ServerDropItem () [0x00061] in <30e436d80b42480193d332dace60c092>:0
                                   at InventorySystem.InventoryExtensions.ServerDropItem (InventorySystem.Inventory inv, System.UInt16 itemSerial) [0x00017] in <30e436d80b42480193d332dace60c092>:0
                                   at InventorySystem.InventoryExtensions.ServerDropEverything (InventorySystem.Inventory inv) [0x000be] in <30e436d80b42480193d332dace60c092>:0
                                   at Exiled.Events.Handlers.Internal.Round.OnChangingRole (Exiled.Events.EventArgs.Player.ChangingRoleEventArgs ev) [0x0003b] in <78e1995e2d3040c28fde968e4a52021a>:0
                                   at Exiled.Events.Features.Event`1[T].InvokeSafely (T arg) [0x00028] in <78e1995e2d3040c28fde968e4a52021a>:0```