### PR TITLE
SearchingPickupEventArgs::SearchTime setter 'fix'

### DIFF
--- a/Exiled.Events/EventArgs/Player/SearchingPickupEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/SearchingPickupEventArgs.cs
@@ -7,10 +7,11 @@
 
 namespace Exiled.Events.EventArgs.Player
 {
+    using System;
+
     using Exiled.API.Features;
     using Exiled.API.Features.Pickups;
     using Exiled.Events.EventArgs.Interfaces;
-
     using InventorySystem.Items.Pickups;
     using InventorySystem.Searching;
 
@@ -43,7 +44,9 @@ namespace Exiled.Events.EventArgs.Player
             Pickup = Pickup.Get(pickup);
             SearchSession = searchSession;
             SearchCompletor = searchCompletor;
+#pragma warning disable CS0618 // Type or member is obsolete
             SearchTime = searchTime;
+#pragma warning restore CS0618 // Type or member is obsolete
             IsAllowed = searchCompletor.ValidateStart();
         }
 
@@ -60,7 +63,12 @@ namespace Exiled.Events.EventArgs.Player
         /// <summary>
         /// Gets or sets the Pickup search duration.
         /// </summary>
-        public float SearchTime { get; set; }
+        public float SearchTime
+        {
+            get;
+            [Obsolete("Setter is deprecated and doing nothing.")]
+            set;
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether the Pickup can be searched.

--- a/Exiled.Events/EventArgs/Player/SearchingPickupEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/SearchingPickupEventArgs.cs
@@ -63,6 +63,7 @@ namespace Exiled.Events.EventArgs.Player
         /// <summary>
         /// Gets or sets the Pickup search duration.
         /// </summary>
+        /// <remarks>Setter is deprecated.</remarks>
         public float SearchTime
         {
             get;

--- a/Exiled.Events/Patches/Events/Player/SearchingPickupEvent.cs
+++ b/Exiled.Events/Patches/Events/Player/SearchingPickupEvent.cs
@@ -113,21 +113,6 @@ namespace Exiled.Events.Patches.Events.Player
                     new(OpCodes.Stloc_1),
                 });
 
-            offset = -5;
-            index = newInstructions.FindIndex(i => i.opcode == OpCodes.Stloc_S && i.operand is LocalBuilder { LocalIndex: 4 }) + offset;
-
-            // remove base-game SearchTime setter
-            newInstructions.RemoveRange(index, 5);
-
-            newInstructions.InsertRange(
-                index,
-                new[]
-                {
-                    // num3 = ev.SearchTime
-                    new CodeInstruction(OpCodes.Ldloc_S, ev.LocalIndex),
-                    new(OpCodes.Callvirt, PropertyGetter(typeof(SearchingPickupEventArgs), nameof(SearchingPickupEventArgs.SearchTime))),
-                });
-
             for (int z = 0; z < newInstructions.Count; z++)
                 yield return newInstructions[z];
 


### PR DESCRIPTION
Seems that setter is no more working. It's changins actual value but it doesn't affect anything. Also, as said in #2324, there is a NWAPI event that allows to change that but I've not found event that would do that.
So I think the only way to "fix" it - deprecate it