### PR TITLE
Add doc, Fix bug, code simplification

### DIFF
--- a/Exiled.API/Features/Core/EObject.cs
+++ b/Exiled.API/Features/Core/EObject.cs
@@ -322,7 +322,7 @@ namespace Exiled.API.Features.Core
         public static EObject CreateDefaultSubobject(Type type, params object[] parameters)
         {
             BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance;
-            EObject @object = Activator.CreateInstance(type, flags, null, parameters, null) is not EObject outer ? null : outer;
+            EObject @object = Activator.CreateInstance(type, flags, null, parameters, null) as EObject;
 
             // Do not use implicit bool conversion as @object may be null
             if (@object != null)

--- a/Exiled.API/Features/Core/Generic/EnumClass.cs
+++ b/Exiled.API/Features/Core/Generic/EnumClass.cs
@@ -182,7 +182,7 @@ namespace Exiled.API.Features.Core.Generic
         /// Converts the <see cref="EnumClass{TSource, TObject}"/> instance to a human-readable <see cref="string"/> representation.
         /// </summary>
         /// <returns>A human-readable <see cref="string"/> representation of the <see cref="EnumClass{TSource, TObject}"/> instance.</returns>
-        public override string ToString() => name;
+        public override string ToString() => Name;
 
         /// <summary>
         /// Determines whether the specified object is equal to the current object.

--- a/Exiled.API/Features/Core/Generic/UnmanagedEnumClass.cs
+++ b/Exiled.API/Features/Core/Generic/UnmanagedEnumClass.cs
@@ -204,7 +204,7 @@ namespace Exiled.API.Features.Core.Generic
         /// Converts the <see cref="UnmanagedEnumClass{TSource, TObject}"/> instance to a human-readable <see cref="string"/> representation.
         /// </summary>
         /// <returns>A human-readable <see cref="string"/> representation of the <see cref="UnmanagedEnumClass{TSource, TObject}"/> instance.</returns>
-        public override string ToString() => name;
+        public override string ToString() => Name;
 
         /// <summary>
         /// Determines whether the specified object is equal to the current object.

--- a/Exiled.API/Features/Core/StaticActor.cs
+++ b/Exiled.API/Features/Core/StaticActor.cs
@@ -42,6 +42,11 @@ namespace Exiled.API.Features.Core
         /// </summary>
         public bool IsDestroyed { get; private set; }
 
+        /// <inheritdoc cref="CreateNewInstance"/>
+        /// <typeparam name="T"><inheritdoc path="/param[@name='type']" cref="CreateNewInstance"/></typeparam>
+        public static StaticActor CreateNewInstance<T>()
+            where T : new() => CreateNewInstance(typeof(T));
+
         /// <summary>
         /// Creates a new instance of the <see cref="StaticActor"/>.
         /// </summary>
@@ -60,7 +65,7 @@ namespace Exiled.API.Features.Core
         /// <typeparam name="T">The type of the <see cref="StaticActor"/> to look for.</typeparam>
         /// <returns>The corresponding <see cref="StaticActor"/>, or <see langword="null"/> if not found.</returns>
         public static T Get<T>()
-            where T : StaticActor
+            where T : StaticActor, new()
         {
             foreach (StaticActor actor in FindActiveObjectsOfType<StaticActor>())
             {
@@ -70,7 +75,7 @@ namespace Exiled.API.Features.Core
                 return actor.Cast<T>();
             }
 
-            return CreateNewInstance(typeof(T)).Cast<T>();
+            return CreateNewInstance<T>().Cast<T>();
         }
 
         /// <summary>

--- a/Exiled.API/Features/Core/TickComponent.cs
+++ b/Exiled.API/Features/Core/TickComponent.cs
@@ -21,7 +21,7 @@ namespace Exiled.API.Features.Core
     public sealed class TickComponent : EObject
     {
         /// <summary>
-        /// The default fixed tick rate.
+        /// The default fixed tick rate (60 per second).
         /// </summary>
         public const float DefaultFixedTickRate = 0.016f;
 

--- a/Exiled.API/Features/Core/TypeCastMono.cs
+++ b/Exiled.API/Features/Core/TypeCastMono.cs
@@ -26,16 +26,17 @@ namespace Exiled.API.Features.Core
 
         /// <inheritdoc/>
         public TObject Cast<TObject>()
-            where TObject : class, T => this as T as TObject;
+            where TObject : class, T => this as TObject;
 
         /// <inheritdoc/>
         public bool Cast<TObject>(out TObject param)
             where TObject : class, T
         {
-            param = default;
-
-            if (this as TObject is not TObject cast)
+            if (this is not TObject cast)
+            {
+                param = default;
                 return false;
+            }
 
             param = cast;
             return true;

--- a/Exiled.API/Features/Core/TypeCastObject.cs
+++ b/Exiled.API/Features/Core/TypeCastObject.cs
@@ -25,7 +25,7 @@ namespace Exiled.API.Features.Core
 
         /// <inheritdoc/>
         public TObject Cast<TObject>()
-            where TObject : class, T => this as T as TObject;
+            where TObject : class, T => this as TObject;
 
         /// <inheritdoc/>
         public bool Cast<TObject>(out TObject param)
@@ -33,7 +33,7 @@ namespace Exiled.API.Features.Core
         {
             param = default;
 
-            if (this as TObject is not TObject cast)
+            if (this is not TObject cast)
                 return false;
 
             param = cast;

--- a/Exiled.API/Features/Core/TypeCastObject.cs
+++ b/Exiled.API/Features/Core/TypeCastObject.cs
@@ -31,10 +31,11 @@ namespace Exiled.API.Features.Core
         public bool Cast<TObject>(out TObject param)
             where TObject : class, T
         {
-            param = default;
-
             if (this is not TObject cast)
+            {
+                param = default;
                 return false;
+            }
 
             param = cast;
             return true;


### PR DESCRIPTION
Unnecessary caste removal
`this as T as TObject` to `this as TObject` because TObject is a superclass of T or T.
 `is not EObject outer ? null : outer ` to  ` as EObject  `.
 
Fix usage of non init field
`ToString() => name`  to `ToString() => Name` because `name` is init after the first call of `Name`.

New method
```cs
public static StaticActor CreateNewInstance<T>()
            where T : new() => CreateNewInstance(typeof(T));
```
To ensures that there is a (public) constructor to avoid cases where the type has no constructor. It is still possible to use Get even in the case of a privet constructor if we use T Get<T>(Type type). The advantage of this modification allows future optimization of the code if necessary
