### PR TITLE
Fix nuget

### DIFF
--- a/.github/workflows/push_nuget.yml
+++ b/.github/workflows/push_nuget.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  EXILED_REFERENCES_URL: https://misaka-zerotwo.github.io/SL-References/Master.zip
+  EXILED_REFERENCES_URL: https://misaka-zerotwo.github.io/SL-References/Dev.zip
   EXILED_REFERENCES_PATH: ${{ github.workspace }}/References
 
 jobs:


### PR DESCRIPTION
Most errors in building nuget caused by namespace error, I think that changing reference to dev won’t affect anything but will fix this