### PR TITLE
Removed SpawnReason::Vocalize

### DIFF
--- a/Exiled.API/Enums/SpawnReason.cs
+++ b/Exiled.API/Enums/SpawnReason.cs
@@ -61,10 +61,5 @@ namespace Exiled.API.Enums
         /// The player was spawned due to the usage of an item.
         /// </summary>
         ItemUsage,
-
-        /// <summary>
-        /// The player was revived by SCP-1507.
-        /// </summary>
-        Vocalize,
     }
 }


### PR DESCRIPTION
They pointed out to me that nw doesn't use "Vocalize" but uses "Revived"