### PR TITLE
`[Exiled::API]` EnumClasses fix

### DIFF
--- a/Exiled.API/Features/Core/Generic/EnumClass.cs
+++ b/Exiled.API/Features/Core/Generic/EnumClass.cs
@@ -13,7 +13,7 @@ namespace Exiled.API.Features.Core.Generic
     using System.Reflection;
 
     using Exiled.API.Features.Core.Generic.Pools;
-
+    using Exiled.API.Interfaces;
     using LiteNetLib.Utils;
 
     /// <summary>
@@ -22,7 +22,7 @@ namespace Exiled.API.Features.Core.Generic
     /// </summary>
     /// <typeparam name="TSource">The type of the source object to handle the instance of.</typeparam>
     /// <typeparam name="TObject">The type of the child object to handle the instance of.</typeparam>
-    public abstract class EnumClass<TSource, TObject> : IComparable, IEquatable<TObject>, IComparable<TObject>, IComparer<TObject>
+    public abstract class EnumClass<TSource, TObject> : IComparable, IEquatable<TObject>, IComparable<TObject>, IComparer<TObject>, IEnumClass
         where TSource : Enum
         where TObject : EnumClass<TSource, TObject>
     {

--- a/Exiled.API/Features/Core/Generic/UniqueUnmanagedEnumClass.cs
+++ b/Exiled.API/Features/Core/Generic/UniqueUnmanagedEnumClass.cs
@@ -13,7 +13,7 @@ namespace Exiled.API.Features.Core.Generic
     using System.Reflection;
 
     using Exiled.API.Features.Core.Generic.Pools;
-
+    using Exiled.API.Interfaces;
     using LiteNetLib.Utils;
 
     /// <summary>
@@ -22,7 +22,7 @@ namespace Exiled.API.Features.Core.Generic
     /// </summary>
     /// <typeparam name="TSource">The type of the <see langword="unmanaged"/> source object to handle the instance of.</typeparam>
     /// <typeparam name="TObject">The type of the child object to handle the instance of.</typeparam>
-    public abstract class UniqueUnmanagedEnumClass<TSource, TObject> : IComparable, IEquatable<TObject>, IComparable<TObject>, IComparer<TObject>, IConvertible
+    public abstract class UniqueUnmanagedEnumClass<TSource, TObject> : IComparable, IEquatable<TObject>, IComparable<TObject>, IComparer<TObject>, IConvertible, IEnumClass
         where TSource : unmanaged, IComparable, IFormattable, IConvertible, IComparable<TSource>, IEquatable<TSource>
         where TObject : UniqueUnmanagedEnumClass<TSource, TObject>
     {

--- a/Exiled.API/Features/Core/Generic/UnmanagedEnumClass.cs
+++ b/Exiled.API/Features/Core/Generic/UnmanagedEnumClass.cs
@@ -13,7 +13,7 @@ namespace Exiled.API.Features.Core.Generic
     using System.Reflection;
 
     using Exiled.API.Features.Core.Generic.Pools;
-
+    using Exiled.API.Interfaces;
     using LiteNetLib.Utils;
 
     /// <summary>
@@ -22,7 +22,7 @@ namespace Exiled.API.Features.Core.Generic
     /// </summary>
     /// <typeparam name="TSource">The type of the <see langword="unmanaged"/> source object to handle the instance of.</typeparam>
     /// <typeparam name="TObject">The type of the child object to handle the instance of.</typeparam>
-    public abstract class UnmanagedEnumClass<TSource, TObject> : IComparable, IEquatable<TObject>, IComparable<TObject>, IComparer<TObject>, IConvertible
+    public abstract class UnmanagedEnumClass<TSource, TObject> : IComparable, IEquatable<TObject>, IComparable<TObject>, IComparer<TObject>, IConvertible, IEnumClass
         where TSource : unmanaged, IComparable, IFormattable, IConvertible, IComparable<TSource>, IEquatable<TSource>
         where TObject : UnmanagedEnumClass<TSource, TObject>
     {

--- a/Exiled.API/Interfaces/IEnumClass.cs
+++ b/Exiled.API/Interfaces/IEnumClass.cs
@@ -1,7 +1,14 @@
-﻿namespace Exiled.API.Interfaces
+﻿// -----------------------------------------------------------------------
+// <copyright file="IEnumClass.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Interfaces
 {
     /// <summary>
-    /// An interface for.
+    /// An interface for all enum classes.
     /// </summary>
     public interface IEnumClass
     {

--- a/Exiled.API/Interfaces/IEnumClass.cs
+++ b/Exiled.API/Interfaces/IEnumClass.cs
@@ -1,0 +1,9 @@
+﻿namespace Exiled.API.Interfaces
+{
+    /// <summary>
+    /// An interface for.
+    /// </summary>
+    public interface IEnumClass
+    {
+    }
+}

--- a/Exiled.Events/Events.cs
+++ b/Exiled.Events/Events.cs
@@ -9,10 +9,13 @@ namespace Exiled.Events
 {
     using System;
     using System.Diagnostics;
+    using System.Linq;
+    using System.Reflection;
 
     using API.Enums;
     using API.Features;
     using CentralAuth;
+    using Exiled.API.Interfaces;
     using Exiled.Events.Features;
     using HarmonyLib;
     using InventorySystem.Items.Pickups;
@@ -83,6 +86,19 @@ namespace Exiled.Events
             ServerConsole.ReloadServerName();
 
             EventManager.RegisterEvents<Handlers.Player>(this);
+
+            foreach (Type type in typeof(IEnumClass).Assembly.GetTypes().Where(x => x.GetInterface(nameof(IEnumClass)) == typeof(IEnumClass)))
+            {
+                FieldInfo[] fieldInfos = type.GetFields();
+
+                if (fieldInfos.All(x => !x.IsInitOnly))
+                    continue;
+
+                foreach (FieldInfo field in fieldInfos.Where(x => x.IsStatic))
+                {
+                    field.GetValue(null);
+                }
+            }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
One of a variants of fixes.
Getting a values from all enum classes to fill values collections so no more NRE.