### PR TITLE
Fix typo in Split.cs

### DIFF
--- a/Exiled.Events/Commands/Config/Split.cs
+++ b/Exiled.Events/Commands/Config/Split.cs
@@ -50,7 +50,7 @@ namespace Exiled.Events.Commands.Config
             bool haveBeenSaved = ConfigManager.Save(configs);
             PluginAPI.Loader.AssemblyLoader.InstalledPlugins.FirstOrDefault(x => x.PluginName == "Exiled Loader")?.SaveConfig(new LoaderPlugin(), nameof(LoaderPlugin.Config));
 
-            response = $"Configs have been merged successfully! Feel free to remove the file in the following path:\n\"{Paths.Config}\"";
+            response = $"Configs have been split successfully! Feel free to remove the file in the following path:\n\"{Paths.Config}\"";
             return haveBeenSaved;
         }
     }


### PR DESCRIPTION
this was not tested. if it breaks the entirety of exiled I am not responsible. be very very careful.