### PR TITLE
`[Exiled::Events]` (`Bug fix`) Scp173Gate can't be closed when using InteractingDoor event `[Exiled::API]` (`Bug fix`) Fix Scp173Gate IsFullyOpen always return false

### DIFF
--- a/Exiled.API/Features/Doors/Door.cs
+++ b/Exiled.API/Features/Doors/Door.cs
@@ -102,12 +102,12 @@ namespace Exiled.API.Features.Doors
         /// <summary>
         /// Gets a value indicating whether the door is fully open.
         /// </summary>
-        public virtual bool IsFullyOpen => ExactState is 1;
+        public virtual bool IsFullyOpen => ExactState is 1 || (Base is Timed173PryableDoor && ExactState is 0.5845918f);
 
         /// <summary>
         /// Gets a value indicating whether or not the door is currently moving.
         /// </summary>
-        public virtual bool IsMoving => ExactState is not(0 or 1);
+        public virtual bool IsMoving => !(IsFullyOpen || IsFullyClosed);
 
         /// <summary>
         /// Gets a value indicating the precise state of the door, from <c>0-1</c>. A value of <c>0</c> indicates the door is fully closed, while a value of <c>1</c> indicates the door is fully open. Values in-between represent the door's animation progress.

--- a/Exiled.API/Features/Doors/Door.cs
+++ b/Exiled.API/Features/Doors/Door.cs
@@ -102,7 +102,7 @@ namespace Exiled.API.Features.Doors
         /// <summary>
         /// Gets a value indicating whether the door is fully open.
         /// </summary>
-        public virtual bool IsFullyOpen => ExactState is 1 || (Base is Timed173PryableDoor && ExactState is 0.5845918f);
+        public virtual bool IsFullyOpen => ExactState is 1;
 
         /// <summary>
         /// Gets a value indicating whether or not the door is currently moving.

--- a/Exiled.API/Features/Doors/Gate.cs
+++ b/Exiled.API/Features/Doors/Gate.cs
@@ -48,7 +48,7 @@ namespace Exiled.API.Features.Doors
         /// <summary>
         /// Gets a value indicating whether the door is fully open.
         /// </summary>
-        public override bool IsFullyOpen => base.IsFullyOpen;
+        public override bool IsFullyOpen => base.IsFullyOpen || (Base is Timed173PryableDoor && ExactState is 0.5845918f);
 
         /// <summary>
         /// Gets a value indicating whether or not the door is currently moving.

--- a/Exiled.Events/Patches/Events/Player/InteractingDoor.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingDoor.cs
@@ -44,10 +44,6 @@ namespace Exiled.Events.Patches.Events.Player
                 0,
                 new CodeInstruction[]
                 {
-                    new(OpCodes.Ldarg_0),
-                    new(OpCodes.Call, Method(typeof(InteractingDoor), nameof(InteractingDoor.CanStateChange))),
-                    new(OpCodes.Brfalse_S, retLabel),
-
                     // InteractingDoorEventArgs ev = new(Player.Get(ply), __instance, false);
                     new(OpCodes.Ldarg_1),
                     new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
@@ -114,11 +110,6 @@ namespace Exiled.Events.Patches.Events.Player
                 yield return newInstructions[z];
 
             ListPool<CodeInstruction>.Pool.Return(newInstructions);
-        }
-
-        private static bool CanStateChange(DoorVariant variant)
-        {
-            return !(variant.GetExactState() > 0f && variant.GetExactState() < 1f);
         }
     }
 }


### PR DESCRIPTION
Removing these lines doesn't make the console spam (verified)
Also, with the patch, it doesn't work because when Scp173Gate is fully open, door.GetExactState() return 0.5845918