### PR TITLE
`[Exiled::API]` `UniqueUnmanagedEnumClass` fix

### DIFF
--- a/Exiled.API/Features/Core/Generic/UniqueUnmanagedEnumClass.cs
+++ b/Exiled.API/Features/Core/Generic/UniqueUnmanagedEnumClass.cs
@@ -38,13 +38,17 @@ namespace Exiled.API.Features.Core.Generic
         public UniqueUnmanagedEnumClass()
         {
             values ??= new();
+            TypeCode code = Convert.GetTypeCode(typeof(TSource).GetField("MinValue").GetValue(null));
+
+            if (code is TypeCode.UInt16 or TypeCode.UInt32 or TypeCode.UInt64)
+                nextValue = 0;
 
             lock (values)
             {
                 TSource value;
                 do
                 {
-                    value = (TSource)(object)nextValue++;
+                    value = (TSource)Convert.ChangeType(nextValue++, code);
                 }
                 while (values.ContainsKey(value));
 


### PR DESCRIPTION
Yeah, main problem was that we casted uint to int.
Tested on UUE, that are presented in exiled.