### PR TITLE
`[Exiled::Permissions]` New features and methods

### DIFF
--- a/Exiled.Permissions/Features/Group.cs
+++ b/Exiled.Permissions/Features/Group.cs
@@ -33,9 +33,20 @@ namespace Exiled.Permissions.Features
         public List<string> Permissions { get; set; } = new();
 
         /// <summary>
+        /// Gets or sets disabled for the group permissions.
+        /// </summary>
+        public List<string> DisabledPermissions { get; set; } = new();
+
+        /// <summary>
         /// Gets the combined permissions of the group plus all inherited groups.
         /// </summary>
         [YamlIgnore]
         public List<string> CombinedPermissions { get; internal set; } = new();
+
+        /// <summary>
+        /// Gets the combined disabled permissions of the group plus all inherited groups.
+        /// </summary>
+        [YamlIgnore]
+        public List<string> CombinedDisabledPermissions { get; internal set; } = new();
     }
 }


### PR DESCRIPTION
1. Added a `DisabledPermissions` so new you can specify permissions that will be reworked from user event when group has a full perm.
2. Added a new overloads for a check permission methods with `out response` param.

Not tested. If it needed, I'll try it a little bit later cuz im on Mac now.