### PR TITLE
`[Exiled::API]` NRE when getting MovementSpeedMultiplier

### DIFF
--- a/Exiled.API/Features/Pickups/BodyArmorPickup.cs
+++ b/Exiled.API/Features/Pickups/BodyArmorPickup.cs
@@ -143,7 +143,7 @@ namespace Exiled.API.Features.Pickups
                 StaminaUseMultiplier = armoritem._staminaUseMultiplier;
                 AmmoLimits = armoritem.AmmoLimits.Select(limit => (ArmorAmmoLimit)limit);
                 CategoryLimits = armoritem.CategoryLimits;
-                MovementSpeedMultiplier = armoritem.MovementSpeedMultiplier;
+                MovementSpeedMultiplier = armoritem._movementSpeedMultiplier;
             }
         }
     }


### PR DESCRIPTION
There's an NRE cause `BodyArmor::MovementSpeedMultiplier` calls `BodyArmor::ProcessMultiplier()` which change the value according to the player's team, which is null when the item is initialized