### PR TITLE
Update CommonExtensions.GetRandomValue<T>(this IEnumerable<T> enumerable)

### DIFF
--- a/Exiled.API/Extensions/CommonExtensions.cs
+++ b/Exiled.API/Extensions/CommonExtensions.cs
@@ -25,10 +25,19 @@ namespace Exiled.API.Extensions
         /// <returns>Returns a random value from <see cref="IEnumerable{T}"/>.</returns>
         public static T GetRandomValue<T>(this IEnumerable<T> enumerable)
         {
-            if (enumerable?.ToArray() is not { Length: > 0 } arr)
-                return default;
-            else
-                return arr[Random.Range(0, arr.Length)];
+            T current = default;
+            int count = 0;
+
+            foreach (T element in enumerable)
+            {
+                count++;
+                if (Random.Range(0, count) == 0)
+                {
+                    current = element;
+                }
+            }
+
+            return current;
         }
 
         /// <summary>

--- a/Exiled.API/Extensions/CommonExtensions.cs
+++ b/Exiled.API/Extensions/CommonExtensions.cs
@@ -23,7 +23,13 @@ namespace Exiled.API.Extensions
         /// <param name="enumerable"><see cref="IEnumerable{T}"/> to be used to get a random value.</param>
         /// <typeparam name="T">Type of <see cref="IEnumerable{T}"/> elements.</typeparam>
         /// <returns>Returns a random value from <see cref="IEnumerable{T}"/>.</returns>
-        public static T GetRandomValue<T>(this IEnumerable<T> enumerable) => enumerable is null || enumerable.Count() == 0 ? default : enumerable.ElementAt(Random.Range(0, enumerable.Count()));
+        public static T GetRandomValue<T>(this IEnumerable<T> enumerable)
+        {
+            if (enumerable?.ToArray() is not { Length: > 0 } arr)
+                return default;
+            else
+                return arr[Random.Range(0, arr.Length)];
+        }
 
         /// <summary>
         /// Gets a random value from an <see cref="IEnumerable{T}"/> that matches the provided condition.


### PR DESCRIPTION
Probably fixed ArgumentOutOfRangeException bug, now avoids multiple enumeration
Related bug-report: https://discord.com/channels/656673194693885975/1249394171140247693