### PR TITLE
CommonExtensions.GetRandomValue

### DIFF
--- a/Exiled.API/Extensions/CommonExtensions.cs
+++ b/Exiled.API/Extensions/CommonExtensions.cs
@@ -23,7 +23,7 @@ namespace Exiled.API.Extensions
         /// <param name="enumerable"><see cref="IEnumerable{T}"/> to be used to get a random value.</param>
         /// <typeparam name="T">Type of <see cref="IEnumerable{T}"/> elements.</typeparam>
         /// <returns>Returns a random value from <see cref="IEnumerable{T}"/>.</returns>
-        public static T GetRandomValue<T>(IEnumerable<T> enumerable)
+        public static T GetRandomValue<T>(this IEnumerable<T> enumerable)
         {
             if (enumerable is null)
                 return default;
@@ -39,7 +39,7 @@ namespace Exiled.API.Extensions
         /// <typeparam name="T">Type of <see cref="IEnumerable{T}"/> elements.</typeparam>
         /// <param name="condition">The condition to require.</param>
         /// <returns>Returns a random value from <see cref="IEnumerable{T}"/>.</returns>
-        public static T GetRandomValue<T>(IEnumerable<T> enumerable, System.Func<T, bool> condition)
+        public static T GetRandomValue<T>(this IEnumerable<T> enumerable, System.Func<T, bool> condition)
         {
             if (enumerable is null)
                 return default;

--- a/Exiled.API/Extensions/CommonExtensions.cs
+++ b/Exiled.API/Extensions/CommonExtensions.cs
@@ -43,7 +43,7 @@ namespace Exiled.API.Extensions
         {
             if (enumerable is null)
                 return default;
-            
+
             T[] array = enumerable.Where(condition).ToArray();
             return array.Length == 0 ? default : array.GetRandomValue();
         }

--- a/Exiled.API/Extensions/CommonExtensions.cs
+++ b/Exiled.API/Extensions/CommonExtensions.cs
@@ -23,7 +23,14 @@ namespace Exiled.API.Extensions
         /// <param name="enumerable"><see cref="IEnumerable{T}"/> to be used to get a random value.</param>
         /// <typeparam name="T">Type of <see cref="IEnumerable{T}"/> elements.</typeparam>
         /// <returns>Returns a random value from <see cref="IEnumerable{T}"/>.</returns>
-        public static T GetRandomValue<T>(this IEnumerable<T> enumerable) => enumerable is null || enumerable.Count() == 0 ? default : enumerable.ElementAt(Random.Range(0, enumerable.Count()));
+        public static T GetRandomValue<T>(IEnumerable<T> enumerable)
+        {
+            if (enumerable is null)
+                return default;
+            
+            T[] array = enumerable.ToArray();
+            return array.Length == 0 ? default : array[Random.Range(0, array.Length)];
+        }
 
         /// <summary>
         /// Gets a random value from an <see cref="IEnumerable{T}"/> that matches the provided condition.
@@ -32,7 +39,14 @@ namespace Exiled.API.Extensions
         /// <typeparam name="T">Type of <see cref="IEnumerable{T}"/> elements.</typeparam>
         /// <param name="condition">The condition to require.</param>
         /// <returns>Returns a random value from <see cref="IEnumerable{T}"/>.</returns>
-        public static T GetRandomValue<T>(this IEnumerable<T> enumerable, System.Func<T, bool> condition) => enumerable is null || enumerable.Count() == 0 ? default : enumerable.Where(condition).GetRandomValue();
+        public static T GetRandomValue<T>(IEnumerable<T> enumerable, Func<T, bool> condition)
+        {
+            if (enumerable is null)
+                return default;
+            
+            T[] array = enumerable.Where(condition).ToArray();
+            return array.Length == 0 ? default : array.GetRandomValue();
+        }
 
         /// <summary>
         /// Modify the curve with the amount used.

--- a/Exiled.API/Extensions/CommonExtensions.cs
+++ b/Exiled.API/Extensions/CommonExtensions.cs
@@ -27,7 +27,7 @@ namespace Exiled.API.Extensions
         {
             if (enumerable is null)
                 return default;
-            
+
             T[] array = enumerable.ToArray();
             return array.Length == 0 ? default : array[Random.Range(0, array.Length)];
         }

--- a/Exiled.API/Extensions/CommonExtensions.cs
+++ b/Exiled.API/Extensions/CommonExtensions.cs
@@ -39,7 +39,7 @@ namespace Exiled.API.Extensions
         /// <typeparam name="T">Type of <see cref="IEnumerable{T}"/> elements.</typeparam>
         /// <param name="condition">The condition to require.</param>
         /// <returns>Returns a random value from <see cref="IEnumerable{T}"/>.</returns>
-        public static T GetRandomValue<T>(IEnumerable<T> enumerable, Func<T, bool> condition)
+        public static T GetRandomValue<T>(IEnumerable<T> enumerable, System.Func<T, bool> condition)
         {
             if (enumerable is null)
                 return default;


### PR DESCRIPTION
IEnumerable values can change when reiterated, meaning that if we use a random prompt for the condition, the enumerable will change giving a different length in the time of making a random value.

Meaning that for example:
```
int[] t = [1,2,3]
t.GetRandomValue(x => Random.value < 0.1);
```

will throw an exception.

This PR basically avoids multiple enumeration by first converting the IEnumerable to an array.