### PR TITLE
Fix NRE while loading

### DIFF
--- a/Exiled.Loader/LoaderPlugin.cs
+++ b/Exiled.Loader/LoaderPlugin.cs
@@ -38,6 +38,12 @@ namespace Exiled.Loader
         [PluginPriority(byte.MinValue)]
         public void Enable()
         {
+            if (Config == null)
+            {
+                Log.Error("Loader's config is null. EXILED won't be loaded. Please check your config.");
+                return;
+            }
+
             if (!Config.IsEnabled)
             {
                 Log.Info("EXILED is disabled on this server via config.");


### PR DESCRIPTION
Most of the time NRE happens when config is not correct (no exceptions from plugin api lol)