### PR TITLE
CustomItemsUnhold & CustomItemsHolded

### DIFF
--- a/Exiled.CustomModules/API/Features/CustomItems/CustomItem.cs
+++ b/Exiled.CustomModules/API/Features/CustomItems/CustomItem.cs
@@ -64,12 +64,12 @@ namespace Exiled.CustomModules.API.Features.CustomItems
         /// <summary>
         /// Gets all pickups belonging to a <see cref="CustomItem"/>.
         /// </summary>
-        public static HashSet<Pickup> CustomItemsUnhold => PickupManager.Keys.ToHashSet();
+        public static IEnumerable<Pickup> CustomPickups => PickupManager.Keys.ToHashSet();
 
         /// <summary>
         /// Gets all items belonging to a <see cref="CustomItem"/>.
         /// </summary>
-        public static HashSet<Item> CustomItemsHolded => ItemManager.Keys.ToHashSet();
+        public static IEnumerable<Item> CustomItems => ItemManager.Keys;
 
         /// <summary>
         /// Gets the <see cref="CustomItem"/>'s <see cref="Type"/>.

--- a/Exiled.CustomModules/API/Features/CustomItems/CustomItem.cs
+++ b/Exiled.CustomModules/API/Features/CustomItems/CustomItem.cs
@@ -64,7 +64,7 @@ namespace Exiled.CustomModules.API.Features.CustomItems
         /// <summary>
         /// Gets all pickups belonging to a <see cref="CustomItem"/>.
         /// </summary>
-        public static IEnumerable<Pickup> CustomPickups => PickupManager.Keys.ToHashSet();
+        public static IEnumerable<Pickup> CustomPickups => PickupManager.Keys;
 
         /// <summary>
         /// Gets all items belonging to a <see cref="CustomItem"/>.


### PR DESCRIPTION
Current name is a bad one, calling .ToHashSet() every time property is accessed is heavily unoptimized, as it basicaly calls HashSet.Add for every item