### PR TITLE
`[Exiled::API]` ServerWhitelisted

### DIFF
--- a/Exiled.API/Features/Server.cs
+++ b/Exiled.API/Features/Server.cs
@@ -181,6 +181,11 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Gets the List of player currently whitelisted.
+        /// </summary>
+        public static HashSet<string> UsersWhitelisted => WhiteList.Users;
+
+        /// <summary>
         /// Gets a value indicating whether or not this server is verified.
         /// </summary>
         public static bool IsVerified => CustomNetworkManager.IsVerified;


### PR DESCRIPTION
Adds a method called `ServerWhitelisted` that lets the user get the Whitelist loaded by SL