### PR TITLE
[Resonance] Quaternion fixes

### DIFF
--- a/Exiled.API/Features/Generator.cs
+++ b/Exiled.API/Features/Generator.cs
@@ -254,9 +254,9 @@ namespace Exiled.API.Features
         /// <param name="position">The position to spawn it at.</param>
         /// <param name="rotation">The rotation to spawn it as.</param>
         /// <returns>The <see cref="Generator"/> that was spawned.</returns>
-        public static Generator Spawn(Vector3 position, Quaternion rotation = default)
+        public static Generator Spawn(Vector3 position, Quaternion? rotation = null)
         {
-            Scp079Generator generator = PrefabHelper.Spawn<Scp079Generator>(PrefabType, position, rotation);
+            Scp079Generator generator = PrefabHelper.Spawn<Scp079Generator>(PrefabType, position, rotation ?? Quaternion.identity);
             return Get(generator);
         }
 

--- a/Exiled.API/Features/Items/Item.cs
+++ b/Exiled.API/Features/Items/Item.cs
@@ -326,11 +326,11 @@ namespace Exiled.API.Features.Items
         /// <param name="rotation">The rotation of the item.</param>
         /// <param name="spawn">Whether the <see cref="Pickup"/> should be initially spawned.</param>
         /// <returns>The created <see cref="Pickup"/>.</returns>
-        public virtual Pickup CreatePickup(Vector3 position, Quaternion rotation = default, bool spawn = true)
+        public virtual Pickup CreatePickup(Vector3 position, Quaternion? rotation = null, bool spawn = true)
         {
             PickupSyncInfo info = new(Type, Weight, Serial);
 
-            ItemPickupBase ipb = InventoryExtensions.ServerCreatePickup(Base, info, position, rotation);
+            ItemPickupBase ipb = InventoryExtensions.ServerCreatePickup(Base, info, position, rotation ?? Quaternion.identity);
 
             Base.OnRemoved(ipb);
 

--- a/Exiled.API/Features/Items/Scp244.cs
+++ b/Exiled.API/Features/Items/Scp244.cs
@@ -97,11 +97,11 @@ namespace Exiled.API.Features.Items
         /// <param name="rotation">The rotation of the item.</param>
         /// <param name="spawn">Whether the <see cref="Pickup"/> should be initially spawned.</param>
         /// <returns>The created <see cref="Pickup"/>.</returns>
-        public override Pickup CreatePickup(Vector3 position, Quaternion rotation = default, bool spawn = true)
+        public override Pickup CreatePickup(Vector3 position, Quaternion? rotation = null, bool spawn = true)
         {
             PickupSyncInfo info = new(Type, Weight, Serial);
 
-            Scp244DeployablePickup ipb = (Scp244DeployablePickup)InventoryExtensions.ServerCreatePickup(Base, info, position, rotation);
+            Scp244DeployablePickup ipb = (Scp244DeployablePickup)InventoryExtensions.ServerCreatePickup(Base, info, position, rotation ?? Quaternion.identity);
 
             Base.OnRemoved(ipb);
 

--- a/Exiled.API/Features/Items/Scp330.cs
+++ b/Exiled.API/Features/Items/Scp330.cs
@@ -271,11 +271,11 @@ namespace Exiled.API.Features.Items
         /// <param name="rotation">The <see cref="Quaternion"/> rotation to give the item.</param>
         /// <param name="spawn">Whether the <see cref="Scp330Pickup"/> should be initially spawned.</param>
         /// <returns>The created <see cref="Pickup"/>.</returns>
-        public override Pickup CreatePickup(Vector3 position, Quaternion rotation = default, bool spawn = true)
+        public override Pickup CreatePickup(Vector3 position, Quaternion? rotation = null, bool spawn = true)
         {
             PickupSyncInfo info = new(Type, Weight, Serial);
 
-            InventorySystem.Items.Usables.Scp330.Scp330Pickup ipb = (InventorySystem.Items.Usables.Scp330.Scp330Pickup)InventoryExtensions.ServerCreatePickup(Base, info, position, rotation);
+            InventorySystem.Items.Usables.Scp330.Scp330Pickup ipb = (InventorySystem.Items.Usables.Scp330.Scp330Pickup)InventoryExtensions.ServerCreatePickup(Base, info, position, rotation ?? Quaternion.identity);
 
             Base.OnRemoved(ipb);
 

--- a/Exiled.API/Features/Items/Usable.cs
+++ b/Exiled.API/Features/Items/Usable.cs
@@ -115,11 +115,11 @@ namespace Exiled.API.Features.Items
         /// <param name="rotation">The rotation of the item.</param>
         /// <param name="spawn">Whether the <see cref="Pickup"/> should be initially spawned.</param>
         /// <returns>The created <see cref="Pickup"/>.</returns>
-        public override Pickup CreatePickup(Vector3 position, Quaternion rotation = default, bool spawn = true)
+        public override Pickup CreatePickup(Vector3 position, Quaternion? rotation = null, bool spawn = true)
         {
             PickupSyncInfo info = new(Type, Weight, Serial);
 
-            ItemPickupBase ipb = InventoryExtensions.ServerCreatePickup(Base, info, position, rotation);
+            ItemPickupBase ipb = InventoryExtensions.ServerCreatePickup(Base, info, position, rotation ?? Quaternion.identity);
 
             Base.OnRemoved(ipb);
 

--- a/Exiled.API/Features/Pickups/Pickup.cs
+++ b/Exiled.API/Features/Pickups/Pickup.cs
@@ -229,7 +229,7 @@ namespace Exiled.API.Features.Pickups
         /// <summary>
         /// Gets or sets the previous owner of this item.
         /// </summary>
-        /// <seealso cref="CreateAndSpawn(ItemType, Vector3, Quaternion, Player)"/>
+        /// <seealso cref="CreateAndSpawn(ItemType, Vector3, Quaternion?, Player)"/>
         public Player PreviousOwner
         {
             get => Player.Get(Base.PreviousOwner.Hub);
@@ -253,7 +253,7 @@ namespace Exiled.API.Features.Pickups
         /// <summary>
         /// Gets or sets the pickup position.
         /// </summary>
-        /// <seealso cref="CreateAndSpawn(ItemType, Vector3, Quaternion, Player)"/>
+        /// <seealso cref="CreateAndSpawn(ItemType, Vector3, Quaternion?, Player)"/>
         [EProperty(category: nameof(Pickup))]
         public override Vector3 Position
         {
@@ -274,7 +274,7 @@ namespace Exiled.API.Features.Pickups
         /// <summary>
         /// Gets or sets the pickup rotation.
         /// </summary>
-        /// <seealso cref="CreateAndSpawn(ItemType, Vector3, Quaternion, Player)"/>
+        /// <seealso cref="CreateAndSpawn(ItemType, Vector3, Quaternion?, Player)"/>
         [EProperty(category: nameof(Pickup))]
         public override Quaternion Rotation
         {
@@ -514,8 +514,8 @@ namespace Exiled.API.Features.Pickups
         /// <param name="rotation">The rotation to spawn the <see cref="Pickup"/>.</param>
         /// <param name="previousOwner">An optional previous owner of the item.</param>
         /// <returns>The <see cref="Pickup"/>. See documentation of <see cref="Create(ItemType)"/> for more information on casting.</returns>
-        /// <seealso cref="Projectile.CreateAndSpawn(Enums.ProjectileType, Vector3, Quaternion, bool, Player)"/>
-        public static Pickup CreateAndSpawn(ItemType type, Vector3 position, Quaternion rotation, Player previousOwner = null) => Create(type).Spawn(position, rotation, previousOwner);
+        /// <seealso cref="Projectile.CreateAndSpawn(Enums.ProjectileType, Vector3, Quaternion?, bool, Player)"/>
+        public static Pickup CreateAndSpawn(ItemType type, Vector3 position, Quaternion? rotation = null, Player previousOwner = null) => Create(type).Spawn(position, rotation, previousOwner);
 
         /// <summary>
         /// Returns the amount of time it will take for the provided <paramref name="player"/> to pick up this item, based on <see cref="Weight"/> and active status effects.
@@ -556,11 +556,11 @@ namespace Exiled.API.Features.Pickups
         /// <param name="rotation">The rotation to spawn the <see cref="Pickup"/>.</param>
         /// <param name="previousOwner">An optional previous owner of the item.</param>
         /// <returns>The spawned <see cref="Pickup"/>.</returns>
-        /// <seealso cref="Projectile.Spawn(Vector3, Quaternion, bool, Player)"/>
-        public Pickup Spawn(Vector3 position, Quaternion rotation, Player previousOwner = null)
+        /// <seealso cref="Projectile.Spawn(Vector3, Quaternion?, bool, Player)"/>
+        public Pickup Spawn(Vector3 position, Quaternion? rotation = null, Player previousOwner = null)
         {
             Position = position;
-            Rotation = rotation;
+            Rotation = rotation ?? Quaternion.identity;
             PreviousOwner = previousOwner;
             Spawn();
 

--- a/Exiled.API/Features/Pickups/Projectiles/Projectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/Projectile.cs
@@ -84,7 +84,7 @@ namespace Exiled.API.Features.Pickups.Projectiles
         /// <param name="shouldBeActive">Whether the <see cref="Projectile"/> should be in active state after spawn.</param>
         /// <param name="previousOwner">An optional previous owner of the item.</param>
         /// <returns>The <see cref="Projectile"/>. See documentation of <see cref="Pickup.Create(ItemType)"/> for more information on casting.</returns>
-        public static Projectile CreateAndSpawn(ProjectileType type, Vector3 position, Quaternion rotation, bool shouldBeActive = true, Player previousOwner = null) => Create(type).Spawn(position, rotation, shouldBeActive, previousOwner);
+        public static Projectile CreateAndSpawn(ProjectileType type, Vector3 position, Quaternion? rotation = null, bool shouldBeActive = true, Player previousOwner = null) => Create(type).Spawn(position, rotation, shouldBeActive, previousOwner);
 
         /// <summary>
         /// Activates the current <see cref="Projectile"/>.
@@ -99,10 +99,10 @@ namespace Exiled.API.Features.Pickups.Projectiles
         /// <param name="shouldBeActive">Whether the <see cref="Projectile"/> should be in active state after spawn.</param>
         /// <param name="previousOwner">An optional previous owner of the item.</param>
         /// <returns>The spawned <see cref="Projectile"/>.</returns>
-        public Projectile Spawn(Vector3 position, Quaternion rotation, bool shouldBeActive = true, Player previousOwner = null)
+        public Projectile Spawn(Vector3 position, Quaternion? rotation = null, bool shouldBeActive = true, Player previousOwner = null)
         {
             Position = position;
-            Rotation = rotation;
+            Rotation = rotation ?? Quaternion.identity;
             PreviousOwner = previousOwner;
             Spawn();
 

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -3774,7 +3774,7 @@ namespace Exiled.API.Features
                 case TeslaGate teslaGate:
                     Teleport(
                         teslaGate.Position + offset + Vector3.up +
-                        (teslaGate.Room.Transform.rotation == new Quaternion(0f, 0f, 0f, 1f)
+                        (teslaGate.Room.Transform.rotation == Quaternion.identity
                             ? new Vector3(3, 0, 0)
                             : new Vector3(0, 0, 3)));
                     break;

--- a/Exiled.API/Features/PrefabHelper.cs
+++ b/Exiled.API/Features/PrefabHelper.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="PrefabHelper.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
@@ -48,11 +48,11 @@ namespace Exiled.API.Features
         /// <param name="position">The position to spawn the prefab.</param>
         /// <param name="rotation">The rotation of the prefab.</param>
         /// <returns>The <see cref="GameObject"/> instantied.</returns>
-        public static GameObject Spawn(PrefabType prefabType, Vector3 position = default, Quaternion rotation = default)
+        public static GameObject Spawn(PrefabType prefabType, Vector3 position = default, Quaternion? rotation = null)
         {
             if (!Stored.TryGetValue(prefabType, out GameObject gameObject))
                 return null;
-            GameObject newGameObject = UnityEngine.Object.Instantiate(gameObject, position, rotation);
+            GameObject newGameObject = UnityEngine.Object.Instantiate(gameObject, position, rotation ?? Quaternion.identity);
             NetworkServer.Spawn(newGameObject);
             return newGameObject;
         }
@@ -65,12 +65,12 @@ namespace Exiled.API.Features
         /// <param name="rotation">The rotation of the prefab.</param>
         /// <typeparam name="T">The <see cref="Component"/> type.</typeparam>
         /// <returns>The <see cref="Component"/> instantied.</returns>
-        public static T Spawn<T>(PrefabType prefabType, Vector3 position = default, Quaternion rotation = default)
+        public static T Spawn<T>(PrefabType prefabType, Vector3 position = default, Quaternion? rotation = null)
             where T : Component
         {
             if (!Stored.TryGetValue(prefabType, out GameObject gameObject) || !gameObject.TryGetComponent(out T component))
                 return null;
-            T obj = UnityEngine.Object.Instantiate(component, position, rotation);
+            T obj = UnityEngine.Object.Instantiate(component, position, rotation ?? Quaternion.identity);
             NetworkServer.Spawn(obj.gameObject);
             return obj;
         }

--- a/Exiled.API/Features/Ragdoll.cs
+++ b/Exiled.API/Features/Ragdoll.cs
@@ -367,8 +367,8 @@ namespace Exiled.API.Features
         /// <param name="rotation">The rotation of the ragdoll.</param>
         /// <param name="owner">The optional owner of the ragdoll.</param>
         /// <returns>The ragdoll.</returns>
-        public static Ragdoll CreateAndSpawn(RoleTypeId roleType, string name, DamageHandlerBase damageHandler, Vector3 position, Quaternion rotation, Player owner = null)
-            => CreateAndSpawn(new(owner != null ? owner.ReferenceHub : Server.Host.ReferenceHub, damageHandler, roleType, position, rotation, name, NetworkTime.time));
+        public static Ragdoll CreateAndSpawn(RoleTypeId roleType, string name, DamageHandlerBase damageHandler, Vector3 position, Quaternion? rotation = null, Player owner = null)
+            => CreateAndSpawn(new(owner != null ? owner.ReferenceHub : Server.Host.ReferenceHub, damageHandler, roleType, position, rotation ?? Quaternion.identity, name, NetworkTime.time));
 
         /// <summary>
         /// Creates and spawns a new ragdoll.
@@ -380,7 +380,7 @@ namespace Exiled.API.Features
         /// <param name="rotation">The rotation of the ragdoll.</param>
         /// <param name="owner">The optional owner of the ragdoll.</param>
         /// <returns>The ragdoll.</returns>
-        public static Ragdoll CreateAndSpawn(RoleTypeId roleType, string name, string deathReason, Vector3 position, Quaternion rotation, Player owner = null)
+        public static Ragdoll CreateAndSpawn(RoleTypeId roleType, string name, string deathReason, Vector3 position, Quaternion? rotation = null, Player owner = null)
             => CreateAndSpawn(roleType, name, new CustomReasonDamageHandler(deathReason), position, rotation, owner);
 
         /// <summary>

--- a/Exiled.API/Features/Workstation.cs
+++ b/Exiled.API/Features/Workstation.cs
@@ -103,9 +103,9 @@ namespace Exiled.API.Features
         /// <param name="position">The position to spawn it at.</param>
         /// <param name="rotation">The rotation to spawn it as.</param>
         /// <returns>The Workstation that was spawned.</returns>
-        public static Workstation Spawn(Vector3 position, Quaternion rotation = default)
+        public static Workstation Spawn(Vector3 position, Quaternion? rotation = null)
         {
-            WorkstationController controller = PrefabHelper.Spawn<WorkstationController>(PrefabType, position, rotation);
+            WorkstationController controller = PrefabHelper.Spawn<WorkstationController>(PrefabType, position, rotation ?? Quaternion.identity);
             return Get(controller);
         }
 


### PR DESCRIPTION
### Changes

- Make rotation optional for `Pickup.Spawn`, `Pickup.CreateAndSpawn`, `Projectile.Spawn`, `Projectile.CreateAndSpawn` and `Ragdoll.CreateAndSpawn`
- Fix zero `Quaternion`