### PR TITLE
[Resonance] Remove List from GameEntity

### DIFF
--- a/Exiled.API/Extensions/ItemExtensions.cs
+++ b/Exiled.API/Extensions/ItemExtensions.cs
@@ -15,7 +15,6 @@ namespace Exiled.API.Extensions
     using Features.Items;
     using InventorySystem;
     using InventorySystem.Items;
-    using InventorySystem.Items.Firearms;
     using InventorySystem.Items.Firearms.Attachments;
     using InventorySystem.Items.Pickups;
     using InventorySystem.Items.ThrowableProjectiles;

--- a/Exiled.API/Extensions/MirrorExtensions.cs
+++ b/Exiled.API/Extensions/MirrorExtensions.cs
@@ -13,22 +13,11 @@ namespace Exiled.API.Extensions
     using System.Linq;
     using System.Reflection;
     using System.Reflection.Emit;
-    using System.Text;
 
     using Features;
-    using Features.Core.Generic.Pools;
-    using InventorySystem.Items.Firearms;
     using Mirror;
     using PlayerRoles;
-    using PlayerRoles.FirstPersonControl;
-    using PlayerRoles.PlayableScps.Scp049.Zombies;
     using PlayerRoles.Subroutines;
-    using PlayerRoles.Voice;
-    using RelativePositioning;
-    using Respawning;
-    using UnityEngine;
-
-    using EIntercom = Exiled.API.Features.Intercom;
 
     /// <summary>
     /// A set of extensions for <see cref="Mirror"/> Networking.

--- a/Exiled.API/Extensions/RoomExtensions.cs
+++ b/Exiled.API/Extensions/RoomExtensions.cs
@@ -8,9 +8,7 @@
 namespace Exiled.API.Extensions
 {
     using Exiled.API.Enums;
-    using Exiled.API.Features;
     using MapGeneration;
-    using UnityEngine;
 
     /// <summary>
     /// A set of extensions for <see cref="RoomType"/> and <see cref="ZoneType"/>.

--- a/Exiled.API/Features/Camera.cs
+++ b/Exiled.API/Features/Camera.cs
@@ -148,7 +148,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a <see cref="IEnumerable{T}"/> of <see cref="Camera"/> which contains all the <see cref="Camera"/> instances.
         /// </summary>
-        public static new IReadOnlyCollection<Camera> List => Camera079ToCamera.Values;
+        public static IReadOnlyCollection<Camera> List => Camera079ToCamera.Values;
 
         /// <summary>
         /// Gets a randomly selected <see cref="Camera"/>.

--- a/Exiled.API/Features/Core/GameEntity.cs
+++ b/Exiled.API/Features/Core/GameEntity.cs
@@ -37,24 +37,7 @@ namespace Exiled.API.Features.Core
         /// Initializes a new instance of the <see cref="GameEntity"/> class.
         /// </summary>
         /// <param name="gameObject">Gameobject of the Entity.</param>
-        protected GameEntity(GameObject gameObject)
-        {
-            GameObject = gameObject;
-
-            // List.Add(this);
-        }
-
-        /// <summary>
-        /// Finalizes an instance of the <see cref="GameEntity"/> class.
-        /// </summary>
-        ~GameEntity() => List.Remove(this);
-
-        /// <summary>
-        /// Gets all active <see cref="GameEntity"/> instances.
-        /// <para/>
-        /// This collection should be used sparingly and only if circumstances require it, due to its potentially large size.
-        /// </summary>
-        public static HashSet<GameEntity> List { get; } = new();
+        protected GameEntity(GameObject gameObject) => GameObject = gameObject;
 
         /// <inheritdoc/>
         public IReadOnlyCollection<EActor> ComponentsInChildren => componentsInChildren;
@@ -93,44 +76,6 @@ namespace Exiled.API.Features.Core
             get => Transform.rotation;
             set => Transform.rotation = value;
         }
-
-        /// <summary>
-        /// Gets the nearest game entity to the specified <see cref="Vector3" /> within the given distance.
-        /// </summary>
-        /// <param name="vector">The <see cref="Vector3" /> to compare.</param>
-        /// <param name="distance">The maximum distance the game entity can be from the <paramref name="vector" /> to be included.</param>
-        /// <returns>
-        /// The nearest <see cref="GameEntity" /> within the specified distance, or <see langword="null" /> if no game
-        /// entity is found.
-        /// </returns>
-        public static GameEntity GetNearestEntity(Vector3 vector, float distance) => GetNearestEntities(vector, distance).OrderBy(p => MathExtensions.DistanceSquared(vector, p.GameObject.transform.position)).FirstOrDefault();
-
-        /// <summary>
-        /// Gets all game entities near the specified <see cref="Vector3" /> within the given distance.
-        /// </summary>
-        /// <param name="vector">The <see cref="Vector3" /> to compare.</param>
-        /// <param name="distance">The maximum distance the game entity can be from the <paramref name="vector" /> to be included.</param>
-        /// <returns>The filtered collection of <see cref="GameEntity" /> objects.</returns>
-        public static IEnumerable<GameEntity> GetNearestEntities(Vector3 vector, float distance) => List.Where(p => p.GameObject.transform && MathExtensions.DistanceSquared(vector, p.GameObject.transform.position) <= distance * distance);
-
-        /// <summary>
-        /// Gets the farthest game entity from the specified <see cref="Vector3" /> within the given distance.
-        /// </summary>
-        /// <param name="vector">The <see cref="Vector3" /> to compare.</param>
-        /// <param name="distance">The minimum distance the game entity can be from the <paramref name="vector" /> to be included.</param>
-        /// <returns>
-        /// The farthest <see cref="GameEntity" /> from the specified <paramref name="vector" /> within the given
-        /// distance, or <see langword="null" /> if no game entity is found.
-        /// </returns>
-        public static GameEntity GetFarthestEntity(Vector3 vector, float distance) => GetFarthestEntities(vector, distance).OrderByDescending(p => MathExtensions.DistanceSquared(vector, p.GameObject.transform.position)).FirstOrDefault();
-
-        /// <summary>
-        /// Gets all game entities that have a distance greater than the specified distance from the given <see cref="Vector3" />.
-        /// </summary>
-        /// <param name="vector">The <see cref="Vector3" /> to compare.</param>
-        /// <param name="distance">The minimum distance the game entity can be from the <paramref name="vector" /> to be included.</param>
-        /// <returns>The filtered collection of <see cref="GameEntity" /> objects.</returns>
-        public static IEnumerable<GameEntity> GetFarthestEntities(Vector3 vector, float distance) => List.Where(p => p.GameObject.transform && MathExtensions.DistanceSquared(vector, p.GameObject.transform.position) >= distance * distance);
 
         /// <summary>
         /// Returns the local space position, based on a world space position.

--- a/Exiled.API/Features/Doors/Door.cs
+++ b/Exiled.API/Features/Doors/Door.cs
@@ -68,7 +68,7 @@ namespace Exiled.API.Features.Doors
         /// <summary>
         /// Gets a <see cref="IEnumerable{T}"/> of <see cref="Door"/> which contains all the <see cref="Door"/> instances.
         /// </summary>
-        public static new IReadOnlyCollection<Door> List => DoorVariantToDoor.Values;
+        public static IReadOnlyCollection<Door> List => DoorVariantToDoor.Values;
 
         /// <summary>
         /// Gets the base-game <see cref="DoorVariant"/> corresponding with this door.
@@ -203,6 +203,20 @@ namespace Exiled.API.Features.Doors
         }
 
         /// <summary>
+        /// Gets or sets the door's rotation.
+        /// </summary>
+        public override Quaternion Rotation
+        {
+            get => Transform.rotation;
+            set
+            {
+                NetworkServer.UnSpawn(GameObject);
+                Transform.rotation = value;
+                NetworkServer.Spawn(GameObject);
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether or not SCP-106 can walk through the door.
         /// </summary>
         public bool AllowsScp106
@@ -255,20 +269,6 @@ namespace Exiled.API.Features.Doors
         {
             get => Base.RequiredPermissions;
             set => Base.RequiredPermissions = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the door's rotation.
-        /// </summary>
-        public override Quaternion Rotation
-        {
-            get => Transform.rotation;
-            set
-            {
-                NetworkServer.UnSpawn(GameObject);
-                Transform.rotation = value;
-                NetworkServer.Spawn(GameObject);
-            }
         }
 
         /// <summary>

--- a/Exiled.API/Features/Effect.cs
+++ b/Exiled.API/Features/Effect.cs
@@ -12,7 +12,6 @@ namespace Exiled.API.Features
     using CustomPlayerEffects;
     using Exiled.API.Enums;
     using Exiled.API.Extensions;
-    using Exiled.API.Features.Core.Interfaces;
 
     /// <summary>
     /// Useful struct to save effect-related configs cleanly.

--- a/Exiled.API/Features/Generator.cs
+++ b/Exiled.API/Features/Generator.cs
@@ -55,7 +55,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a <see cref="IEnumerable{T}"/> of <see cref="Generator"/> which contains all the <see cref="Generator"/> instances.
         /// </summary>
-        public static new IReadOnlyCollection<Generator> List => Scp079GeneratorToGenerator.Values;
+        public static IReadOnlyCollection<Generator> List => Scp079GeneratorToGenerator.Values;
 
         /// <summary>
         /// Gets a randomly selected <see cref="Generator"/>.

--- a/Exiled.API/Features/Hazards/AmnesticCloudHazard.cs
+++ b/Exiled.API/Features/Hazards/AmnesticCloudHazard.cs
@@ -8,12 +8,8 @@
 namespace Exiled.API.Features.Hazards
 {
     using Exiled.API.Enums;
-    using Exiled.API.Extensions;
-    using PlayerRoles;
     using PlayerRoles.PlayableScps.Scp939;
     using UnityEngine;
-
-    using Scp939GameRole = PlayerRoles.PlayableScps.Scp939.Scp939Role;
 
     /// <summary>
     /// A wrapper for SCP-939's amnestic cloud.

--- a/Exiled.API/Features/Hazards/Hazard.cs
+++ b/Exiled.API/Features/Hazards/Hazard.cs
@@ -43,7 +43,7 @@ namespace Exiled.API.Features.Hazards
         /// <summary>
         /// Gets the list of all hazards.
         /// </summary>
-        public static new IReadOnlyCollection<Hazard> List => EnvironmentalHazardToHazard.Values;
+        public static IReadOnlyCollection<Hazard> List => EnvironmentalHazardToHazard.Values;
 
         /// <summary>
         /// Gets the <see cref="EnvironmentalHazard"/>.

--- a/Exiled.API/Features/Hazards/TantrumHazard.cs
+++ b/Exiled.API/Features/Hazards/TantrumHazard.cs
@@ -9,16 +9,9 @@ namespace Exiled.API.Features.Hazards
 {
     using CustomPlayerEffects;
     using Exiled.API.Enums;
-    using Exiled.API.Extensions;
     using global::Hazards;
-    using Mirror;
-    using PlayerRoles;
-    using PlayerRoles.PlayableScps.Scp173;
     using RelativePositioning;
     using UnityEngine;
-
-    using Object = UnityEngine.Object;
-    using Scp173GameRole = PlayerRoles.PlayableScps.Scp173.Scp173Role;
 
     /// <summary>
     /// A wrapper for <see cref="TantrumEnvironmentalHazard"/>.

--- a/Exiled.API/Features/Items/Flashlight.cs
+++ b/Exiled.API/Features/Items/Flashlight.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.API.Features.Items
 {
-    using System;
-
     using Exiled.API.Features.Core.Attributes;
 
     using Exiled.API.Interfaces;

--- a/Exiled.API/Features/Items/Item.cs
+++ b/Exiled.API/Features/Items/Item.cs
@@ -80,7 +80,7 @@ namespace Exiled.API.Features.Items
         /// <summary>
         /// Gets a list of all <see cref="Item"/>'s on the server.
         /// </summary>
-        public static new IEnumerable<Item> List => BaseToItem.Values;
+        public static IEnumerable<Item> List => BaseToItem.Values;
 
         /// <summary>
         /// Gets or sets the unique serial number for the item.

--- a/Exiled.API/Features/Lift.cs
+++ b/Exiled.API/Features/Lift.cs
@@ -64,7 +64,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a <see cref="IEnumerable{T}"/> of <see cref="Lift"/> which contains all the <see cref="Lift"/> instances.
         /// </summary>
-        public static new IReadOnlyCollection<Lift> List => ElevatorChamberToLift.Values;
+        public static IReadOnlyCollection<Lift> List => ElevatorChamberToLift.Values;
 
         /// <summary>
         /// Gets a random <see cref="Lift"/>.

--- a/Exiled.API/Features/Lockers/Chamber.cs
+++ b/Exiled.API/Features/Lockers/Chamber.cs
@@ -46,7 +46,7 @@ namespace Exiled.API.Features.Lockers
         /// <summary>
         /// Gets all chambers.
         /// </summary>
-        public static new IReadOnlyCollection<Chamber> List => Chambers.Values;
+        public static IReadOnlyCollection<Chamber> List => Chambers.Values;
 
         /// <inheritdoc/>
         public LockerChamber Base { get; }

--- a/Exiled.API/Features/Lockers/Locker.cs
+++ b/Exiled.API/Features/Lockers/Locker.cs
@@ -44,7 +44,7 @@ namespace Exiled.API.Features.Lockers
         /// <summary>
         /// Gets the all <see cref="Locker"/> instances.
         /// </summary>
-        public static new IReadOnlyCollection<Locker> List => BaseToExiledLockers.Values;
+        public static IReadOnlyCollection<Locker> List => BaseToExiledLockers.Values;
 
         /// <inheritdoc/>
         public BaseLocker Base { get; }

--- a/Exiled.API/Features/Pickups/BodyArmorPickup.cs
+++ b/Exiled.API/Features/Pickups/BodyArmorPickup.cs
@@ -9,8 +9,6 @@ namespace Exiled.API.Features.Pickups
 {
     using System.Collections.Generic;
     using System.Linq;
-
-    using Exiled.API.Extensions;
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Features.Items;
     using Exiled.API.Interfaces;

--- a/Exiled.API/Features/Pickups/BodyArmorPickup.cs
+++ b/Exiled.API/Features/Pickups/BodyArmorPickup.cs
@@ -9,6 +9,7 @@ namespace Exiled.API.Features.Pickups
 {
     using System.Collections.Generic;
     using System.Linq;
+
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Features.Items;
     using Exiled.API.Interfaces;

--- a/Exiled.API/Features/Pickups/ExplosiveGrenadePickup.cs
+++ b/Exiled.API/Features/Pickups/ExplosiveGrenadePickup.cs
@@ -8,7 +8,6 @@
 namespace Exiled.API.Features.Pickups
 {
     using Exiled.API.Enums;
-    using Exiled.API.Extensions;
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Features.Items;
     using Exiled.API.Features.Pickups.Projectiles;

--- a/Exiled.API/Features/Pickups/FlashGrenadePickup.cs
+++ b/Exiled.API/Features/Pickups/FlashGrenadePickup.cs
@@ -8,7 +8,6 @@
 namespace Exiled.API.Features.Pickups
 {
     using Exiled.API.Enums;
-    using Exiled.API.Extensions;
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Features.Items;
     using Exiled.API.Features.Pickups.Projectiles;

--- a/Exiled.API/Features/Pickups/JailbirdPickup.cs
+++ b/Exiled.API/Features/Pickups/JailbirdPickup.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Features.Pickups
 {
-    using Exiled.API.Extensions;
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Features.Items;
     using Exiled.API.Interfaces;

--- a/Exiled.API/Features/Pickups/KeycardPickup.cs
+++ b/Exiled.API/Features/Pickups/KeycardPickup.cs
@@ -8,7 +8,6 @@
 namespace Exiled.API.Features.Pickups
 {
     using Exiled.API.Enums;
-    using Exiled.API.Extensions;
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Features.Items;
     using Exiled.API.Interfaces;

--- a/Exiled.API/Features/Pickups/MicroHIDPickup.cs
+++ b/Exiled.API/Features/Pickups/MicroHIDPickup.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Features.Pickups
 {
-    using Exiled.API.Extensions;
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Interfaces;
 

--- a/Exiled.API/Features/Pickups/Pickup.cs
+++ b/Exiled.API/Features/Pickups/Pickup.cs
@@ -97,7 +97,7 @@ namespace Exiled.API.Features.Pickups
         /// <summary>
         /// Gets a <see cref="IEnumerable{T}"/> of <see cref="Pickup"/> which contains all the <see cref="Pickup"/> instances.
         /// </summary>
-        public static new IEnumerable<Pickup> List => BaseToPickup.Values;
+        public static IEnumerable<Pickup> List => BaseToPickup.Values;
 
         /// <summary>
         /// Gets a randomly selected <see cref="Pickup"/>.

--- a/Exiled.API/Features/Pickups/Projectiles/EffectGrenadeProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/EffectGrenadeProjectile.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Features.Pickups.Projectiles
 {
-    using Exiled.API.Extensions;
     using Exiled.API.Interfaces;
     using InventorySystem.Items.ThrowableProjectiles;
 

--- a/Exiled.API/Features/Pickups/Projectiles/ExplosionGrenadeProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/ExplosionGrenadeProjectile.cs
@@ -14,7 +14,6 @@ namespace Exiled.API.Features.Pickups.Projectiles
     using InventorySystem.Items;
     using InventorySystem.Items.ThrowableProjectiles;
     using PlayerRoles;
-    using UnityEngine;
 
     /// <summary>
     /// A wrapper class for ExplosionGrenade.

--- a/Exiled.API/Features/Pickups/Projectiles/FlashbangProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/FlashbangProjectile.cs
@@ -13,7 +13,6 @@ namespace Exiled.API.Features.Pickups.Projectiles
     using InventorySystem;
     using InventorySystem.Items;
     using InventorySystem.Items.ThrowableProjectiles;
-    using UnityEngine;
 
     /// <summary>
     /// A wrapper class for FlashbangGrenade.

--- a/Exiled.API/Features/Pickups/Projectiles/Scp018Projectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/Scp018Projectile.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Features.Pickups.Projectiles
 {
-    using Exiled.API.Extensions;
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Interfaces;
     using InventorySystem.Items.ThrowableProjectiles;

--- a/Exiled.API/Features/Pickups/Projectiles/Scp2176Projectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/Scp2176Projectile.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Features.Pickups.Projectiles
 {
-    using Exiled.API.Extensions;
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Interfaces;
     using InventorySystem.Items.ThrowableProjectiles;

--- a/Exiled.API/Features/Pickups/Projectiles/TimeGrenadeProjectile.cs
+++ b/Exiled.API/Features/Pickups/Projectiles/TimeGrenadeProjectile.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Features.Pickups.Projectiles
 {
-    using Exiled.API.Extensions;
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Interfaces;
     using InventorySystem.Items.ThrowableProjectiles;

--- a/Exiled.API/Features/Pickups/RadioPickup.cs
+++ b/Exiled.API/Features/Pickups/RadioPickup.cs
@@ -8,7 +8,6 @@
 namespace Exiled.API.Features.Pickups
 {
     using Exiled.API.Enums;
-    using Exiled.API.Extensions;
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Interfaces;
 

--- a/Exiled.API/Features/Pickups/Scp1576Pickup.cs
+++ b/Exiled.API/Features/Pickups/Scp1576Pickup.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Features.Pickups
 {
-    using Exiled.API.Extensions;
     using Exiled.API.Interfaces;
 
     using BaseScp1576 = InventorySystem.Items.Usables.Scp1576.Scp1576Pickup;

--- a/Exiled.API/Features/Pickups/Scp244Pickup.cs
+++ b/Exiled.API/Features/Pickups/Scp244Pickup.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features.Pickups
 {
     using System;
+
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Features.DamageHandlers;
     using Exiled.API.Features.Items;

--- a/Exiled.API/Features/Pickups/Scp244Pickup.cs
+++ b/Exiled.API/Features/Pickups/Scp244Pickup.cs
@@ -8,8 +8,6 @@
 namespace Exiled.API.Features.Pickups
 {
     using System;
-
-    using Exiled.API.Extensions;
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Features.DamageHandlers;
     using Exiled.API.Features.Items;

--- a/Exiled.API/Features/Pickups/Scp330Pickup.cs
+++ b/Exiled.API/Features/Pickups/Scp330Pickup.cs
@@ -8,8 +8,6 @@
 namespace Exiled.API.Features.Pickups
 {
     using System.Collections.Generic;
-
-    using Exiled.API.Extensions;
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Interfaces;
     using InventorySystem.Items.Usables.Scp330;

--- a/Exiled.API/Features/Pickups/Scp330Pickup.cs
+++ b/Exiled.API/Features/Pickups/Scp330Pickup.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features.Pickups
 {
     using System.Collections.Generic;
+
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Interfaces;
     using InventorySystem.Items.Usables.Scp330;

--- a/Exiled.API/Features/Pickups/UsablePickup.cs
+++ b/Exiled.API/Features/Pickups/UsablePickup.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Features.Pickups
 {
-    using Exiled.API.Extensions;
     using Exiled.API.Features.Core.Attributes;
     using Exiled.API.Features.Items;
     using InventorySystem.Items;

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -195,7 +195,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a list of all <see cref="Player"/>'s on the server.
         /// </summary>
-        public static new IReadOnlyCollection<Player> List => Dictionary.Values;
+        public static IReadOnlyCollection<Player> List => Dictionary.Values;
 
         /// <summary>
         /// Gets a <see cref="Dictionary{TKey, TValue}"/> containing cached <see cref="Player"/> and their user ids.

--- a/Exiled.API/Features/Ragdoll.cs
+++ b/Exiled.API/Features/Ragdoll.cs
@@ -52,7 +52,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a <see cref="IEnumerable{T}"/> of <see cref="Ragdoll"/> which contains all the <see cref="Ragdoll"/> instances.
         /// </summary>
-        public static new IReadOnlyCollection<Ragdoll> List => BasicRagdollToRagdoll.Values;
+        public static IReadOnlyCollection<Ragdoll> List => BasicRagdollToRagdoll.Values;
 
         /// <summary>
         /// Gets or sets the <see cref="BasicRagdoll"/>s clean up time.
@@ -230,9 +230,7 @@ namespace Exiled.API.Features
             set
             {
                 NetworkServer.UnSpawn(GameObject);
-
                 Transform.position = value;
-
                 NetworkServer.Spawn(GameObject);
             }
         }
@@ -247,9 +245,7 @@ namespace Exiled.API.Features
             set
             {
                 NetworkServer.UnSpawn(GameObject);
-
                 Transform.rotation = value;
-
                 NetworkServer.Spawn(GameObject);
             }
         }
@@ -264,9 +260,7 @@ namespace Exiled.API.Features
             set
             {
                 NetworkServer.UnSpawn(GameObject);
-
                 Transform.localScale = value;
-
                 NetworkServer.Spawn(GameObject);
             }
         }

--- a/Exiled.API/Features/Roles/Role.cs
+++ b/Exiled.API/Features/Roles/Role.cs
@@ -10,12 +10,10 @@ namespace Exiled.API.Features.Roles
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Reflection;
 
     using Enums;
     using Exiled.API.Features.Core;
     using Exiled.API.Features.Core.Attributes;
-    using Exiled.API.Features.Core.Interfaces;
     using Exiled.API.Features.Spawn;
     using Exiled.API.Interfaces;
     using Extensions;

--- a/Exiled.API/Features/Roles/Scp939Role.cs
+++ b/Exiled.API/Features/Roles/Scp939Role.cs
@@ -19,7 +19,6 @@ namespace Exiled.API.Features.Roles
     using PlayerRoles.PlayableScps.Scp939.Mimicry;
     using PlayerRoles.PlayableScps.Scp939.Ripples;
     using PlayerRoles.Subroutines;
-    using PluginAPI.Roles;
     using RelativePositioning;
     using UnityEngine;
 

--- a/Exiled.API/Features/Room.cs
+++ b/Exiled.API/Features/Room.cs
@@ -74,7 +74,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a <see cref="IEnumerable{T}"/> of <see cref="Room"/> which contains all the <see cref="Room"/> instances.
         /// </summary>
-        public static new IReadOnlyCollection<Room> List => RoomIdentifierToRoom.Values;
+        public static IReadOnlyCollection<Room> List => RoomIdentifierToRoom.Values;
 
         /// <summary>
         /// Gets the <see cref="Room"/> name.

--- a/Exiled.API/Features/TeslaGate.cs
+++ b/Exiled.API/Features/TeslaGate.cs
@@ -52,7 +52,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a <see cref="IEnumerable{T}"/> of <see cref="TeslaGate"/> which contains all the <see cref="TeslaGate"/> instances.
         /// </summary>
-        public static new IReadOnlyCollection<TeslaGate> List => BaseTeslaGateToTeslaGate.Values;
+        public static IReadOnlyCollection<TeslaGate> List => BaseTeslaGateToTeslaGate.Values;
 
         /// <summary>
         /// Gets or sets a <see cref="HashSet{T}"/> of <see cref="Player"/> which contains all the players ignored by tesla gates.

--- a/Exiled.API/Features/Toys/AdminToy.cs
+++ b/Exiled.API/Features/Toys/AdminToy.cs
@@ -11,8 +11,6 @@ namespace Exiled.API.Features.Toys
 
     using AdminToys;
     using Enums;
-    using Exiled.API.Features.Core;
-    using Exiled.API.Features.Core.Interfaces;
     using Exiled.API.Interfaces;
     using Footprinting;
     using Mirror;
@@ -21,7 +19,7 @@ namespace Exiled.API.Features.Toys
     /// <summary>
     /// A wrapper class for <see cref="AdminToys.AdminToyBase"/>.
     /// </summary>
-    public abstract class AdminToy : TypeCastObject<GameEntity>, IWorldSpace, IAssetFragment
+    public abstract class AdminToy : IWorldSpace
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdminToy"/> class.

--- a/Exiled.API/Features/Toys/ShootingTargetToy.cs
+++ b/Exiled.API/Features/Toys/ShootingTargetToy.cs
@@ -14,7 +14,6 @@ namespace Exiled.API.Features.Toys
     using Enums;
     using Exiled.API.Interfaces;
     using Exiled.API.Structs;
-    using Mirror;
 
     using PlayerStatsSystem;
 

--- a/Exiled.API/Features/Window.cs
+++ b/Exiled.API/Features/Window.cs
@@ -50,7 +50,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a <see cref="IEnumerable{T}"/> of <see cref="Door"/> which contains all the <see cref="Door"/> instances.
         /// </summary>
-        public static new IReadOnlyCollection<Window> List => BreakableWindowToWindow.Values;
+        public static IReadOnlyCollection<Window> List => BreakableWindowToWindow.Values;
 
         /// <summary>
         /// Gets a randomly selected <see cref="Window"/>.

--- a/Exiled.API/Features/Workstation.cs
+++ b/Exiled.API/Features/Workstation.cs
@@ -46,7 +46,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a list with all <see cref="Workstation"/>.
         /// </summary>
-        public static new IReadOnlyCollection<Workstation> List => BaseToWrapper.Values;
+        public static IReadOnlyCollection<Workstation> List => BaseToWrapper.Values;
 
         /// <summary>
         /// Gets the prefab's type.

--- a/Exiled.API/Features/Workstation.cs
+++ b/Exiled.API/Features/Workstation.cs
@@ -16,7 +16,6 @@ namespace Exiled.API.Features
     using Interactables;
     using InventorySystem.Items.Firearms.Attachments;
     using MapGeneration;
-    using Mirror;
     using UnityEngine;
 
     /// <summary>

--- a/Exiled.CustomModules/API/Features/CustomAbilities/ISelectableAbility.cs
+++ b/Exiled.CustomModules/API/Features/CustomAbilities/ISelectableAbility.cs
@@ -7,10 +7,6 @@
 
 namespace Exiled.CustomModules.API.Features.CustomAbilities
 {
-    using Exiled.API.Features.Core;
-    using Exiled.API.Features.Core.Interfaces;
-    using Exiled.CustomModules.API.Features.PlayerAbilities;
-
     /// <summary>
     /// Represents a marker interface for custom ability that can be selected.
     /// </summary>

--- a/Exiled.CustomModules/API/Features/CustomAbilities/Settings/AbilitySettings.cs
+++ b/Exiled.CustomModules/API/Features/CustomAbilities/Settings/AbilitySettings.cs
@@ -7,11 +7,8 @@
 
 namespace Exiled.CustomModules.API.Features.CustomAbilities.Settings
 {
-    using Exiled.API.Features;
     using Exiled.API.Features.Core;
     using Exiled.API.Features.Core.Interfaces;
-    using Exiled.CustomModules.API.Features.CustomAbilities;
-    using Exiled.CustomModules.API.Features.CustomRoles;
 
     /// <summary>
     /// Represents the base class for player-specific ability behaviors.

--- a/Exiled.CustomModules/API/Features/CustomAbilities/Settings/LevelAbilitySettings.cs
+++ b/Exiled.CustomModules/API/Features/CustomAbilities/Settings/LevelAbilitySettings.cs
@@ -8,9 +8,6 @@
 namespace Exiled.CustomModules.API.Features.CustomAbilities.Settings
 {
     using Exiled.API.Features;
-    using Exiled.API.Features.Core;
-    using Exiled.API.Features.Core.Interfaces;
-    using Exiled.CustomModules.API.Features.CustomRoles;
 
     /// <summary>
     /// Represents the base class for player-specific ability behaviors.

--- a/Exiled.CustomModules/API/Features/CustomAbilities/Types/AbilityBehaviourBase.cs
+++ b/Exiled.CustomModules/API/Features/CustomAbilities/Types/AbilityBehaviourBase.cs
@@ -11,7 +11,6 @@ namespace Exiled.CustomModules.API.Features.CustomAbilities
 
     using Exiled.API.Features;
     using Exiled.API.Features.Core;
-    using Exiled.API.Features.Core.Generic;
     using Exiled.API.Features.Core.Interfaces;
     using Exiled.API.Features.DynamicEvents;
     using Exiled.CustomModules.API.Features.CustomAbilities.Settings;

--- a/Exiled.CustomModules/API/Features/CustomItems/Items/ItemSettings.cs
+++ b/Exiled.CustomModules/API/Features/CustomItems/Items/ItemSettings.cs
@@ -8,7 +8,6 @@
 namespace Exiled.CustomModules.API.Features.CustomItems.Items
 {
     using Exiled.API.Features;
-    using Exiled.API.Features.Core;
     using Exiled.API.Features.Spawn;
 
     using UnityEngine;

--- a/Exiled.CustomModules/API/Features/Deserializers/Inheritables/RoleSettingsDeserializer.cs
+++ b/Exiled.CustomModules/API/Features/Deserializers/Inheritables/RoleSettingsDeserializer.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.CustomModules.API.Features.Deserializers.Inheritables
 {
-    using System;
     using System.Reflection;
 
     using Exiled.CustomModules.API.Features.CustomRoles;

--- a/Exiled.CustomModules/API/Features/ModuleBehaviour.cs
+++ b/Exiled.CustomModules/API/Features/ModuleBehaviour.cs
@@ -12,7 +12,6 @@ namespace Exiled.CustomModules.API.Features
 
     using Exiled.API.Features.Core;
     using Exiled.API.Features.Core.Generic;
-    using Exiled.CustomModules.API.Features.Attributes;
 
     /// <summary>
     /// Represents a marker class for a module's pointer.

--- a/Exiled.CustomModules/API/Features/Pawn.cs
+++ b/Exiled.CustomModules/API/Features/Pawn.cs
@@ -15,7 +15,6 @@ namespace Exiled.CustomModules.API.Features
     using Exiled.API.Extensions;
     using Exiled.API.Features;
     using Exiled.API.Features.Attributes;
-    using Exiled.API.Features.Core.Generic;
     using Exiled.API.Features.Items;
     using Exiled.API.Features.Roles;
     using Exiled.CustomModules.API.Features.CustomAbilities;

--- a/Exiled.CustomModules/Config.cs
+++ b/Exiled.CustomModules/Config.cs
@@ -10,7 +10,6 @@ namespace Exiled.CustomModules
     using System.ComponentModel;
 
     using Exiled.API.Interfaces;
-    using Exiled.CustomModules.API.Enums;
 
     /// <summary>
     /// The plugin's config.

--- a/Exiled.CustomModules/Events/EventArgs/CustomAbilities/AddedAbilityEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/CustomAbilities/AddedAbilityEventArgs.cs
@@ -9,7 +9,6 @@ namespace Exiled.CustomModules.Events.EventArgs.CustomAbilities
 {
     using Exiled.API.Features.Core;
     using Exiled.CustomModules.API.Features.CustomAbilities;
-    using Exiled.Events.EventArgs.Interfaces;
 
     /// <summary>
     /// Contains all information after adding an ability.

--- a/Exiled.CustomModules/Events/EventArgs/CustomAbilities/RemovedAbilityEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/CustomAbilities/RemovedAbilityEventArgs.cs
@@ -9,7 +9,6 @@ namespace Exiled.CustomModules.Events.EventArgs.CustomAbilities
 {
     using Exiled.API.Features.Core;
     using Exiled.CustomModules.API.Features.CustomAbilities;
-    using Exiled.Events.EventArgs.Interfaces;
 
     /// <summary>
     /// Contains all information after removing an ability.

--- a/Exiled.CustomModules/Events/EventArgs/CustomItems/OwnerChangingRoleEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/CustomItems/OwnerChangingRoleEventArgs.cs
@@ -8,13 +8,10 @@
 namespace Exiled.CustomModules.Events.EventArgs.CustomItems
 {
     using Exiled.API.Features;
-    using Exiled.API.Features.Core;
     using Exiled.API.Features.Items;
     using Exiled.CustomModules.API.Features.CustomItems;
     using Exiled.CustomModules.API.Features.CustomItems.Items;
     using Exiled.Events.EventArgs.Player;
-
-    using InventorySystem.Items;
 
     using PlayerRoles;
 

--- a/Exiled.CustomModules/Events/EventArgs/CustomRoles/AssigningHumanCustomRolesEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/CustomRoles/AssigningHumanCustomRolesEventArgs.cs
@@ -8,10 +8,7 @@
 namespace Exiled.CustomModules.Events.EventArgs.CustomRoles
 {
     using System.Collections.Generic;
-
-    using API.Enums;
     using Exiled.Events.EventArgs.Interfaces;
-    using PlayerRoles;
 
     /// <summary>
     /// Contains all information before assigning human roles.

--- a/Exiled.CustomModules/Events/EventArgs/CustomRoles/AssigningHumanCustomRolesEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/CustomRoles/AssigningHumanCustomRolesEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.CustomModules.Events.EventArgs.CustomRoles
 {
     using System.Collections.Generic;
+
     using Exiled.Events.EventArgs.Interfaces;
 
     /// <summary>

--- a/Exiled.CustomModules/Events/EventArgs/CustomRoles/AssigningScpCustomRolesEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/CustomRoles/AssigningScpCustomRolesEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.CustomModules.Events.EventArgs.CustomRoles
 {
     using System.Collections.Generic;
     using System.Linq;
+
     using Exiled.API.Features;
     using Exiled.Events.EventArgs.Interfaces;
 

--- a/Exiled.CustomModules/Events/EventArgs/CustomRoles/AssigningScpCustomRolesEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/CustomRoles/AssigningScpCustomRolesEventArgs.cs
@@ -9,12 +9,8 @@ namespace Exiled.CustomModules.Events.EventArgs.CustomRoles
 {
     using System.Collections.Generic;
     using System.Linq;
-
-    using API.Enums;
-    using API.Features;
     using Exiled.API.Features;
     using Exiled.Events.EventArgs.Interfaces;
-    using PlayerRoles;
 
     /// <summary>
     /// Contains all information before assigning SCP roles.

--- a/Exiled.CustomModules/Events/EventArgs/CustomRoles/ChangedCustomRoleEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/CustomRoles/ChangedCustomRoleEventArgs.cs
@@ -7,13 +7,8 @@
 
 namespace Exiled.CustomModules.Events.EventArgs.CustomRoles
 {
-    using System.Collections.Generic;
-
-    using API.Enums;
     using Exiled.API.Features;
-    using Exiled.CustomModules.API.Features;
     using Exiled.Events.EventArgs.Interfaces;
-    using PlayerRoles;
 
     /// <summary>
     /// Contains all information after a player changes role to a custom role.

--- a/Exiled.CustomModules/Events/EventArgs/CustomRoles/ChangingCustomRoleEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/CustomRoles/ChangingCustomRoleEventArgs.cs
@@ -7,13 +7,8 @@
 
 namespace Exiled.CustomModules.Events.EventArgs.CustomRoles
 {
-    using System.Collections.Generic;
-
-    using API.Enums;
     using Exiled.API.Features;
-    using Exiled.CustomModules.API.Features;
     using Exiled.Events.EventArgs.Interfaces;
-    using PlayerRoles;
 
     /// <summary>
     /// Contains all information before a player changes role to a custom role.

--- a/Exiled.CustomModules/Events/EventArgs/CustomRoles/SelectingCustomTeamRespawnEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/CustomRoles/SelectingCustomTeamRespawnEventArgs.cs
@@ -7,15 +7,8 @@
 
 namespace Exiled.CustomModules.Events.EventArgs.CustomRoles
 {
-    using System.Collections.Generic;
-    using System.Linq;
-
-    using API.Enums;
-    using API.Features;
-    using Exiled.API.Features;
     using Exiled.CustomModules.API.Features.CustomRoles;
     using Exiled.Events.EventArgs.Interfaces;
-    using PlayerRoles;
     using Respawning;
 
     /// <summary>

--- a/Exiled.CustomModules/Events/EventArgs/Interfaces/ICustomItemEvent.cs
+++ b/Exiled.CustomModules/Events/EventArgs/Interfaces/ICustomItemEvent.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.CustomModules.Events.EventArgs.CustomItems
 {
-    using Exiled.API.Features.Items;
     using Exiled.CustomModules.API.Features.CustomItems;
     using Exiled.CustomModules.API.Features.CustomItems.Items;
     using Exiled.Events.EventArgs.Interfaces;

--- a/Exiled.CustomModules/Events/EventArgs/Interfaces/ICustomPickupEvent.cs
+++ b/Exiled.CustomModules/Events/EventArgs/Interfaces/ICustomPickupEvent.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.CustomModules.Events.EventArgs.CustomItems
 {
-    using Exiled.API.Features.Items;
     using Exiled.CustomModules.API.Features.CustomItems;
     using Exiled.CustomModules.API.Features.CustomItems.Items;
     using Exiled.Events.EventArgs.Interfaces;

--- a/Exiled.CustomModules/Events/EventArgs/Tracking/ItemTrackingModifiedEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/Tracking/ItemTrackingModifiedEventArgs.cs
@@ -11,8 +11,6 @@ namespace Exiled.CustomModules.Events.EventArgs.Tracking
 
     using Exiled.API.Features.Items;
     using Exiled.API.Features.Pickups;
-    using Exiled.CustomModules.API.Features;
-    using Exiled.CustomModules.API.Features.CustomAbilities;
     using Exiled.CustomModules.API.Interfaces;
     using Exiled.Events.EventArgs.Interfaces;
 

--- a/Exiled.CustomModules/Events/EventArgs/Tracking/PickupTrackingModifiedEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/Tracking/PickupTrackingModifiedEventArgs.cs
@@ -10,7 +10,6 @@ namespace Exiled.CustomModules.Events.EventArgs.Tracking
     using System.Collections.Generic;
 
     using Exiled.API.Features.Pickups;
-    using Exiled.CustomModules.API.Features;
     using Exiled.CustomModules.API.Interfaces;
     using Exiled.Events.EventArgs.Interfaces;
 

--- a/Exiled.CustomModules/Events/EventArgs/Tracking/TrackingModifiedEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/Tracking/TrackingModifiedEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.CustomModules.Events.EventArgs.Tracking
 {
     using System.Collections.Generic;
+
     using Exiled.CustomModules.API.Interfaces;
     using Exiled.Events.EventArgs.Interfaces;
 

--- a/Exiled.CustomModules/Events/EventArgs/Tracking/TrackingModifiedEventArgs.cs
+++ b/Exiled.CustomModules/Events/EventArgs/Tracking/TrackingModifiedEventArgs.cs
@@ -8,8 +8,6 @@
 namespace Exiled.CustomModules.Events.EventArgs.Tracking
 {
     using System.Collections.Generic;
-
-    using Exiled.CustomModules.API.Features;
     using Exiled.CustomModules.API.Interfaces;
     using Exiled.Events.EventArgs.Interfaces;
 

--- a/Exiled.Events/Commands/PluginManager/Disable.cs
+++ b/Exiled.Events/Commands/PluginManager/Disable.cs
@@ -11,8 +11,6 @@ namespace Exiled.Events.Commands.PluginManager
 
     using API.Interfaces;
     using CommandSystem;
-    using Exiled.Permissions.Extensions;
-    using RemoteAdmin;
 
     /// <summary>
     /// The command to disable a plugin.

--- a/Exiled.Events/Commands/PluginManager/Enable.cs
+++ b/Exiled.Events/Commands/PluginManager/Enable.cs
@@ -15,8 +15,6 @@ namespace Exiled.Events.Commands.PluginManager
     using API.Interfaces;
     using CommandSystem;
     using Exiled.API.Features;
-    using Exiled.Permissions.Extensions;
-    using RemoteAdmin;
 
     /// <summary>
     /// The command to enable a plugin.

--- a/Exiled.Events/Commands/PluginManager/Patches.cs
+++ b/Exiled.Events/Commands/PluginManager/Patches.cs
@@ -17,9 +17,7 @@ namespace Exiled.Events.Commands.PluginManager
     using Exiled.API.Features;
     using Exiled.API.Interfaces;
     using Exiled.Events.Features;
-    using Exiled.Permissions.Extensions;
     using NorthwoodLib.Pools;
-    using RemoteAdmin;
 
     /// <summary>
     /// The command to show all the patches done by plugins.

--- a/Exiled.Events/Commands/Reload/Configs.cs
+++ b/Exiled.Events/Commands/Reload/Configs.cs
@@ -13,8 +13,6 @@ namespace Exiled.Events.Commands.Reload
 
     using CommandSystem;
 
-    using Exiled.Permissions.Extensions;
-
     using Loader;
 
     /// <summary>

--- a/Exiled.Events/Commands/Reload/GamePlay.cs
+++ b/Exiled.Events/Commands/Reload/GamePlay.cs
@@ -11,7 +11,6 @@ namespace Exiled.Events.Commands.Reload
 
     using CommandSystem;
     using Exiled.API.Interfaces;
-    using Exiled.Permissions.Extensions;
 
     using static GameCore.ConfigFile;
 

--- a/Exiled.Events/Commands/Reload/Permissions.cs
+++ b/Exiled.Events/Commands/Reload/Permissions.cs
@@ -12,7 +12,6 @@ namespace Exiled.Events.Commands.Reload
     using CommandSystem;
     using Exiled.API.Interfaces;
     using Exiled.Events.Handlers;
-    using Exiled.Permissions.Extensions;
 
     /// <summary>
     /// The reload permissions command.

--- a/Exiled.Events/Commands/Reload/Plugins.cs
+++ b/Exiled.Events/Commands/Reload/Plugins.cs
@@ -12,7 +12,6 @@ namespace Exiled.Events.Commands.Reload
     using CommandSystem;
     using Exiled.API.Interfaces;
     using Exiled.Events.Handlers;
-    using Exiled.Permissions.Extensions;
     using Loader;
 
     /// <summary>

--- a/Exiled.Events/Commands/Reload/RemoteAdmin.cs
+++ b/Exiled.Events/Commands/Reload/RemoteAdmin.cs
@@ -11,7 +11,6 @@ namespace Exiled.Events.Commands.Reload
 
     using CommandSystem;
     using Exiled.API.Interfaces;
-    using Exiled.Permissions.Extensions;
     using Loader;
 
     /// <summary>

--- a/Exiled.Events/Commands/Reload/Translations.cs
+++ b/Exiled.Events/Commands/Reload/Translations.cs
@@ -13,8 +13,6 @@ namespace Exiled.Events.Commands.Reload
 
     using CommandSystem;
 
-    using Exiled.Permissions.Extensions;
-
     using Loader;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Item/ChangedAttachmentsEventArgs.cs
+++ b/Exiled.Events/EventArgs/Item/ChangedAttachmentsEventArgs.cs
@@ -8,7 +8,6 @@
 namespace Exiled.Events.EventArgs.Item
 {
     using System.Collections.Generic;
-    using System.Linq;
 
     using API.Features;
     using API.Features.Items;

--- a/Exiled.Events/EventArgs/Map/ChangedIntoGrenadeEventArgs.cs
+++ b/Exiled.Events/EventArgs/Map/ChangedIntoGrenadeEventArgs.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Map
 {
-    using System;
-
     using Exiled.API.Features.Pickups;
     using Exiled.API.Features.Pickups.Projectiles;
     using Exiled.Events.EventArgs.Interfaces;

--- a/Exiled.Events/EventArgs/Player/ChangedItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ChangedItemEventArgs.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Player
 {
-    using System;
-
     using API.Features;
     using API.Features.Items;
 

--- a/Exiled.Events/EventArgs/Player/ChangingMoveStateEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/ChangingMoveStateEventArgs.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Player
 {
-    using System;
-
     using API.Features;
 
     using Interfaces;

--- a/Exiled.Events/EventArgs/Player/DiedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DiedEventArgs.cs
@@ -13,8 +13,6 @@ namespace Exiled.Events.EventArgs.Player
     using Interfaces;
 
     using PlayerRoles;
-
-    using CustomAttackerHandler = API.Features.DamageHandlers.AttackerDamageHandler;
     using DamageHandlerBase = PlayerStatsSystem.DamageHandlerBase;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/DiedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DiedEventArgs.cs
@@ -11,8 +11,8 @@ namespace Exiled.Events.EventArgs.Player
     using API.Features.DamageHandlers;
 
     using Interfaces;
-
     using PlayerRoles;
+
     using DamageHandlerBase = PlayerStatsSystem.DamageHandlerBase;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Player/DyingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DyingEventArgs.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Player
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
 

--- a/Exiled.Events/EventArgs/Player/InteractingLockerEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/InteractingLockerEventArgs.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Player
 {
-    using System;
-
     using API.Features;
     using Exiled.API.Features.Lockers;
     using Interfaces;

--- a/Exiled.Events/EventArgs/Player/KickingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/KickingEventArgs.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Player
 {
-    using System;
-    using System.Linq;
     using System.Reflection;
 
     using API.Features;

--- a/Exiled.Events/EventArgs/Player/TransmittingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/TransmittingEventArgs.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Player
 {
-    using System;
-
     using Exiled.API.Features;
     using Exiled.Events.EventArgs.Interfaces;
 

--- a/Exiled.Events/EventArgs/Scp049/ActivatingSenseEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp049/ActivatingSenseEventArgs.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Scp049
 {
-    using System;
-
     using API.Features;
     using Exiled.Events.EventArgs.Interfaces;
 

--- a/Exiled.Events/EventArgs/Scp106/StalkingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp106/StalkingEventArgs.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Scp106
 {
-    using System;
-
     using API.Features;
     using Interfaces;
     using PlayerRoles.PlayableScps.Scp106;

--- a/Exiled.Events/EventArgs/Scp3114/DancingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp3114/DancingEventArgs.cs
@@ -11,7 +11,6 @@ namespace Exiled.Events.EventArgs.Scp3114
     using Exiled.API.Features;
     using Exiled.API.Features.Roles;
     using Exiled.Events.EventArgs.Interfaces;
-    using Exiled.Events.Patches.Events.Scp3114;
 
     /// <summary>
     /// Contains all information before SCP-3114 changes its dancing status.

--- a/Exiled.Events/EventArgs/Scp3114/SlappedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp3114/SlappedEventArgs.cs
@@ -10,7 +10,6 @@ namespace Exiled.Events.EventArgs.Scp3114
     using API.Features;
     using Exiled.API.Features.Roles;
     using Interfaces;
-    using Mono.Cecil;
     using PlayerRoles.PlayableScps.Subroutines;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Scp914/UpgradingInventoryItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp914/UpgradingInventoryItemEventArgs.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Scp914
 {
-    using System;
-
     using API.Features;
     using API.Features.Items;
     using Exiled.API.Features.Scp914Processors;

--- a/Exiled.Events/EventArgs/Scp914/UpgradingPickupEventArgs.cs
+++ b/Exiled.Events/EventArgs/Scp914/UpgradingPickupEventArgs.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Scp914
 {
-    using System;
-
     using Exiled.API.Features.Pickups;
     using Exiled.API.Features.Scp914Processors;
     using Exiled.Events.EventArgs.Interfaces;

--- a/Exiled.Events/EventArgs/Server/AssigningHumanRolesEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/AssigningHumanRolesEventArgs.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Server
 {
-    using API.Enums;
-
     using Interfaces;
 
     using PlayerRoles;

--- a/Exiled.Events/EventArgs/Server/AssigningScpRolesEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/AssigningScpRolesEventArgs.cs
@@ -9,8 +9,6 @@ namespace Exiled.Events.EventArgs.Server
 {
     using System.Collections.Generic;
     using System.Linq;
-
-    using API.Enums;
     using API.Features;
 
     using Interfaces;

--- a/Exiled.Events/EventArgs/Server/AssigningScpRolesEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/AssigningScpRolesEventArgs.cs
@@ -9,10 +9,9 @@ namespace Exiled.Events.EventArgs.Server
 {
     using System.Collections.Generic;
     using System.Linq;
+
     using API.Features;
-
     using Interfaces;
-
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Server/DeployingHumanRoleEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/DeployingHumanRoleEventArgs.cs
@@ -8,11 +8,6 @@
 namespace Exiled.Events.EventArgs.Server
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
-    using API.Enums;
-    using API.Features;
 
     using Interfaces;
 

--- a/Exiled.Events/EventArgs/Server/DeployingScpRoleEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/DeployingScpRoleEventArgs.cs
@@ -9,10 +9,6 @@ namespace Exiled.Events.EventArgs.Server
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
-
-    using API.Enums;
-    using API.Features;
 
     using Interfaces;
 

--- a/Exiled.Events/EventArgs/Server/DeployingTeamRoleEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/DeployingTeamRoleEventArgs.cs
@@ -8,10 +8,9 @@
 namespace Exiled.Events.EventArgs.Server
 {
     using System;
+
     using API.Features;
-
     using Interfaces;
-
     using PlayerRoles;
 
     /// <summary>

--- a/Exiled.Events/EventArgs/Server/DeployingTeamRoleEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/DeployingTeamRoleEventArgs.cs
@@ -8,16 +8,11 @@
 namespace Exiled.Events.EventArgs.Server
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
-    using API.Enums;
     using API.Features;
 
     using Interfaces;
 
     using PlayerRoles;
-    using PlayerRoles.RoleAssign;
 
     /// <summary>
     /// Contains all information before deploying a team role.

--- a/Exiled.Events/EventArgs/Server/PreRespawningTeamEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/PreRespawningTeamEventArgs.cs
@@ -7,12 +7,7 @@
 
 namespace Exiled.Events.EventArgs.Server
 {
-    using System.Collections.Generic;
-
-    using Exiled.API.Features;
     using Exiled.Events.EventArgs.Interfaces;
-
-    using PlayerRoles;
 
     using Respawning;
 

--- a/Exiled.Events/EventArgs/Server/RestartedRespawnSequenceEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/RestartedRespawnSequenceEventArgs.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.EventArgs.Server
 {
     using System.Diagnostics;
+
     using Interfaces;
     using Respawning;
 

--- a/Exiled.Events/EventArgs/Server/RestartedRespawnSequenceEventArgs.cs
+++ b/Exiled.Events/EventArgs/Server/RestartedRespawnSequenceEventArgs.cs
@@ -7,16 +7,8 @@
 
 namespace Exiled.Events.EventArgs.Server
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Linq;
-
-    using API.Enums;
-    using API.Features;
     using Interfaces;
-    using PlayerRoles;
-    using PlayerRoles.RoleAssign;
     using Respawning;
 
     /// <summary>

--- a/Exiled.Events/Events.cs
+++ b/Exiled.Events/Events.cs
@@ -17,7 +17,6 @@ namespace Exiled.Events
     using CentralAuth;
     using Exiled.API.Interfaces;
     using Exiled.Events.Features;
-    using HarmonyLib;
     using InventorySystem.Items.Pickups;
     using InventorySystem.Items.Usables;
     using PlayerRoles.Ragdolls;

--- a/Exiled.Events/Features/Event.cs
+++ b/Exiled.Events/Features/Event.cs
@@ -10,7 +10,6 @@ namespace Exiled.Events.Features
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Reflection;
 
     using Exiled.API.Features;
     using Exiled.Events.EventArgs.Interfaces;

--- a/Exiled.Events/Handlers/Internal/MapGenerated.cs
+++ b/Exiled.Events/Handlers/Internal/MapGenerated.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.Events.Handlers.Internal
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
 

--- a/Exiled.Events/Handlers/Internal/Round.cs
+++ b/Exiled.Events/Handlers/Internal/Round.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.Handlers.Internal
 {
-    using System.Linq;
-
     using CentralAuth;
     using Exiled.API.Extensions;
     using Exiled.API.Features;

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.Events.Handlers
 {
-    using Exiled.API.Features.Pickups;
 #pragma warning disable IDE0079
 #pragma warning disable IDE0060
 #pragma warning disable SA1623 // Property summary documentation should match accessors

--- a/Exiled.Events/Handlers/Server.cs
+++ b/Exiled.Events/Handlers/Server.cs
@@ -13,7 +13,6 @@ namespace Exiled.Events.Handlers
 
 #pragma warning disable SA1623 // Property summary documentation should match accessors
 
-    using Exiled.Events.EventArgs.Player;
     using Exiled.Events.EventArgs.Server;
     using Exiled.Events.Features;
 

--- a/Exiled.Events/Patches/Events/Map/PlacingPickupIntoPocketDimension.cs
+++ b/Exiled.Events/Patches/Events/Map/PlacingPickupIntoPocketDimension.cs
@@ -7,14 +7,11 @@
 
 namespace Exiled.Events.Patches.Events.Map
 {
-    using System.Collections.Generic;
-
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Map;
     using Handlers;
     using HarmonyLib;
     using InventorySystem.Items.Pickups;
-    using Mirror;
     using PlayerRoles.PlayableScps.Scp106;
 
     using static PlayerRoles.PlayableScps.Scp106.Scp106PocketItemManager;

--- a/Exiled.Events/Patches/Events/Player/Healing.cs
+++ b/Exiled.Events/Patches/Events/Player/Healing.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.Events.Patches.Events.Player
 {
-    using System;
     using System.Collections.Generic;
     using System.Reflection.Emit;
 

--- a/Exiled.Events/Patches/Events/Player/Hurting.cs
+++ b/Exiled.Events/Patches/Events/Player/Hurting.cs
@@ -11,11 +11,8 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Reflection.Emit;
 
     using API.Features.Core.Generic.Pools;
-    using API.Features.Roles;
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Player;
-    using Exiled.Events.EventArgs.Scp079;
-    using Exiled.Events.Handlers;
 
     using HarmonyLib;
 

--- a/Exiled.Events/Patches/Events/Player/IntercomSpeaking.cs
+++ b/Exiled.Events/Patches/Events/Player/IntercomSpeaking.cs
@@ -8,7 +8,6 @@
 namespace Exiled.Events.Patches.Events.Player
 {
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Reflection.Emit;
 
     using API.Features.Core.Generic.Pools;

--- a/Exiled.Events/Patches/Events/Player/Reporting.cs
+++ b/Exiled.Events/Patches/Events/Player/Reporting.cs
@@ -13,8 +13,6 @@ namespace Exiled.Events.Patches.Events.Player
     using API.Features.Core.Generic.Pools;
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Player;
-    using Exiled.Events.EventArgs.Server;
-    using Exiled.Events.Handlers;
 
     using HarmonyLib;
 

--- a/Exiled.Events/Patches/Events/Player/TogglingNoClip.cs
+++ b/Exiled.Events/Patches/Events/Player/TogglingNoClip.cs
@@ -12,8 +12,6 @@ namespace Exiled.Events.Patches.Events.Player
 
     using API.Features;
     using API.Features.Core.Generic.Pools;
-
-    using Exiled.API.Features.Roles;
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Player;
 

--- a/Exiled.Events/Patches/Events/Scp106/Attacking.cs
+++ b/Exiled.Events/Patches/Events/Scp106/Attacking.cs
@@ -8,7 +8,6 @@
 namespace Exiled.Events.Patches.Events.Scp106
 {
     using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection.Emit;
 
     using Exiled.API.Features;

--- a/Exiled.Events/Patches/Events/Scp3114/Dancing.cs
+++ b/Exiled.Events/Patches/Events/Scp3114/Dancing.cs
@@ -10,13 +10,9 @@ namespace Exiled.Events.Patches.Events.Scp3114
 #pragma warning disable SA1402 // File may only contain a single type
 
     using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection.Emit;
-
-    using Exiled.API.Enums;
     using Exiled.API.Features;
     using Exiled.API.Features.Core.Generic.Pools;
-    using Exiled.API.Features.Roles;
     using Exiled.Events.EventArgs.Scp3114;
     using HarmonyLib;
     using Mirror;

--- a/Exiled.Events/Patches/Events/Scp3114/Dancing.cs
+++ b/Exiled.Events/Patches/Events/Scp3114/Dancing.cs
@@ -11,6 +11,7 @@ namespace Exiled.Events.Patches.Events.Scp3114
 
     using System.Collections.Generic;
     using System.Reflection.Emit;
+
     using Exiled.API.Features;
     using Exiled.API.Features.Core.Generic.Pools;
     using Exiled.Events.EventArgs.Scp3114;

--- a/Exiled.Events/Patches/Events/Scp3114/Slapped.cs
+++ b/Exiled.Events/Patches/Events/Scp3114/Slapped.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Events.Scp3114
 {
     using System.Collections.Generic;
     using System.Reflection.Emit;
+
     using Exiled.API.Features.Core.Generic.Pools;
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Scp3114;

--- a/Exiled.Events/Patches/Events/Scp3114/Slapped.cs
+++ b/Exiled.Events/Patches/Events/Scp3114/Slapped.cs
@@ -8,10 +8,7 @@
 namespace Exiled.Events.Patches.Events.Scp3114
 {
     using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection.Emit;
-
-    using Exiled.API.Features;
     using Exiled.API.Features.Core.Generic.Pools;
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Scp3114;

--- a/Exiled.Events/Patches/Events/Server/HumanSpawner.cs
+++ b/Exiled.Events/Patches/Events/Server/HumanSpawner.cs
@@ -15,7 +15,6 @@ namespace Exiled.Events.Patches.Events.Server
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Server;
     using HarmonyLib;
-    using Respawning;
 
     using static HarmonyLib.AccessTools;
 

--- a/Exiled.Events/Patches/Events/Server/RestartedRespawnSequence.cs
+++ b/Exiled.Events/Patches/Events/Server/RestartedRespawnSequence.cs
@@ -7,10 +7,7 @@
 
 namespace Exiled.Events.Patches.Events.Server
 {
-    using System;
     using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
     using System.Reflection.Emit;
 
     using API.Features.Core.Generic.Pools;
@@ -19,11 +16,8 @@ namespace Exiled.Events.Patches.Events.Server
     using Exiled.Events.Handlers;
     using HarmonyLib;
     using Respawning;
-    using Respawning.NamingRules;
 
     using static HarmonyLib.AccessTools;
-
-    using Player = API.Features.Player;
 
     /// <summary>
     /// Patch the <see cref="RespawnManager.RestartSequence"/>.

--- a/Exiled.Events/Patches/Events/Server/ScpSpawner.cs
+++ b/Exiled.Events/Patches/Events/Server/ScpSpawner.cs
@@ -17,8 +17,6 @@ namespace Exiled.Events.Patches.Events.Server
 
     using HarmonyLib;
 
-    using Respawning;
-
     using static HarmonyLib.AccessTools;
 
     /// <summary>

--- a/Exiled.Events/Patches/Fixes/PositionSpawnScp0492Fix.cs
+++ b/Exiled.Events/Patches/Fixes/PositionSpawnScp0492Fix.cs
@@ -9,10 +9,7 @@ namespace Exiled.Events.Patches.Fixes
 {
     using System.Collections.Generic;
     using System.Reflection.Emit;
-
-    using API.Features;
     using API.Features.Core.Generic.Pools;
-    using Exiled.Events.EventArgs.Player;
 
     using HarmonyLib;
 

--- a/Exiled.Events/Patches/Fixes/PositionSpawnScp0492Fix.cs
+++ b/Exiled.Events/Patches/Fixes/PositionSpawnScp0492Fix.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.Patches.Fixes
 {
     using System.Collections.Generic;
     using System.Reflection.Emit;
+
     using API.Features.Core.Generic.Pools;
 
     using HarmonyLib;

--- a/Exiled.Events/Patches/Generic/AddRespawnTargetMultiplierConfig.cs
+++ b/Exiled.Events/Patches/Generic/AddRespawnTargetMultiplierConfig.cs
@@ -15,8 +15,6 @@ namespace Exiled.Events.Patches.Generic.Scp079API
 
     using static HarmonyLib.AccessTools;
 
-    using Scp049Role = API.Features.Roles.Scp049Role;
-
     /// <summary>
     /// Patches <see cref="RoundSummary.ServerOnRespawned(Respawning.SpawnableTeamType, List{ReferenceHub})"/>.
     /// Adds the <see cref="RoundSummary.RespawnTargetMultiplier" /> as NW config.

--- a/Exiled.Events/Patches/Generic/CameraList.cs
+++ b/Exiled.Events/Patches/Generic/CameraList.cs
@@ -9,21 +9,12 @@ namespace Exiled.Events.Patches.Generic
 {
 #pragma warning disable SA1402
 #pragma warning disable SA1313 // Parameter names should begin with lower-case letter
-    using System.Collections.Generic;
-    using System.Reflection.Emit;
-
     using API.Features;
-
-    using Exiled.API.Features.Core.Generic.Pools;
 
     using HarmonyLib;
 
-    using MapGeneration;
-
     using PlayerRoles.PlayableScps.Scp079;
     using PlayerRoles.PlayableScps.Scp079.Cameras;
-
-    using static HarmonyLib.AccessTools;
 
     /// <summary>
     /// Patches <see cref="Scp079InteractableBase.OnRegistered"/>.

--- a/Exiled.Events/Patches/Generic/DestroyRecontainerInstance.cs
+++ b/Exiled.Events/Patches/Generic/DestroyRecontainerInstance.cs
@@ -7,17 +7,11 @@
 
 namespace Exiled.Events.Patches.Generic
 {
-    using System.Collections.Generic;
-    using System.Reflection.Emit;
-
     using API.Features;
-    using API.Features.Core.Generic.Pools;
 
     using HarmonyLib;
 
     using PlayerRoles.PlayableScps.Scp079;
-
-    using static HarmonyLib.AccessTools;
 
     /// <summary>
     /// Patches <see cref="Scp079Recontainer.OnDestroy"/>.

--- a/Exiled.Loader/GHApi/Models/Release.cs
+++ b/Exiled.Loader/GHApi/Models/Release.cs
@@ -10,7 +10,6 @@ namespace Exiled.Loader.GHApi.Models
     using System;
     using System.Net.Http;
     using System.Runtime.Serialization;
-    using System.Threading.Tasks;
 
     using Utf8Json;
 


### PR DESCRIPTION
### Changes

- Remove `List`, `GetNearestEntity`, `GetNearestEntities`, `GetFarthestEntity` and `GetFarthestEntities`, because it's causing TPS drops on the server
- Remove all unnecessary usings