### PR TITLE
[Resonance] Fix DamageHandler

### DIFF
--- a/Exiled.API/Extensions/DamageTypeExtensions.cs
+++ b/Exiled.API/Extensions/DamageTypeExtensions.cs
@@ -38,6 +38,7 @@ namespace Exiled.API.Extensions
             { DeathTranslations.Scp939Lunge, DamageType.Scp939 },
             { DeathTranslations.Scp939Other, DamageType.Scp939 },
             { DeathTranslations.Scp3114Slap, DamageType.Scp3114 },
+            { DeathTranslations.CardiacArrest, DamageType.CardiacArrest },
             { DeathTranslations.Tesla, DamageType.Tesla },
             { DeathTranslations.Unknown, DamageType.Unknown },
             { DeathTranslations.Warhead, DamageType.Warhead },

--- a/Exiled.API/Features/DamageHandlers/DamageHandlerBase.cs
+++ b/Exiled.API/Features/DamageHandlers/DamageHandlerBase.cs
@@ -134,7 +134,7 @@ namespace Exiled.API.Features.DamageHandlers
                         Scp049DamageHandler.AttackType.Scp0492 => DamageType.Scp0492,
                         _ => DamageType.Unknown,
                     },
-                    _ => throw new InvalidOperationException("Unknown damage type."),
+                    _ => DamageType.Unknown,
                 };
             }
 


### PR DESCRIPTION
### Changes

- Fix player being kicked by applying `FirearmDamageHandler` damage to him (MessageHandler: InvalidOperationException Unknown damage type.)
- Add missing `DeathTranslations`