### PR TITLE
[Resonance] Fix flags set

### DIFF
--- a/Exiled.API/Extensions/EffectTypeExtension.cs
+++ b/Exiled.API/Extensions/EffectTypeExtension.cs
@@ -155,7 +155,7 @@ namespace Exiled.API.Extensions
         /// <param name="effect">The <see cref="EffectType"/>.</param>
         /// <returns>Whether or not the effect is a negative effect.</returns>
         /// <seealso cref="IsHarmful(EffectType)"/>
-        public static bool IsNegative(this EffectType effect) => IsHarmful(effect) || GetEffectBase(effect)?.Classification is StatusEffectBase.EffectClassification.Negative;
+        public static bool IsNegative(this EffectType effect) => IsHarmful(effect) || GetEffectBase(effect)?.Classification == StatusEffectBase.EffectClassification.Negative;
 
         /// <summary>
         /// Returns whether or not the provided <paramref name="effect"/> is a positive effect.
@@ -212,13 +212,13 @@ namespace Exiled.API.Extensions
         {
             EffectCategory category = EffectCategory.None;
             if (effect.IsPositive())
-                category.AddFlags(EffectCategory.Positive);
+                category = category.AddFlags(EffectCategory.Positive);
             if (effect.IsNegative())
-                category.AddFlags(EffectCategory.Negative);
+                category = category.AddFlags(EffectCategory.Negative);
             if (effect.IsMovement())
-                category.AddFlags(EffectCategory.Movement);
+                category = category.AddFlags(EffectCategory.Movement);
             if (effect.IsHarmful())
-                category.AddFlags(EffectCategory.Harmful);
+                category = category.AddFlags(EffectCategory.Harmful);
 
             return category;
         }

--- a/Exiled.API/Features/Items/Firearm.cs
+++ b/Exiled.API/Features/Items/Firearm.cs
@@ -61,7 +61,7 @@ namespace Exiled.API.Features.Items
         {
             FirearmStatusFlags firearmStatusFlags = FirearmStatusFlags.MagazineInserted;
             if (Base.HasAdvantageFlag(AttachmentDescriptiveAdvantages.Flashlight))
-                firearmStatusFlags.AddFlags(FirearmStatusFlags.FlashlightEnabled);
+                firearmStatusFlags = firearmStatusFlags.AddFlags(FirearmStatusFlags.FlashlightEnabled);
 
             Base.Status = new(MaxAmmo, firearmStatusFlags, Base.GetCurrentAttachmentsCode());
         }

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -2895,7 +2895,7 @@ namespace Exiled.API.Features
                 FirearmStatusFlags flags = FirearmStatusFlags.MagazineInserted;
 
                 if (firearm.Attachments.Any(a => a.Name == AttachmentName.Flashlight))
-                    flags.AddFlags(FirearmStatusFlags.FlashlightEnabled);
+                    flags = flags.AddFlags(FirearmStatusFlags.FlashlightEnabled);
 
                 firearm.Base.Status = new FirearmStatus(firearm.MaxAmmo, flags, firearm.Base.GetCurrentAttachmentsCode());
             }


### PR DESCRIPTION
### Changes

- Fix `EffectCategory` setter (previously always return None)
- Fix firearms, don't enable flashlight when created