### PR TITLE
[ONGOING-FIX] - Fixed Pawn class being null and command fix and constructor error. Need to be fixed GameObject being null.

### DIFF
--- a/Exiled.CustomModules/API/Features/CustomRoles/RoleBehaviour.cs
+++ b/Exiled.CustomModules/API/Features/CustomRoles/RoleBehaviour.cs
@@ -37,8 +37,24 @@ namespace Exiled.CustomModules.API.Features.CustomRoles
     /// This class extends <see cref="ModuleBehaviour{T}"/> and implements <see cref="IAdditiveSettings{T}"/>.
     /// <br/>It provides a foundation for creating custom behaviors associated with in-game player roles.
     /// </remarks>
-    public abstract class RoleBehaviour : ModuleBehaviour<Player>, IAdditiveSettings<RoleSettings>
+    public class RoleBehaviour : ModuleBehaviour<Player>, IAdditiveSettings<RoleSettings>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RoleBehaviour"/> class.
+        /// </summary>
+        protected RoleBehaviour()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RoleBehaviour"/> class.
+        /// </summary>
+        /// <param name="gameObject">owner's gameobject.</param>
+        protected RoleBehaviour(GameObject gameObject)
+            : base(gameObject)
+        {
+        }
+
         private Vector3 lastPosition;
         private RoleTypeId fakeAppearance;
         private bool isHuman;

--- a/Exiled.CustomModules/API/Features/ModuleBehaviour.cs
+++ b/Exiled.CustomModules/API/Features/ModuleBehaviour.cs
@@ -12,7 +12,7 @@ namespace Exiled.CustomModules.API.Features
 
     using Exiled.API.Features.Core;
     using Exiled.API.Features.Core.Generic;
-    using Exiled.CustomModules.API.Features.Attributes;
+    using UnityEngine;
 
     /// <summary>
     /// Represents a marker class for a module's pointer.
@@ -30,6 +30,15 @@ namespace Exiled.CustomModules.API.Features
         /// </summary>
         protected ModuleBehaviour()
             : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModuleBehaviour{TEntity}"/> class.
+        /// </summary>
+        /// <param name="gameObject">owner's gameobject.</param>
+        protected ModuleBehaviour(GameObject gameObject)
+            : base(gameObject)
         {
         }
 

--- a/Exiled.CustomModules/API/Features/Pawn.cs
+++ b/Exiled.CustomModules/API/Features/Pawn.cs
@@ -15,7 +15,6 @@ namespace Exiled.CustomModules.API.Features
     using Exiled.API.Extensions;
     using Exiled.API.Features;
     using Exiled.API.Features.Attributes;
-    using Exiled.API.Features.Core.Generic;
     using Exiled.API.Features.Items;
     using Exiled.API.Features.Roles;
     using Exiled.CustomModules.API.Features.CustomAbilities;
@@ -41,7 +40,7 @@ namespace Exiled.CustomModules.API.Features
     /// <br>It serves as a comprehensive representation of an in-game entity, encapsulating the associated <see cref="ReferenceHub"/> with an expanded set of features.</br>
     /// </remarks>
     /// </summary>
-    [DefaultPlayerClass(enforceAuthority: false)]
+    [DefaultPlayerClass(enforceAuthority: true)]
     public class Pawn : Player
     {
         private readonly List<ActiveAbilityBehaviour> abilityBehaviours = new();
@@ -83,21 +82,21 @@ namespace Exiled.CustomModules.API.Features
         /// <para/>
         /// Can be <see langword="null"/>.
         /// </summary>
-        public CustomRole CustomRole => roleBehaviour.CustomRole;
+        public CustomRole CustomRole => roleBehaviour?.CustomRole;
 
         /// <summary>
         /// Gets the pawn's <see cref="CustomRoles.CustomTeam"/>.
         /// <para/>
         /// Can be <see langword="null"/>.
         /// </summary>
-        public CustomTeam CustomTeam => roleBehaviour.CustomTeam;
+        public CustomTeam CustomTeam => roleBehaviour?.CustomTeam;
 
         /// <summary>
         /// Gets the pawn's <see cref="CustomEscapes.CustomEscape"/>.
         /// <para/>
         /// Can be <see langword="null"/>.
         /// </summary>
-        public CustomEscape CustomEscape => escapeBehaviour.CustomEscape;
+        public CustomEscape CustomEscape => escapeBehaviour?.CustomEscape;
 
         /// <summary>
         /// Gets the pawn's current <see cref="CustomItem"/>.

--- a/Exiled.Example/Example.cs
+++ b/Exiled.Example/Example.cs
@@ -9,6 +9,7 @@ namespace Exiled.Example
 {
     using Exiled.API.Enums;
     using Exiled.API.Features;
+    using Exiled.CustomModules.API.Features.CustomRoles;
 
     /// <summary>
     /// The example plugin.
@@ -37,6 +38,7 @@ namespace Exiled.Example
             // Create new instance of the event handler
             EventHandler = new();
 
+            CustomRole.EnableAll();
             base.OnEnabled();
         }
 

--- a/Exiled.Example/Exiled.Example.csproj
+++ b/Exiled.Example/Exiled.Example.csproj
@@ -13,6 +13,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Exiled.API\Exiled.API.csproj" />
+        <ProjectReference Include="..\Exiled.CustomModules\Exiled.CustomModules.csproj" />
         <ProjectReference Include="..\Exiled.Events\Exiled.Events.csproj" />
     </ItemGroup>
 

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -202,16 +202,15 @@ namespace Exiled.Loader
                 foreach (Type type in assembly.GetTypes())
                 {
                     if (type.BaseType == typeof(Player) || type.IsSubclassOf(typeof(Player)))
-                    {
-                        Log.ErrorWithContext(type.Name);
                         defaultPlayerClass = type;
-                    }
 
-                    DefaultPlayerClassAttribute dpc = Player.DEFAULT_PLAYER_CLASS.GetCustomAttribute<DefaultPlayerClassAttribute>();
-                    if (Player.DEFAULT_PLAYER_CLASS != typeof(Player) && !dpc.EnforceAuthority && defaultPlayerClass is not null)
+                    DefaultPlayerClassAttribute dpc = type.GetCustomAttribute<DefaultPlayerClassAttribute>();
+
+                    // To fix. dcp.Enforce don't have to be set true under CustomModules::Pawn. *testing purpose*
+                    if (Player.DEFAULT_PLAYER_CLASS == typeof(Player) && dpc is not null && dpc.EnforceAuthority && defaultPlayerClass is not null)
                     {
-                        if (Player.DEFAULT_PLAYER_CLASS == typeof(Player) && dpc.EnforceAuthority)
-                            Player.DEFAULT_PLAYER_CLASS = defaultPlayerClass;
+                        Log.DebugWithContext("Changing default player class to " + defaultPlayerClass.Name);
+                        Player.DEFAULT_PLAYER_CLASS = defaultPlayerClass;
                     }
                 }
 


### PR DESCRIPTION
Fixed Pawn.cs being null if try to use it by Player::Get().Cast<Pawn>(). Adding a method for load a constructor without any param or constructor. Removing abstract from RoleBehaviour.cs for allow the creating of an instance. Added custom role example under Exiled.Example for testing purpose.