### PR TITLE
`[EXILED::API]` Adding ScaleNetworkIdentityObject

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -4108,6 +4108,23 @@ namespace Exiled.API.Features
         public void SendFakeSceneLoading(ScenesType newSceneName) => SendFakeSceneLoading(newSceneName.ToString());
 
         /// <summary>
+        /// Scale object for the player.
+        /// </summary>
+        /// <param name="identity">The <see cref="Mirror.NetworkIdentity"/> to move.</param>
+        /// <param name="scale">The scale to change.</param>
+        public void ScaleNetworkIdentityObject(NetworkIdentity identity, Vector3 scale)
+        {
+            identity.gameObject.transform.localScale = scale;
+            ObjectDestroyMessage objectDestroyMessage = new()
+            {
+                netId = identity.netId,
+            };
+
+            Connection.Send(objectDestroyMessage, 0);
+            MirrorExtensions.SendSpawnMessageMethodInfo?.Invoke(null, new object[] { identity, Connection });
+        }
+
+        /// <summary>
         /// Converts the player in a human-readable format.
         /// </summary>
         /// <returns>A string containing Player-related data.</returns>

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -4110,8 +4110,8 @@ namespace Exiled.API.Features
         /// <summary>
         /// Scale object for the player.
         /// </summary>
-        /// <param name="identity">The <see cref="Mirror.NetworkIdentity"/> to move.</param>
-        /// <param name="scale">The scale to change.</param>
+        /// <param name="identity">The <see cref="Mirror.NetworkIdentity"/> to scale.</param>
+        /// <param name="scale">The scale the object needs to be.</param>
         public void ScaleNetworkIdentityObject(NetworkIdentity identity, Vector3 scale)
         {
             identity.gameObject.transform.localScale = scale;

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -4108,7 +4108,7 @@ namespace Exiled.API.Features
         public void SendFakeSceneLoading(ScenesType newSceneName) => SendFakeSceneLoading(newSceneName.ToString());
 
         /// <summary>
-        /// Scale object for the player.
+        /// Scales an object for the specified player.
         /// </summary>
         /// <param name="identity">The <see cref="Mirror.NetworkIdentity"/> to scale.</param>
         /// <param name="scale">The scale the object needs to be.</param>

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -4111,7 +4111,7 @@ namespace Exiled.API.Features
         /// Scales an object for the specified player.
         /// </summary>
         /// <param name="identity">The <see cref="Mirror.NetworkIdentity"/> to scale.</param>
-        /// <param name="scale">The scale the object needs to be.</param>
+        /// <param name="scale">The scale the object needs to be set to.</param>
         public void ScaleNetworkIdentityObject(NetworkIdentity identity, Vector3 scale)
         {
             identity.gameObject.transform.localScale = scale;

--- a/Exiled.API/Features/Server.cs
+++ b/Exiled.API/Features/Server.cs
@@ -12,7 +12,7 @@ namespace Exiled.API.Features
     using System.Reflection;
 
     using Exiled.API.Enums;
-
+    using Exiled.API.Extensions;
     using GameCore;
 
     using Interfaces;
@@ -356,5 +356,25 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="scene">The new Scene the client will load.</param>
         public static void ChangeSceneToAllClients(ScenesType scene) => ChangeSceneToAllClients(scene.ToString());
+
+        /// <summary>
+        /// Scales object for all the players.
+        /// </summary>
+        /// <param name="identity">The <see cref="NetworkIdentity"/> to move.</param>
+        /// <param name="scale">The scale to change.</param>
+        public static void ScaleNetworkIdentityObject(NetworkIdentity identity, Vector3 scale)
+        {
+            identity.gameObject.transform.localScale = scale;
+            ObjectDestroyMessage objectDestroyMessage = new()
+            {
+                netId = identity.netId,
+            };
+
+            foreach (Player ply in Player.List)
+            {
+                ply.Connection.Send(objectDestroyMessage, 0);
+                MirrorExtensions.SendSpawnMessageMethodInfo?.Invoke(null, new object[] { identity, ply.Connection });
+            }
+        }
     }
 }

--- a/Exiled.API/Features/Server.cs
+++ b/Exiled.API/Features/Server.cs
@@ -361,7 +361,7 @@ namespace Exiled.API.Features
         /// Scales object for all the players.
         /// </summary>
         /// <param name="identity">The <see cref="Mirror.NetworkIdentity"/> to scale.</param>
-        /// <param name="scale">The scale the object needs to be.</param>
+        /// <param name="scale">The scale the object needs to be set to.</param>
         public static void ScaleNetworkIdentityObject(NetworkIdentity identity, Vector3 scale)
         {
             identity.gameObject.transform.localScale = scale;

--- a/Exiled.API/Features/Server.cs
+++ b/Exiled.API/Features/Server.cs
@@ -358,7 +358,7 @@ namespace Exiled.API.Features
         public static void ChangeSceneToAllClients(ScenesType scene) => ChangeSceneToAllClients(scene.ToString());
 
         /// <summary>
-        /// Scales object for all the players.
+        /// Scales an object for all players.
         /// </summary>
         /// <param name="identity">The <see cref="Mirror.NetworkIdentity"/> to scale.</param>
         /// <param name="scale">The scale the object needs to be set to.</param>

--- a/Exiled.API/Features/Server.cs
+++ b/Exiled.API/Features/Server.cs
@@ -360,8 +360,8 @@ namespace Exiled.API.Features
         /// <summary>
         /// Scales object for all the players.
         /// </summary>
-        /// <param name="identity">The <see cref="NetworkIdentity"/> to move.</param>
-        /// <param name="scale">The scale to change.</param>
+        /// <param name="identity">The <see cref="Mirror.NetworkIdentity"/> to scale.</param>
+        /// <param name="scale">The scale the object needs to be.</param>
         public static void ScaleNetworkIdentityObject(NetworkIdentity identity, Vector3 scale)
         {
             identity.gameObject.transform.localScale = scale;


### PR DESCRIPTION
Let's you scale down or up everything that has a NetworkIdentity

![SPOILER_immagine](https://github.com/user-attachments/assets/93a6713a-3eaa-42fd-a620-88876af35613)
![immagine](https://github.com/user-attachments/assets/416fa8ce-4cfb-4261-9c1d-0c86fb8aaee9)
